### PR TITLE
Rename BinaryCatalog to MinimalCatalog, bump 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starfield"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Matthew Goodman"]
 description = "Astronomical data reduction toolkit with star catalogs, coordinate systems, and star finding algorithms (inspired by skyfield)"

--- a/examples/create_hip_binary.rs
+++ b/examples/create_hip_binary.rs
@@ -1,6 +1,6 @@
-//! Script to create a binary catalog from Hipparcos data
+//! Script to create a minimal catalog from Hipparcos data
 
-use starfield::catalogs::{BinaryCatalog, StarCatalog, StarData};
+use starfield::catalogs::{MinimalCatalog, StarCatalog, StarData};
 use starfield::Loader;
 use std::path::PathBuf;
 
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Loaded {} stars from Hipparcos catalog", hip_catalog.len());
 
-    // Convert to StarData for binary catalog
+    // Convert to StarData for minimal catalog
     let star_data: Vec<StarData> = hip_catalog.star_data().collect();
 
     // Create output path in the test_output directory
@@ -26,9 +26,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Get the count before we move the data
     let star_count = star_data.len();
 
-    // Create the binary catalog
-    println!("Creating binary catalog at {}...", output_path.display());
-    BinaryCatalog::write_from_star_data(
+    // Create the minimal catalog
+    println!("Creating minimal catalog at {}...", output_path.display());
+    MinimalCatalog::write_from_star_data(
         &output_path,
         star_data.into_iter(),
         "Hipparcos Catalog (magnitude < 9.0)",
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     println!(
-        "Binary catalog created successfully with {} stars",
+        "Minimal catalog created successfully with {} stars",
         star_count
     );
     println!("Use with --catalog {}", output_path.display());

--- a/examples/gaia_filter.rs
+++ b/examples/gaia_filter.rs
@@ -16,7 +16,7 @@ use clap::{Parser, Subcommand};
 use flate2::read::GzDecoder;
 use flate2::write;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use starfield::catalogs::{BinaryCatalog, StarData};
+use starfield::catalogs::{MinimalCatalog, StarData};
 use starfield::data::list_cached_gaia_files;
 
 /// Command line arguments for the Gaia Catalog Filter Tool
@@ -653,7 +653,7 @@ fn process_files_and_stream<P: AsRef<Path>>(
     // Create description for the catalog
     let desc = format!("Gaia catalog filtered to magnitude {}", magnitude_limit);
 
-    // Create a progress bar for writing to the binary catalog
+    // Create a progress bar for writing to the minimal catalog
     let catalog_style = ProgressStyle::default_bar()
         .template(
             "{spinner:.green} [{elapsed_precise}] [{bar:40.yellow/blue}] Writing stars ({eta})",
@@ -672,7 +672,7 @@ fn process_files_and_stream<P: AsRef<Path>>(
     });
 
     // Write catalog directly from the iterator interface of our collector
-    let written_count = BinaryCatalog::write_from_star_data(
+    let written_count = MinimalCatalog::write_from_star_data(
         &output_path,
         counting_iterator,
         &desc,
@@ -836,7 +836,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Create description for the catalog
             let desc = format!("Gaia catalog filtered to magnitude {}", cli.magnitude);
 
-            // Create a progress bar for writing to the binary catalog
+            // Create a progress bar for writing to the minimal catalog
             let catalog_style = ProgressStyle::default_bar()
                 .template(
                     "{spinner:.green} [{elapsed_precise}] [{bar:40.yellow/blue}] Writing stars ({eta})",
@@ -856,7 +856,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             });
 
             // Write catalog directly from the iterator interface of our collector
-            let star_count = BinaryCatalog::write_from_star_data(
+            let star_count = MinimalCatalog::write_from_star_data(
                 &output_file,
                 counting_iterator,
                 &desc,

--- a/examples/minimal_catalog_info.rs
+++ b/examples/minimal_catalog_info.rs
@@ -1,20 +1,20 @@
-//! Utility to show information about binary star catalogs
+//! Utility to show information about minimal star catalogs
 //!
-//! This tool reads binary catalogs and displays metadata and statistics
+//! This tool reads minimal catalogs and displays metadata and statistics
 //! about the catalog contents.
 
 use std::env;
 use std::path::Path;
 
-use starfield::catalogs::{BinaryCatalog, StarPosition};
+use starfield::catalogs::{MinimalCatalog, StarPosition};
 
 fn print_catalog_info<P: AsRef<Path>>(path: P) -> Result<(), Box<dyn std::error::Error>> {
     // Get path as string for later use
     let path_string = path.as_ref().to_string_lossy().to_string();
 
     // Load the catalog
-    println!("Loading binary catalog: {}", path.as_ref().display());
-    let catalog = BinaryCatalog::load(&path)?;
+    println!("Loading minimal catalog: {}", path.as_ref().display());
+    let catalog = MinimalCatalog::load(&path)?;
 
     // Print basic information
     println!("\nCatalog Information:");
@@ -148,7 +148,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 2 {
-        println!("Usage: cargo run --example binary_catalog_info -- <catalog_file_path>");
+        println!("Usage: cargo run --example minimal_catalog_info -- <catalog_file_path>");
         return Ok(());
     }
 

--- a/examples/minimal_catalog_viewer.rs
+++ b/examples/minimal_catalog_viewer.rs
@@ -1,14 +1,14 @@
-//! Binary Star Catalog Viewer
+//! Minimal Star Catalog Viewer
 //!
-//! This utility displays information about binary star catalog files and can
+//! This utility displays information about minimal star catalog files and can
 //! convert them to CSV format if needed.
 //!
 //! Usage:
-//!   cargo run --example binary_catalog_viewer -- [options]
+//!   cargo run --example minimal_catalog_viewer -- [options]
 //!
 //! Options:
-//!   --input PATH       Binary catalog file to view
-//!   --convert PATH     Convert binary catalog to CSV at specified path
+//!   --input PATH       Minimal catalog file to view
+//!   --convert PATH     Convert minimal catalog to CSV at specified path
 //!   --magnitude FLOAT  Only include stars brighter than this magnitude when converting
 
 use std::env;
@@ -16,17 +16,17 @@ use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
-use starfield::catalogs::{BinaryCatalog, StarPosition};
+use starfield::catalogs::{MinimalCatalog, StarPosition};
 
-/// Print information about a binary catalog file
+/// Print information about a minimal catalog file
 fn view_catalog<P: AsRef<Path>>(catalog_path: P) -> Result<(), Box<dyn std::error::Error>> {
     println!(
-        "Loading binary catalog: {}",
+        "Loading minimal catalog: {}",
         catalog_path.as_ref().display()
     );
 
     // Load the catalog
-    let catalog = BinaryCatalog::load(&catalog_path)?;
+    let catalog = MinimalCatalog::load(&catalog_path)?;
 
     // Print basic information
     println!("\nCatalog Information:");
@@ -111,20 +111,20 @@ fn view_catalog<P: AsRef<Path>>(catalog_path: P) -> Result<(), Box<dyn std::erro
     Ok(())
 }
 
-/// Convert a binary catalog to CSV format
+/// Convert a minimal catalog to CSV format
 fn convert_to_csv<P: AsRef<Path>, Q: AsRef<Path>>(
     input_path: P,
     output_path: Q,
     magnitude_limit: Option<f64>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!(
-        "Converting binary catalog to CSV: {} -> {}",
+        "Converting minimal catalog to CSV: {} -> {}",
         input_path.as_ref().display(),
         output_path.as_ref().display()
     );
 
     // Load the catalog
-    let catalog = BinaryCatalog::load(input_path)?;
+    let catalog = MinimalCatalog::load(input_path)?;
 
     // Create output CSV file
     let output_file = File::create(output_path)?;
@@ -206,17 +206,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    println!("Binary Star Catalog Viewer");
-    println!("==========================");
+    println!("Minimal Star Catalog Viewer");
+    println!("===========================");
 
     // Check if input path is provided
     if input_path.is_none() {
         println!("Usage:");
-        println!("  cargo run --example binary_catalog_viewer -- --input <binary_file> [options]");
+        println!(
+            "  cargo run --example minimal_catalog_viewer -- --input <catalog_file> [options]"
+        );
         println!("");
         println!("Options:");
-        println!("  --input PATH       Binary catalog file to view");
-        println!("  --convert PATH     Convert binary catalog to CSV at specified path");
+        println!("  --input PATH       Minimal catalog file to view");
+        println!("  --convert PATH     Convert minimal catalog to CSV at specified path");
         println!(
             "  --magnitude FLOAT  Only include stars brighter than this magnitude when converting"
         );

--- a/examples/synthetic_catalog.rs
+++ b/examples/synthetic_catalog.rs
@@ -4,7 +4,7 @@
 //! with realistic magnitude distributions.
 
 use starfield::catalogs::{
-    create_fov_catalog, create_synthetic_catalog, BinaryCatalog, SpatialDistribution,
+    create_fov_catalog, create_synthetic_catalog, MinimalCatalog, SpatialDistribution,
     SyntheticCatalogConfig,
 };
 use std::path::Path;
@@ -74,7 +74,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// Print information about a catalog
-fn print_catalog_info(catalog: &BinaryCatalog, title: &str) {
+fn print_catalog_info(catalog: &MinimalCatalog, title: &str) {
     println!("\n{}", title);
     println!("{}", "-".repeat(title.len()));
     println!("Description: {}", catalog.description());

--- a/src/bin/catalog_stats.rs
+++ b/src/bin/catalog_stats.rs
@@ -7,7 +7,7 @@ use std::io::{self, Write};
 use std::path::Path;
 
 use starfield::catalogs::hipparcos::HipparcosEntry;
-use starfield::catalogs::{BinaryCatalog, MinimalStar, StarCatalog};
+use starfield::catalogs::{MinimalCatalog, MinimalStar, StarCatalog};
 use starfield::Loader;
 
 /// Print a simple progress bar
@@ -38,14 +38,14 @@ fn filter_and_save<P: AsRef<Path>>(
         output_path.as_ref().display()
     );
 
-    // Create description for the binary catalog
+    // Create description for the minimal catalog
     let desc = format!(
         "Hipparcos filtered catalog: magnitude <= {}, created on {}",
         magnitude_limit,
         chrono::Local::now().format("%Y-%m-%d")
     );
 
-    // Filter stars and add to binary catalog
+    // Filter stars and add to minimal catalog
     let mut count = 0;
     // We'll collect the stars first, then build the catalog
     let mut filtered_stars = Vec::new();
@@ -60,12 +60,12 @@ fn filter_and_save<P: AsRef<Path>>(
     }
 
     // Create the catalog from collected stars
-    let binary_catalog = BinaryCatalog::from_stars(filtered_stars, &desc);
+    let catalog = MinimalCatalog::from_stars(filtered_stars, &desc);
 
     // Save the catalog
-    binary_catalog.save(output_path)?;
+    catalog.save(output_path)?;
 
-    println!("Saved {} stars to binary catalog", count);
+    println!("Saved {} stars to minimal catalog", count);
     Ok(count)
 }
 

--- a/src/catalogs/mod.rs
+++ b/src/catalogs/mod.rs
@@ -6,16 +6,16 @@
 
 use crate::coordinates::Equatorial;
 
-pub mod binary_catalog;
 pub mod features;
 mod gaia;
 pub mod hipparcos;
+pub mod minimal_catalog;
 pub mod synthetic;
 
-pub use binary_catalog::{BinaryCatalog, MinimalStar};
 pub use features::{FeatureCatalog, FeatureType, SkyFeature};
 pub use gaia::{GaiaCatalog, GaiaEntry};
 pub use hipparcos::{HipparcosCatalog, HipparcosEntry};
+pub use minimal_catalog::{MinimalCatalog, MinimalStar};
 pub use synthetic::{
     create_fov_catalog, create_synthetic_catalog, MagnitudeDistribution, SpatialDistribution,
     SyntheticCatalogConfig,
@@ -154,8 +154,8 @@ pub trait StarCatalog {
 pub enum CatalogSource {
     /// Hipparcos catalog (default path in cache)
     Hipparcos,
-    /// Binary catalog with specified path (checks relative path and cache)
-    Binary(PathBuf),
+    /// Minimal catalog with specified path (checks relative path and cache)
+    Minimal(PathBuf),
     /// Random synthetic stars with specified seed and count
     Random { seed: u64, count: usize },
 }
@@ -178,9 +178,9 @@ pub fn get_stars_in_window(
             ))
         }
 
-        CatalogSource::Binary(path) => {
-            println!("Loading binary catalog from: {}", path.display());
-            let catalog = BinaryCatalog::load(&path)?;
+        CatalogSource::Minimal(path) => {
+            println!("Loading minimal catalog from: {}", path.display());
+            let catalog = MinimalCatalog::load(&path)?;
             println!("Loaded catalog: {}", catalog.description());
             println!("Total stars in catalog: {}", catalog.len());
 
@@ -274,12 +274,12 @@ fn generate_synthetic_stars(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::catalogs::binary_catalog::{BinaryCatalog, MinimalStar};
+    use crate::catalogs::minimal_catalog::{MinimalCatalog, MinimalStar};
 
-    /// Test the StarCatalog trait with a simple binary catalog
+    /// Test the StarCatalog trait with a simple minimal catalog
     #[test]
     fn test_star_data() {
-        // Create a binary catalog
+        // Create a minimal catalog
         let stars = vec![
             MinimalStar::new(1, 100.0, 10.0, -1.5), // Sirius-like
             MinimalStar::new(2, 50.0, -20.0, 0.5),  // Canopus-like
@@ -288,7 +288,7 @@ mod tests {
             MinimalStar::new(5, 250.0, 60.0, 5.9),  // Dim
         ];
 
-        let catalog = BinaryCatalog::from_stars(stars, "Test catalog");
+        let catalog = MinimalCatalog::from_stars(stars, "Test catalog");
 
         // Test star_data iterator
         let star_data: Vec<StarData> = catalog.star_data().collect();

--- a/src/catalogs/synthetic.rs
+++ b/src/catalogs/synthetic.rs
@@ -10,7 +10,7 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use std::f64::consts::PI;
 
-use super::{BinaryCatalog, MinimalStar};
+use super::{MinimalCatalog, MinimalStar};
 use crate::StarfieldError;
 
 /// Statistical star magnitude distribution parameters
@@ -136,7 +136,7 @@ impl SyntheticCatalogConfig {
     }
 
     /// Generate a synthetic star catalog with the configured parameters
-    pub fn generate(&self) -> Result<BinaryCatalog, StarfieldError> {
+    pub fn generate(&self) -> Result<MinimalCatalog, StarfieldError> {
         // Create seeded RNG
         let mut rng = StdRng::seed_from_u64(self.seed);
 
@@ -192,8 +192,8 @@ impl SyntheticCatalogConfig {
             );
         }
 
-        // Create and return the binary catalog
-        Ok(BinaryCatalog::from_stars(stars, &self.description))
+        // Create and return the minimal catalog
+        Ok(MinimalCatalog::from_stars(stars, &self.description))
     }
 
     /// Generate a star's position based on the spatial distribution model
@@ -320,7 +320,7 @@ pub fn create_synthetic_catalog(
     min_magnitude: f64,
     max_magnitude: f64,
     seed: u64,
-) -> Result<BinaryCatalog, StarfieldError> {
+) -> Result<MinimalCatalog, StarfieldError> {
     SyntheticCatalogConfig::new()
         .with_count(count)
         .with_magnitude_range(min_magnitude, max_magnitude)
@@ -337,7 +337,7 @@ pub fn create_fov_catalog(
     dec: f64,
     fov_deg: f64,
     seed: u64,
-) -> Result<BinaryCatalog, StarfieldError> {
+) -> Result<MinimalCatalog, StarfieldError> {
     SyntheticCatalogConfig::new()
         .with_count(count)
         .with_magnitude_range(min_magnitude, max_magnitude)


### PR DESCRIPTION
## Summary
- Renames `BinaryCatalog` → `MinimalCatalog` to avoid confusion with binary star systems
- Renames `CatalogSource::Binary` → `CatalogSource::Minimal`
- Renames file `binary_catalog.rs` → `minimal_catalog.rs`
- Renames example files accordingly
- Updates all doc comments, error messages, and string literals
- Bumps version from 0.9.0 to 0.9.1

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy` — clean
- [x] `cargo test` — 323 tests pass