### PR TITLE
Bump version to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starfield"
-version = "0.3.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Matthew Goodman"]
 description = "Astronomical data reduction toolkit with star catalogs, coordinate systems, and star finding algorithms (inspired by skyfield)"


### PR DESCRIPTION
## Summary
- Bumps crate version from 0.3.0 to 0.9.0

## Test plan
- [x] `cargo test` — 323 tests pass
- [x] `cargo clippy` — clean
- [x] `cargo fmt --check` — clean