### PR TITLE
Add From/Into array conversions for Cartesian3, Equatorial

### DIFF
--- a/src/coordinates/cartesian.rs
+++ b/src/coordinates/cartesian.rs
@@ -415,6 +415,18 @@ impl Cartesian3 {
     }
 }
 
+impl From<[f64; 3]> for Cartesian3 {
+    fn from(arr: [f64; 3]) -> Self {
+        Cartesian3::new(arr[0], arr[1], arr[2])
+    }
+}
+
+impl From<Cartesian3> for [f64; 3] {
+    fn from(cart: Cartesian3) -> Self {
+        [cart.x, cart.y, cart.z]
+    }
+}
+
 // Arithmetic operations for convenience
 impl std::ops::Add for Cartesian3 {
     type Output = Cartesian3;
@@ -721,5 +733,28 @@ mod tests {
         assert_eq!(doubled.x, 0.123456789012345 * 2.0);
         assert_eq!(doubled.y, 0.987654321098765 * 2.0);
         assert_eq!(doubled.z, 0.555666777888999 * 2.0);
+    }
+
+    #[test]
+    fn test_from_array() {
+        let cart: Cartesian3 = [1.0, 2.0, 3.0].into();
+        assert_eq!(cart.x, 1.0);
+        assert_eq!(cart.y, 2.0);
+        assert_eq!(cart.z, 3.0);
+    }
+
+    #[test]
+    fn test_into_array() {
+        let cart = Cartesian3::new(4.0, 5.0, 6.0);
+        let arr: [f64; 3] = cart.into();
+        assert_eq!(arr, [4.0, 5.0, 6.0]);
+    }
+
+    #[test]
+    fn test_array_roundtrip() {
+        let original = [1.5, -2.7, 3.14];
+        let cart: Cartesian3 = original.into();
+        let back: [f64; 3] = cart.into();
+        assert_eq!(original, back);
     }
 }

--- a/src/framelib/inertial.rs
+++ b/src/framelib/inertial.rs
@@ -94,6 +94,18 @@ impl Equatorial {
     }
 }
 
+impl From<[f64; 2]> for Equatorial {
+    fn from(arr: [f64; 2]) -> Self {
+        Equatorial::new(arr[0], arr[1])
+    }
+}
+
+impl From<Equatorial> for [f64; 2] {
+    fn from(eq: Equatorial) -> Self {
+        [eq.ra, eq.dec]
+    }
+}
+
 // Ecliptic coordinates
 #[derive(Debug, Clone, Copy)]
 pub struct Ecliptic {
@@ -767,5 +779,28 @@ mod tests {
         );
         assert_relative_eq!(galactic.lon, ec2ga.lon, epsilon = 1e-4);
         assert_relative_eq!(galactic.lat, ec2ga.lat, epsilon = 1e-4);
+    }
+
+    #[test]
+    fn test_equatorial_from_array() {
+        let eq: Equatorial = [1.0, 0.5].into();
+        assert_eq!(eq.ra, 1.0);
+        assert_eq!(eq.dec, 0.5);
+    }
+
+    #[test]
+    fn test_equatorial_into_array() {
+        let eq = Equatorial::new(1.0, 0.5);
+        let arr: [f64; 2] = eq.into();
+        assert_eq!(arr, [1.0, 0.5]);
+    }
+
+    #[test]
+    fn test_equatorial_array_roundtrip() {
+        let eq = Equatorial::new(2.0, -0.3);
+        let arr: [f64; 2] = eq.into();
+        let back: Equatorial = arr.into();
+        assert_eq!(eq.ra, back.ra);
+        assert_eq!(eq.dec, back.dec);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `From<[f64; 3]>` and `From<Cartesian3> for [f64; 3]>` for zero-friction interop with KD-trees and spatial indexing
- Adds `From<[f64; 2]>` and `From<Equatorial> for [f64; 2]>` for RA/Dec array interop
- Includes roundtrip tests for both types

Closes #72

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy` — clean
- [x] `cargo test` — 329 tests pass