### PR TITLE
Add auto-download for BSP ephemeris files

### DIFF
--- a/examples/auto_download.rs
+++ b/examples/auto_download.rs
@@ -1,0 +1,36 @@
+//! Zero-config planetary positions with auto-downloading
+//!
+//! Demonstrates the Loader's automatic data file downloading.
+//! No manual file download or path management needed.
+//!
+//! Run with: cargo run --example auto_download
+
+use starfield::Loader;
+
+fn main() -> starfield::Result<()> {
+    let loader = Loader::new();
+    let ts = loader.timescale();
+
+    // This automatically downloads de421.bsp to ~/.cache/starfield/
+    let mut kernel = loader.open("de421.bsp")?;
+
+    let t = ts.tdb_jd(2451545.0); // J2000
+    println!("Planetary positions at J2000 (2000-01-01 12:00 TDB):\n");
+
+    for name in [
+        "sun",
+        "mercury",
+        "venus",
+        "earth",
+        "mars",
+        "jupiter barycenter",
+    ] {
+        let state = kernel.compute_at(name, &t)?;
+        println!(
+            "  {:<20} ({:>12.6}, {:>12.6}, {:>12.6}) AU",
+            name, state.position.x, state.position.y, state.position.z
+        );
+    }
+
+    Ok(())
+}

--- a/src/data/downloader.rs
+++ b/src/data/downloader.rs
@@ -11,8 +11,17 @@ use std::time::Duration;
 use crate::Result;
 use crate::StarfieldError;
 
+use indicatif::{ProgressBar, ProgressStyle};
+
 // Hipparcos catalog URL
 const HIPPARCOS_URL: &str = "https://cdsarc.cds.unistra.fr/ftp/cats/I/239/hip_main.dat";
+
+/// Base URL for JPL planetary ephemeris BSP files
+const JPL_BSP_URL: &str = "https://ssd.jpl.nasa.gov/ftp/eph/planets/bsp/";
+
+/// Base URL for NAIF satellite SPK files
+const NAIF_SATELLITES_URL: &str =
+    "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/satellites/";
 
 /// Get the cache directory path
 pub fn get_cache_dir() -> PathBuf {
@@ -28,7 +37,7 @@ pub fn ensure_cache_dir() -> io::Result<PathBuf> {
 }
 
 /// Check if a file exists and is not empty
-fn file_exists_and_not_empty<P: AsRef<Path>>(path: P) -> bool {
+pub(crate) fn file_exists_and_not_empty<P: AsRef<Path>>(path: P) -> bool {
     match fs::metadata(path) {
         Ok(metadata) => metadata.is_file() && metadata.len() > 0,
         Err(_) => false,
@@ -147,6 +156,139 @@ fn decompress_gzip<P: AsRef<Path>, Q: AsRef<Path>>(gz_path: P, output_path: Q) -
     }
 }
 
+/// Resolve the download URL for a known data filename.
+///
+/// Returns `Some(full_url)` if the filename matches a known pattern,
+/// `None` otherwise. Full URLs (containing `://`) pass through unchanged.
+pub fn resolve_url(filename: &str) -> Option<String> {
+    if filename.contains("://") {
+        return Some(filename.to_string());
+    }
+
+    if filename.ends_with(".bsp") {
+        let base = if filename.starts_with("jup") {
+            NAIF_SATELLITES_URL
+        } else {
+            JPL_BSP_URL
+        };
+        return Some(format!("{}{}", base, filename));
+    }
+
+    None
+}
+
+/// Download a file from URL to a local path, showing a progress bar.
+///
+/// Uses a longer timeout (600s) suitable for large ephemeris files.
+/// Downloads to a temporary file first, then atomically renames.
+pub fn download_file_with_progress<P: AsRef<Path>>(url: &str, path: P) -> Result<()> {
+    if let Some(parent) = path.as_ref().parent() {
+        fs::create_dir_all(parent).map_err(StarfieldError::IoError)?;
+    }
+
+    let temp_path = path.as_ref().with_extension("tmp");
+    let mut file = BufWriter::new(File::create(&temp_path).map_err(StarfieldError::IoError)?);
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(600))
+        .build()
+        .map_err(|e| StarfieldError::DataError(format!("Failed to create HTTP client: {}", e)))?;
+
+    let response = client
+        .get(url)
+        .send()
+        .map_err(|e| StarfieldError::DataError(format!("Failed to download {}: {}", url, e)))?;
+
+    if !response.status().is_success() {
+        return Err(StarfieldError::DataError(format!(
+            "Download failed for {}: HTTP {}",
+            url,
+            response.status()
+        )));
+    }
+
+    let total_size = response.content_length().unwrap_or(0);
+    let pb = if total_size > 0 {
+        let pb = ProgressBar::new(total_size);
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("[{bar:40}] {percent}% {bytes}/{total_bytes} ({bytes_per_sec})")
+                .unwrap()
+                .progress_chars("##-"),
+        );
+        Some(pb)
+    } else {
+        None
+    };
+
+    let mut reader = io::BufReader::new(response);
+    let mut downloaded: u64 = 0;
+    let mut buffer = [0u8; 131_072]; // 128KB chunks
+
+    loop {
+        let bytes_read = reader
+            .read(&mut buffer)
+            .map_err(|e| StarfieldError::DataError(format!("Failed to read response: {}", e)))?;
+
+        if bytes_read == 0 {
+            break;
+        }
+
+        file.write_all(&buffer[..bytes_read])
+            .map_err(StarfieldError::IoError)?;
+
+        downloaded += bytes_read as u64;
+        if let Some(ref pb) = pb {
+            pb.set_position(downloaded);
+        }
+    }
+
+    if let Some(ref pb) = pb {
+        pb.finish_and_clear();
+    }
+
+    file.flush().map_err(StarfieldError::IoError)?;
+    drop(file);
+
+    fs::rename(temp_path, path).map_err(StarfieldError::IoError)?;
+
+    Ok(())
+}
+
+/// Ensure a data file is available locally, downloading it if necessary.
+///
+/// Checks `data_dir` (or the default cache `~/.cache/starfield/`) for the file.
+/// If not found, resolves the URL from the filename and downloads it.
+/// Returns the path to the local file.
+pub fn download_or_cache(filename: &str, data_dir: Option<&Path>) -> Result<PathBuf> {
+    let dir = match data_dir {
+        Some(d) => {
+            fs::create_dir_all(d).map_err(StarfieldError::IoError)?;
+            d.to_path_buf()
+        }
+        None => ensure_cache_dir().map_err(StarfieldError::IoError)?,
+    };
+
+    let local_path = dir.join(filename);
+
+    if file_exists_and_not_empty(&local_path) {
+        return Ok(local_path);
+    }
+
+    let url = resolve_url(filename).ok_or_else(|| {
+        StarfieldError::DataError(format!(
+            "Unknown file '{}'. Provide a recognized filename (e.g. de421.bsp) or a full URL.",
+            filename
+        ))
+    })?;
+
+    eprintln!("Downloading {} ...", url);
+    download_file_with_progress(&url, &local_path)?;
+    eprintln!("Saved to {}", local_path.display());
+
+    Ok(local_path)
+}
+
 /// Download the Hipparcos catalog
 pub fn download_hipparcos() -> Result<PathBuf> {
     let cache_dir = ensure_cache_dir().map_err(StarfieldError::IoError)?;
@@ -205,5 +347,81 @@ mod tests {
     fn test_cache_dir() {
         let cache_dir = get_cache_dir();
         assert!(cache_dir.to_str().unwrap().contains(".cache/starfield"));
+    }
+
+    #[test]
+    fn test_resolve_url_bsp() {
+        assert_eq!(
+            resolve_url("de421.bsp"),
+            Some("https://ssd.jpl.nasa.gov/ftp/eph/planets/bsp/de421.bsp".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_url_jupiter_bsp() {
+        assert_eq!(
+            resolve_url("jup365.bsp"),
+            Some(
+                "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/satellites/jup365.bsp"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_resolve_url_full_url_passthrough() {
+        let url = "https://example.com/custom.bsp";
+        assert_eq!(resolve_url(url), Some(url.to_string()));
+    }
+
+    #[test]
+    fn test_resolve_url_unknown() {
+        assert_eq!(resolve_url("unknown.xyz"), None);
+    }
+
+    #[test]
+    fn test_download_or_cache_cached_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let test_file = dir.path().join("test.bsp");
+        std::fs::write(&test_file, b"fake bsp data").unwrap();
+
+        let result = download_or_cache("test.bsp", Some(dir.path()));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), test_file);
+    }
+
+    #[test]
+    fn test_download_or_cache_unknown_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = download_or_cache("unknown.xyz", Some(dir.path()));
+        assert!(result.is_err());
+    }
+
+    /// Verify all known download endpoints respond to HEAD requests.
+    ///
+    /// This catches broken URLs in CI without streaming large files.
+    #[test]
+    fn test_known_endpoints_reachable() {
+        let filenames = ["de421.bsp", "de405.bsp", "de430t.bsp", "jup365.bsp"];
+
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .build()
+            .expect("Failed to build HTTP client");
+
+        for filename in filenames {
+            let url = resolve_url(filename).expect("resolve_url returned None");
+            let response = client
+                .head(&url)
+                .send()
+                .unwrap_or_else(|e| panic!("HEAD request failed for {}: {}", url, e));
+
+            assert!(
+                response.status().is_success(),
+                "Endpoint {} returned HTTP {}",
+                url,
+                response.status()
+            );
+        }
     }
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -6,7 +6,9 @@
 mod downloader;
 mod gaia_downloader;
 
-pub use downloader::{download_hipparcos, ensure_cache_dir, get_cache_dir};
+pub use downloader::{
+    download_hipparcos, download_or_cache, ensure_cache_dir, get_cache_dir, resolve_url,
+};
 pub use gaia_downloader::{
     download_gaia_catalog, download_gaia_file, ensure_gaia_cache_dir, get_gaia_cache_dir,
     list_cached_gaia_files,


### PR DESCRIPTION
## Summary
- `Loader::open("de421.bsp")` now auto-downloads ephemeris files to `~/.cache/starfield/` and caches them for reuse
- URL registry maps filenames to JPL/NAIF download endpoints (extensible via `resolve_url`)
- Progress bar for large file downloads (128KB chunks, 600s timeout, atomic rename)
- HEAD-request CI test validates all known download endpoints stay reachable
- Zero-config `auto_download` example: no manual file management needed

Closes #55

## Test plan
- [x] `cargo test` — 234 tests pass (including new resolve_url, cache, and endpoint tests)
- [x] `cargo clippy` — clean
- [x] `cargo run --example auto_download` — downloads de421.bsp, prints positions
- [x] Second run uses cached file (no re-download)