### PR TITLE
Add units, searchlib, and relativity modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ numpy = { version = "0.19", optional = true }
 once_cell = "1.21.3"
 clap = { version = "4.5.40", features = ["derive"] }
 memmap2 = "0.9"
+uom = "0.37.0"
 
 [dev-dependencies]
 criterion = "0.5" # Benchmarking

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub mod positions;
 pub mod precessionlib;
 #[cfg(feature = "python-tests")]
 pub mod pybridge;
+pub mod relativity;
+pub mod searchlib;
 pub mod time;
 pub mod units;
 

--- a/src/relativity/mod.rs
+++ b/src/relativity/mod.rs
@@ -1,0 +1,249 @@
+//! Relativistic correction functions for astrometry
+//!
+//! Ported from Python Skyfield's `relativity.py`. Provides:
+//! - [`light_time_difference`] — light-time projection between observer and barycenter
+//! - [`add_deflection`] — gravitational light bending by a single mass (IERS 2003)
+//! - [`add_aberration`] — stellar aberration correction (Klioner 2003)
+
+use crate::constants::{AU_M, C, C_AUDAY, GS};
+use nalgebra::Vector3;
+
+/// Smallest positive normal f64, used to avoid division by zero.
+const AVOID_DIVIDE_BY_ZERO: f64 = f64::MIN_POSITIVE;
+
+/// Reciprocal masses of solar system bodies (mass of Sun / mass of body).
+///
+/// Used in gravitational deflection calculations.
+pub const RMASSES: &[(&str, f64)] = &[
+    ("sun", 1.0),
+    ("jupiter", 1047.3486),
+    ("saturn", 3497.898),
+    ("uranus", 22902.98),
+    ("neptune", 19412.24),
+    ("venus", 408523.71),
+    ("earth", 332946.050895),
+    ("mars", 3098708.0),
+    ("mercury", 6023600.0),
+    ("moon", 27068700.387534),
+    ("pluto", 135200000.0),
+];
+
+/// Bodies to consider for light deflection, ordered by importance.
+pub const DEFLECTORS: &[&str] = &[
+    "sun", "jupiter", "saturn", "moon", "venus", "uranus", "neptune",
+];
+
+/// Look up the reciprocal mass for a named body.
+pub fn rmass(name: &str) -> Option<f64> {
+    RMASSES.iter().find(|(n, _)| *n == name).map(|(_, m)| *m)
+}
+
+/// Compute light-time difference between barycenter and observer.
+///
+/// Returns the projection of the observer position onto the direction
+/// toward the object, divided by the speed of light, in days.
+///
+/// # Arguments
+/// * `position` - Position vector of the object (AU)
+/// * `observer_pos` - Position vector of the observer (AU)
+pub fn light_time_difference(position: &Vector3<f64>, observer_pos: &Vector3<f64>) -> f64 {
+    let dis = position.norm();
+    let u1 = position / (dis + AVOID_DIVIDE_BY_ZERO);
+    u1.dot(observer_pos) / C_AUDAY
+}
+
+/// Apply gravitational light deflection from a single mass.
+///
+/// Implements the IERS 2003 Conventions formulation for the apparent
+/// direction change of light passing near a gravitating body.
+///
+/// # Arguments
+/// * `position` - Position of observed object from observer (AU), modified in-place
+/// * `observer` - Observer position from solar system barycenter (AU)
+/// * `deflector` - Deflector body position from solar system barycenter (AU)
+/// * `rmass` - Reciprocal mass of the deflector (Sun mass / body mass)
+pub fn add_deflection(
+    position: &mut Vector3<f64>,
+    observer: &Vector3<f64>,
+    deflector: &Vector3<f64>,
+    rmass: f64,
+) {
+    // Geometry vectors
+    let pq = observer + *position - deflector; // deflector to object
+    let pe = observer - deflector; // deflector to observer
+
+    let pmag = position.norm();
+    let qmag = pq.norm();
+    let emag = pe.norm();
+
+    // Unit vectors (guard against zero magnitude)
+    let phat = if pmag > 0.0 {
+        *position / pmag
+    } else {
+        Vector3::zeros()
+    };
+    let qhat = if qmag > 0.0 {
+        pq / qmag
+    } else {
+        Vector3::zeros()
+    };
+    let ehat = if emag > 0.0 {
+        pe / emag
+    } else {
+        Vector3::zeros()
+    };
+
+    // Dot products
+    let pdotq = phat.dot(&qhat);
+    let qdote = qhat.dot(&ehat);
+    let edotp = ehat.dot(&phat);
+
+    // Skip correction if deflector is nearly aligned with object (within ~1 arcsec)
+    if edotp.abs() > 0.99999999999 {
+        return;
+    }
+
+    // Deflection factors
+    let fac1 = 2.0 * GS / (C * C * emag * AU_M * rmass);
+    let fac2 = 1.0 + qdote;
+
+    // Apply correction
+    let correction = fac1 * (pdotq * ehat - edotp * qhat) / fac2 * pmag;
+    *position += correction;
+}
+
+/// Apply stellar aberration correction.
+///
+/// Implements the Klioner (2003) formulation for the apparent shift in
+/// position due to the observer's velocity.
+///
+/// # Arguments
+/// * `position` - Relative position of object from observer (AU), modified in-place
+/// * `velocity` - Observer velocity vector (AU/day)
+/// * `light_time` - Light propagation time to the object (days)
+pub fn add_aberration(position: &mut Vector3<f64>, velocity: &Vector3<f64>, light_time: f64) {
+    let p1mag = light_time * C_AUDAY;
+    let vemag = velocity.norm();
+
+    let beta = vemag / C_AUDAY;
+    let dot = position.dot(velocity);
+
+    let cosd = dot / (p1mag * vemag + AVOID_DIVIDE_BY_ZERO);
+    let gammai = (1.0 - beta * beta).sqrt();
+    let p = beta * cosd;
+    let q = (1.0 + p / (1.0 + gammai)) * light_time;
+    let r = 1.0 + p;
+
+    *position *= gammai;
+    *position += q * velocity;
+    *position /= r;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn test_light_time_difference_along_axis() {
+        // Observer 1 AU along x-axis, object along x-axis
+        let position = Vector3::new(10.0, 0.0, 0.0);
+        let observer = Vector3::new(1.0, 0.0, 0.0);
+        let ltt = light_time_difference(&position, &observer);
+        // Should be 1.0 / C_AUDAY
+        assert_relative_eq!(ltt, 1.0 / C_AUDAY, epsilon = 1e-15);
+    }
+
+    #[test]
+    fn test_light_time_difference_perpendicular() {
+        // Observer along y-axis, object along x-axis — projection is zero
+        let position = Vector3::new(10.0, 0.0, 0.0);
+        let observer = Vector3::new(0.0, 1.0, 0.0);
+        let ltt = light_time_difference(&position, &observer);
+        assert_relative_eq!(ltt, 0.0, epsilon = 1e-15);
+    }
+
+    #[test]
+    fn test_add_deflection_sun() {
+        // Star at 10 AU along x, observer at 1 AU along y (90 deg from Sun)
+        // Sun at origin
+        let mut position = Vector3::new(10.0, 0.0, 0.0);
+        let observer = Vector3::new(0.0, 1.0, 0.0);
+        let deflector = Vector3::new(0.0, 0.0, 0.0);
+
+        let pos_before = position;
+        add_deflection(&mut position, &observer, &deflector, 1.0);
+
+        // Deflection should be small but nonzero
+        let shift = (position - pos_before).norm();
+        assert!(shift > 0.0, "Deflection should be nonzero");
+        // Solar deflection at 90 degrees is ~1.75 arcsec / (angular sep in radians)
+        // This is a very rough magnitude check
+        assert!(shift < 1e-6, "Deflection should be tiny in AU");
+    }
+
+    #[test]
+    fn test_add_deflection_aligned_skipped() {
+        // When observer-deflector line is parallel to object direction,
+        // the correction is skipped
+        let mut position = Vector3::new(10.0, 0.0, 0.0);
+        let observer = Vector3::new(1.0, 0.0, 0.0);
+        let deflector = Vector3::new(0.0, 0.0, 0.0);
+
+        let pos_before = position;
+        add_deflection(&mut position, &observer, &deflector, 1.0);
+
+        // edotp ~1.0, so correction should be skipped
+        assert_relative_eq!(position.x, pos_before.x, epsilon = 1e-15);
+        assert_relative_eq!(position.y, pos_before.y, epsilon = 1e-15);
+        assert_relative_eq!(position.z, pos_before.z, epsilon = 1e-15);
+    }
+
+    #[test]
+    fn test_add_aberration_zero_velocity() {
+        let mut position = Vector3::new(1.0, 0.0, 0.0);
+        let velocity = Vector3::new(0.0, 0.0, 0.0);
+        let pos_before = position;
+
+        add_aberration(&mut position, &velocity, 0.01);
+
+        // Zero velocity should give no aberration
+        assert_relative_eq!(position.x, pos_before.x, epsilon = 1e-10);
+        assert_relative_eq!(position.y, pos_before.y, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_add_aberration_earth_velocity() {
+        // Earth orbital velocity ~29.78 km/s ≈ 0.0172 AU/day
+        // This should produce ~20 arcsec aberration
+        let mut position = Vector3::new(1.0, 0.0, 0.0);
+        let earth_v_auday = 29.78e3 / AU_M * 86400.0; // ~0.0172 AU/day
+        let velocity = Vector3::new(0.0, earth_v_auday, 0.0);
+        let light_time = 1.0 / C_AUDAY;
+
+        let pos_before = position;
+        add_aberration(&mut position, &velocity, light_time);
+
+        // The y-component should have shifted
+        let shift_y = position.y - pos_before.y;
+        assert!(
+            shift_y.abs() > 1e-6,
+            "Aberration should shift position in y"
+        );
+
+        // The shift angle should be on order of v/c ~ 1e-4 radians ~ 20 arcsec
+        let angle = (position - pos_before).norm() / position.norm();
+        assert!(
+            angle > 1e-5 && angle < 1e-3,
+            "Aberration angle {} should be ~1e-4 rad",
+            angle
+        );
+    }
+
+    #[test]
+    fn test_rmass_lookup() {
+        assert_relative_eq!(rmass("sun").unwrap(), 1.0);
+        assert_relative_eq!(rmass("jupiter").unwrap(), 1047.3486);
+        assert!(rmass("nonexistent").is_none());
+    }
+}

--- a/src/searchlib/mod.rs
+++ b/src/searchlib/mod.rs
@@ -1,0 +1,490 @@
+//! Search algorithms for finding events and extrema in time-dependent functions
+//!
+//! Ported from Python Skyfield's `searchlib.py`. Provides:
+//! - [`find_discrete`] — find times when a discrete function changes value
+//! - [`find_maxima`] — find local maxima of a continuous function
+//! - [`find_minima`] — find local minima of a continuous function
+
+use crate::constants::DAY_S;
+
+/// Default epsilon for discrete event finding (0.001 seconds in days)
+pub const EPSILON_DISCRETE: f64 = 0.001 / DAY_S;
+
+/// Default epsilon for extrema finding (1.0 second in days)
+pub const EPSILON_EXTREMA: f64 = 1.0 / DAY_S;
+
+/// Default number of subdivisions per bracket refinement
+pub const DEFAULT_NUM: usize = 12;
+
+/// Find times at which a discrete function of time changes value.
+///
+/// Used for instantaneous events like sunrise, transits, and seasons.
+///
+/// # Arguments
+/// * `jd_start` - Start Julian date (TT)
+/// * `jd_end` - End Julian date (TT)
+/// * `f` - Function mapping a slice of Julian dates to discrete integer values
+/// * `step_days` - Sampling interval in days
+/// * `epsilon` - Convergence threshold in days (default: 0.001/86400)
+/// * `num` - Number of subdivisions per refinement (default: 12)
+///
+/// # Returns
+/// Vector of `(jd, value)` pairs at each transition
+pub fn find_discrete<F>(
+    jd_start: f64,
+    jd_end: f64,
+    f: &F,
+    step_days: f64,
+    epsilon: f64,
+    num: usize,
+) -> Vec<(f64, i64)>
+where
+    F: Fn(&[f64]) -> Vec<i64>,
+{
+    assert!(
+        jd_start < jd_end,
+        "start time must be earlier than end time"
+    );
+
+    let sample_count = ((jd_end - jd_start) / step_days) as usize + 2;
+    let jd = linspace(jd_start, jd_end, sample_count);
+    find_discrete_core(&jd, f, epsilon, num)
+}
+
+fn find_discrete_core<F>(initial_jd: &[f64], f: &F, epsilon: f64, num: usize) -> Vec<(f64, i64)>
+where
+    F: Fn(&[f64]) -> Vec<i64>,
+{
+    let end_mask = linspace(0.0, 1.0, num);
+    let start_mask: Vec<f64> = end_mask.iter().copied().rev().collect();
+
+    let mut jd = initial_jd.to_vec();
+
+    loop {
+        let y = f(&jd);
+
+        // Find indices where consecutive values differ
+        let mut transition_indices = Vec::new();
+        for i in 0..y.len() - 1 {
+            if y[i] != y[i + 1] {
+                transition_indices.push(i);
+            }
+        }
+
+        if transition_indices.is_empty() {
+            return Vec::new();
+        }
+
+        let starts: Vec<f64> = transition_indices.iter().map(|&i| jd[i]).collect();
+        let ends: Vec<f64> = transition_indices.iter().map(|&i| jd[i + 1]).collect();
+
+        // Check convergence
+        let max_width = starts
+            .iter()
+            .zip(ends.iter())
+            .map(|(s, e)| e - s)
+            .fold(0.0_f64, f64::max);
+
+        if max_width <= epsilon {
+            let values: Vec<i64> = transition_indices.iter().map(|&i| y[i + 1]).collect();
+            return ends.into_iter().zip(values).collect();
+        }
+
+        // Subdivide each bracket
+        jd = outer_interp(&starts, &start_mask, &ends, &end_mask);
+    }
+}
+
+/// Find the local maxima of a continuous function over a time range.
+///
+/// # Arguments
+/// * `jd_start` - Start Julian date (TT)
+/// * `jd_end` - End Julian date (TT)
+/// * `f` - Function mapping a slice of Julian dates to f64 values
+/// * `step_days` - Sampling interval in days
+/// * `epsilon` - Convergence threshold in days (default: 1.0/86400)
+/// * `num` - Number of subdivisions per refinement (default: 12)
+///
+/// # Returns
+/// Vector of `(jd, value)` pairs at each maximum
+pub fn find_maxima<F>(
+    jd_start: f64,
+    jd_end: f64,
+    f: &F,
+    step_days: f64,
+    epsilon: f64,
+    num: usize,
+) -> Vec<(f64, f64)>
+where
+    F: Fn(&[f64]) -> Vec<f64>,
+{
+    assert!(
+        jd_start < jd_end,
+        "start time must be earlier than end time"
+    );
+
+    // Add extra points beyond range to catch maxima near endpoints
+    let steps = ((jd_end - jd_start) / step_days) as usize + 3;
+    let real_step = (jd_end - jd_start) / steps as f64;
+    let jd = linspace(jd_start - real_step, jd_end + real_step, steps + 2);
+
+    let end_alpha = linspace(0.0, 1.0, num);
+    let start_alpha: Vec<f64> = end_alpha.iter().copied().rev().collect();
+
+    let mut jd = jd;
+
+    loop {
+        let y = f(&jd);
+
+        // Check convergence using first interval
+        if jd.len() >= 2 && (jd[1] - jd[0]) <= epsilon {
+            let (mut max_jd, mut max_y) = identify_maxima(&jd, &y);
+
+            // Filter out maxima outside our bounds
+            let keep: Vec<usize> = (0..max_jd.len())
+                .filter(|&i| max_jd[i] >= jd_start && max_jd[i] <= jd_end)
+                .collect();
+            max_jd = keep.iter().map(|&i| max_jd[i]).collect();
+            max_y = keep.iter().map(|&i| max_y[i]).collect();
+
+            // Deduplicate within epsilon
+            if !max_jd.is_empty() {
+                let mut deduped_jd = vec![max_jd[0]];
+                let mut deduped_y = vec![max_y[0]];
+                for i in 1..max_jd.len() {
+                    if max_jd[i] - *deduped_jd.last().unwrap() > epsilon {
+                        deduped_jd.push(max_jd[i]);
+                        deduped_y.push(max_y[i]);
+                    }
+                }
+                return deduped_jd.into_iter().zip(deduped_y).collect();
+            }
+            return Vec::new();
+        }
+
+        let (left, right) = choose_brackets(&y);
+
+        if left.is_empty() {
+            return Vec::new();
+        }
+
+        let starts: Vec<f64> = left.iter().map(|&i| jd[i]).collect();
+        let ends: Vec<f64> = right.iter().map(|&i| jd[i]).collect();
+
+        jd = outer_interp(&starts, &start_alpha, &ends, &end_alpha);
+        jd = remove_adjacent_duplicates(&jd);
+    }
+}
+
+/// Find the local minima of a continuous function over a time range.
+///
+/// Negates the function and delegates to [`find_maxima`].
+pub fn find_minima<F>(
+    jd_start: f64,
+    jd_end: f64,
+    f: &F,
+    step_days: f64,
+    epsilon: f64,
+    num: usize,
+) -> Vec<(f64, f64)>
+where
+    F: Fn(&[f64]) -> Vec<f64>,
+{
+    let neg_f = |jd: &[f64]| -> Vec<f64> { f(jd).iter().map(|&v| -v).collect() };
+    find_maxima(jd_start, jd_end, &neg_f, step_days, epsilon, num)
+        .into_iter()
+        .map(|(jd, v)| (jd, -v))
+        .collect()
+}
+
+/// Generate `n` evenly spaced values from `start` to `end` (inclusive).
+fn linspace(start: f64, end: f64, n: usize) -> Vec<f64> {
+    if n <= 1 {
+        return vec![start];
+    }
+    let step = (end - start) / (n - 1) as f64;
+    (0..n).map(|i| start + step * i as f64).collect()
+}
+
+/// Interpolate between starts and ends using outer product masks.
+///
+/// For each bracket (start[i], end[i]), generate `num` points by
+/// `start[i] * start_mask[j] + end[i] * end_mask[j]`.
+fn outer_interp(starts: &[f64], start_mask: &[f64], ends: &[f64], end_mask: &[f64]) -> Vec<f64> {
+    let num = start_mask.len();
+    let mut result = Vec::with_capacity(starts.len() * num);
+    for i in 0..starts.len() {
+        for j in 0..num {
+            result.push(starts[i] * start_mask[j] + ends[i] * end_mask[j]);
+        }
+    }
+    result
+}
+
+/// Find bracket indices where maxima might exist.
+///
+/// Uses second-difference-of-sign to identify downward inflection points.
+fn choose_brackets(y: &[f64]) -> (Vec<usize>, Vec<usize>) {
+    if y.len() < 3 {
+        return (Vec::new(), Vec::new());
+    }
+
+    // diff(sign(diff(y)))
+    let dsd = diff_sign_diff(y);
+
+    // Find indices where dsd < 0
+    let mut indices = Vec::new();
+    for (i, &v) in dsd.iter().enumerate() {
+        if v < 0 {
+            indices.push(i);
+        }
+    }
+
+    // Expand each index to [i, i+1], flatten, deduplicate
+    let mut left = Vec::new();
+    for &idx in &indices {
+        left.push(idx);
+        left.push(idx + 1);
+    }
+    left = remove_adjacent_duplicates_usize(&left);
+
+    let right: Vec<usize> = left.iter().map(|&l| l + 1).collect();
+    (left, right)
+}
+
+/// Identify exact maxima positions from converged x/y data.
+fn identify_maxima(x: &[f64], y: &[f64]) -> (Vec<f64>, Vec<f64>) {
+    if x.len() < 3 {
+        return (Vec::new(), Vec::new());
+    }
+
+    let dsd = diff_sign_diff(y);
+
+    // Sharp peaks: dsd == -2
+    let mut peak_x = Vec::new();
+    let mut peak_y = Vec::new();
+    for (i, &v) in dsd.iter().enumerate() {
+        if v == -2 {
+            let idx = i + 1;
+            peak_x.push(x[idx]);
+            peak_y.push(y[idx]);
+        }
+    }
+
+    // Plateau maxima: find runs of zeros in dsd bordered by -1 values
+    let nonzero_indices: Vec<usize> = dsd
+        .iter()
+        .enumerate()
+        .filter(|(_, &v)| v != 0)
+        .map(|(i, _)| i)
+        .collect();
+    let nonzero_values: Vec<i32> = nonzero_indices.iter().map(|&i| dsd[i]).collect();
+
+    let mut plateau_x = Vec::new();
+    let mut plateau_y = Vec::new();
+    for i in 0..nonzero_values.len().saturating_sub(1) {
+        if nonzero_values[i] == -1 && nonzero_values[i + 1] == -1 {
+            let left_idx = nonzero_indices[i];
+            let right_idx = nonzero_indices[i + 1] + 2;
+            if right_idx < x.len() {
+                plateau_x.push((x[left_idx] + x[right_idx]) / 2.0);
+                plateau_y.push(y[left_idx + 1]);
+            }
+        }
+    }
+
+    // Combine and sort
+    peak_x.extend(plateau_x);
+    peak_y.extend(plateau_y);
+
+    if peak_x.len() > 1 {
+        let mut indices: Vec<usize> = (0..peak_x.len()).collect();
+        indices.sort_by(|&a, &b| peak_x[a].partial_cmp(&peak_x[b]).unwrap());
+        let sorted_x: Vec<f64> = indices.iter().map(|&i| peak_x[i]).collect();
+        let sorted_y: Vec<f64> = indices.iter().map(|&i| peak_y[i]).collect();
+        (sorted_x, sorted_y)
+    } else {
+        (peak_x, peak_y)
+    }
+}
+
+/// Compute diff(sign(diff(y))) as integer values.
+fn diff_sign_diff(y: &[f64]) -> Vec<i32> {
+    if y.len() < 2 {
+        return Vec::new();
+    }
+    let sign_diff: Vec<i32> = y
+        .windows(2)
+        .map(|w| {
+            let d = w[1] - w[0];
+            if d > 0.0 {
+                1
+            } else if d < 0.0 {
+                -1
+            } else {
+                0
+            }
+        })
+        .collect();
+
+    sign_diff.windows(2).map(|w| w[1] - w[0]).collect()
+}
+
+fn remove_adjacent_duplicates(a: &[f64]) -> Vec<f64> {
+    if a.is_empty() {
+        return Vec::new();
+    }
+    let mut result = vec![a[0]];
+    for i in 1..a.len() {
+        if a[i] != a[i - 1] {
+            result.push(a[i]);
+        }
+    }
+    result
+}
+
+fn remove_adjacent_duplicates_usize(a: &[usize]) -> Vec<usize> {
+    if a.is_empty() {
+        return Vec::new();
+    }
+    let mut result = vec![a[0]];
+    for i in 1..a.len() {
+        if a[i] != a[i - 1] {
+            result.push(a[i]);
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+    use std::f64::consts::PI;
+
+    #[test]
+    fn test_linspace() {
+        let v = linspace(0.0, 1.0, 5);
+        assert_eq!(v.len(), 5);
+        assert_relative_eq!(v[0], 0.0);
+        assert_relative_eq!(v[1], 0.25);
+        assert_relative_eq!(v[4], 1.0);
+    }
+
+    #[test]
+    fn test_linspace_single() {
+        let v = linspace(5.0, 10.0, 1);
+        assert_eq!(v.len(), 1);
+        assert_relative_eq!(v[0], 5.0);
+    }
+
+    #[test]
+    fn test_find_discrete_step_function() {
+        // sign(sin(x)) transitions at multiples of pi
+        let f = |jd: &[f64]| -> Vec<i64> {
+            jd.iter()
+                .map(|&x| {
+                    let s = x.sin();
+                    if s > 0.0 {
+                        1
+                    } else {
+                        0
+                    }
+                })
+                .collect()
+        };
+
+        let results = find_discrete(0.1, 4.0 * PI, &f, 0.1, EPSILON_DISCRETE, DEFAULT_NUM);
+
+        // Should find transitions near pi, 2*pi, 3*pi
+        assert!(
+            results.len() >= 3,
+            "Expected at least 3 transitions, got {}",
+            results.len()
+        );
+        for (jd, _) in &results {
+            // Each transition should be near a multiple of pi
+            let nearest_pi = (*jd / PI).round() * PI;
+            assert!(
+                (jd - nearest_pi).abs() < 0.01,
+                "Transition at {} not near a multiple of pi",
+                jd
+            );
+        }
+    }
+
+    #[test]
+    fn test_find_discrete_no_transitions() {
+        let f = |jd: &[f64]| -> Vec<i64> { vec![1; jd.len()] };
+        let results = find_discrete(0.0, 10.0, &f, 1.0, EPSILON_DISCRETE, DEFAULT_NUM);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_find_maxima_sin() {
+        // sin(x) has maxima at pi/2, 5*pi/2, etc.
+        let f = |jd: &[f64]| -> Vec<f64> { jd.iter().map(|&x| x.sin()).collect() };
+
+        let results = find_maxima(0.0, 4.0 * PI, &f, 0.5, EPSILON_EXTREMA, DEFAULT_NUM);
+
+        // Should find maxima near pi/2 and 5*pi/2
+        assert!(
+            results.len() >= 2,
+            "Expected at least 2 maxima, got {}",
+            results.len()
+        );
+
+        for (jd, val) in &results {
+            // Value at maximum should be close to 1.0
+            assert_relative_eq!(*val, 1.0, epsilon = 0.01);
+            // Position should be near an odd multiple of pi/2
+            let phase = (*jd / (PI / 2.0)).round();
+            assert!(
+                (phase as i64) % 2 == 1,
+                "Maximum at {} not near odd multiple of pi/2",
+                jd
+            );
+        }
+    }
+
+    #[test]
+    fn test_find_minima_sin() {
+        let f = |jd: &[f64]| -> Vec<f64> { jd.iter().map(|&x| x.sin()).collect() };
+
+        let results = find_minima(0.0, 4.0 * PI, &f, 0.5, EPSILON_EXTREMA, DEFAULT_NUM);
+
+        assert!(
+            results.len() >= 2,
+            "Expected at least 2 minima, got {}",
+            results.len()
+        );
+
+        for (_, val) in &results {
+            assert_relative_eq!(*val, -1.0, epsilon = 0.01);
+        }
+    }
+
+    #[test]
+    fn test_find_maxima_no_maxima() {
+        // Monotonically increasing function
+        let f = |jd: &[f64]| -> Vec<f64> { jd.to_vec() };
+        let results = find_maxima(0.0, 10.0, &f, 1.0, EPSILON_EXTREMA, DEFAULT_NUM);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_diff_sign_diff() {
+        // [1, 3, 2] -> sign(diff) = [+1, -1] -> diff = [-2]
+        let y = vec![1.0, 3.0, 2.0];
+        let dsd = diff_sign_diff(&y);
+        assert_eq!(dsd, vec![-2]);
+    }
+
+    #[test]
+    fn test_diff_sign_diff_plateau() {
+        // [1, 3, 3, 2] -> sign(diff) = [+1, 0, -1] -> diff = [-1, -1]
+        let y = vec![1.0, 3.0, 3.0, 2.0];
+        let dsd = diff_sign_diff(&y);
+        assert_eq!(dsd, vec![-1, -1]);
+    }
+}

--- a/src/units/mod.rs
+++ b/src/units/mod.rs
@@ -1,1 +1,105 @@
-//! units module\n\n// Placeholder for units implementations
+//! Type-safe astronomical units built on the `uom` crate
+//!
+//! Provides custom unit definitions for astronomical calculations:
+//! - `astronomical_unit_iau` for length with IAU 2012 exact value
+//! - `au_per_day` for velocity (AU/day)
+//!
+//! Re-exports commonly used `uom::si::f64` quantity types.
+
+// Re-export uom SI quantity types for convenience
+pub use uom::si::angle;
+pub use uom::si::f64::Angle;
+pub use uom::si::f64::Length;
+pub use uom::si::f64::Time;
+pub use uom::si::f64::Velocity;
+
+// Re-export built-in SI units commonly used in astronomy
+pub use uom::si::angle::degree;
+pub use uom::si::angle::radian;
+pub use uom::si::angle::second as arcsecond;
+pub use uom::si::length::astronomical_unit;
+pub use uom::si::length::kilometer;
+pub use uom::si::length::meter;
+pub use uom::si::time::day;
+pub use uom::si::time::second;
+pub use uom::si::velocity::kilometer_per_second;
+pub use uom::si::velocity::meter_per_second;
+
+/// IAU 2012 exact Astronomical Unit in meters
+pub const AU_M_EXACT: f64 = 149_597_870_700.0;
+
+/// Speed of light in AU/day (derived from C and AU_M_EXACT)
+pub const C_AUDAY: f64 = 299_792_458.0 * 86_400.0 / AU_M_EXACT;
+
+/// Convert AU to kilometers using IAU 2012 exact value
+pub fn au_to_km(au: f64) -> f64 {
+    au * AU_M_EXACT / 1000.0
+}
+
+/// Convert kilometers to AU using IAU 2012 exact value
+pub fn km_to_au(km: f64) -> f64 {
+    km * 1000.0 / AU_M_EXACT
+}
+
+/// Convert AU/day to km/s
+pub fn au_per_day_to_km_per_s(au_day: f64) -> f64 {
+    au_day * AU_M_EXACT / (86_400.0 * 1000.0)
+}
+
+/// Convert km/s to AU/day
+pub fn km_per_s_to_au_per_day(km_s: f64) -> f64 {
+    km_s * 86_400.0 * 1000.0 / AU_M_EXACT
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn test_au_to_km_value() {
+        let one_au = Length::new::<astronomical_unit>(1.0);
+        let km = one_au.get::<kilometer>();
+        // Built-in uom AU is slightly imprecise (1.495979e11 vs exact 1.495978707e11)
+        // So we test our exact conversion function separately
+        assert_relative_eq!(km, 149_597_900.0, epsilon = 200.0);
+    }
+
+    #[test]
+    fn test_exact_au_conversion() {
+        assert_relative_eq!(au_to_km(1.0), 149_597_870.700, epsilon = 1e-6);
+        assert_relative_eq!(km_to_au(149_597_870.700), 1.0, epsilon = 1e-15);
+    }
+
+    #[test]
+    fn test_c_auday() {
+        // Speed of light should be ~173.14 AU/day
+        assert_relative_eq!(C_AUDAY, 173.144_632_720, epsilon = 1e-3);
+    }
+
+    #[test]
+    fn test_velocity_conversions() {
+        // Earth orbital velocity ~30 km/s
+        let au_day = km_per_s_to_au_per_day(29.78);
+        assert_relative_eq!(au_day, 0.017_202, epsilon = 1e-3);
+
+        let roundtrip = au_per_day_to_km_per_s(au_day);
+        assert_relative_eq!(roundtrip, 29.78, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_angle_arcseconds() {
+        let one_degree = Angle::new::<degree>(1.0);
+        let asec = one_degree.get::<arcsecond>();
+        assert_relative_eq!(asec, 3600.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_uom_length_velocity_time() {
+        // uom dimensional analysis: Length / Time = Velocity
+        let dist = Length::new::<meter>(1000.0);
+        let time = Time::new::<second>(10.0);
+        let vel: Velocity = dist / time;
+        assert_relative_eq!(vel.get::<meter_per_second>(), 100.0, epsilon = 1e-10);
+    }
+}


### PR DESCRIPTION
## Summary
- **Units module (#30)**: Integrates `uom` crate for type-safe dimensional analysis. Re-exports SI quantity types (Length, Velocity, Time, Angle) and common unit types (astronomical_unit, kilometer, degree, arcsecond). Provides exact IAU 2012 AU conversion functions since uom's built-in AU value is slightly imprecise ([filed upstream](https://github.com/iliekturtles/uom/issues/559)).
- **Searchlib module (#31)**: Ports Skyfield's `searchlib.py` — `find_discrete` (bisection for state changes), `find_maxima` (second-derivative peak finding with plateau handling), `find_minima` (negation wrapper). Pure numerical algorithms operating on closures.
- **Relativity module (#32)**: Ports Skyfield's `relativity.py` — `light_time_difference`, `add_deflection` (IERS 2003 gravitational light bending), `add_aberration` (Klioner 2003 velocity aberration). Low-level math primitives for use by the positions layer.

Closes #30, #31, #32

## Test plan
- [x] `cargo test` — 145 lib tests + 12 doc-tests all pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)