### PR TITLE
Add SpiceKernel::from_bytes for embedded assets

### DIFF
--- a/src/jplephem/spk.rs
+++ b/src/jplephem/spk.rs
@@ -106,6 +106,20 @@ impl SPK {
         Ok(spk)
     }
 
+    /// Create an SPK from an in-memory byte buffer
+    pub fn from_bytes(data: &[u8]) -> Result<Self> {
+        let daf = Arc::new(DAF::from_bytes(data)?);
+
+        let mut spk = SPK {
+            daf,
+            segments: Vec::new(),
+            pairs: HashMap::new(),
+        };
+
+        spk.parse_segments()?;
+        Ok(spk)
+    }
+
     fn parse_segments(&mut self) -> Result<()> {
         let summaries = self.daf.summaries()?;
 


### PR DESCRIPTION
## Summary
- `SpiceKernel::from_bytes(&[u8])` parses BSP data from an in-memory buffer
- Enables `include_bytes!()` for compile-time embedded ephemeris files
- `DAF::from_bytes()` and `SPK::from_bytes()` exposed at each layer
- BFS chain resolution refactored into shared `build_chains()` helper

Closes #57

## Test plan
- [x] New `test_from_bytes_matches_file` verifies bit-exact parity with file-based loading
- [x] All 27 jplephem tests pass
- [x] `cargo clippy` clean