### PR TITLE
Exclude test data from crates.io package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,16 @@ license = "MIT"
 readme = "README.md"
 keywords = ["astronomy", "catalog", "stars", "celestial", "skyfield"]
 categories = ["science"]
+exclude = [
+    "src/jplephem/test_data/",
+    "python-skyfield/",
+    "devops/",
+    ".env",
+    ".env.python",
+    ".vscode/",
+    ".python-version",
+    ".skyfield-version",
+]
 
 [dependencies]
 # Core astronomical calculations


### PR DESCRIPTION
## Summary
- Adds `exclude` to `Cargo.toml` to drop `de421.bsp` (17 MiB) and other non-essential files from the published crate
- Package size: 17.6 MiB -> 1.6 MiB (372 KiB compressed)
- The 17 MiB BSP ephemeris test file was exceeding crates.io's 10 MiB upload limit

## Test plan
- [x] `cargo test` — 323 tests pass (test data still available locally)
- [x] `cargo package --allow-dirty` — 1.6 MiB, well under 10 MiB limit
- [x] `cargo clippy` — clean