### PR TITLE
Add HORIZONS API client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # Network and compression
-reqwest = { version = "0.11", features = ["blocking"] }
+reqwest = { version = "0.11", features = ["blocking", "json"] }
 flate2 = "1.0"                                          # GZip compression
 rand = "0.8"                                            # Random number generation for synthetic data
 md5 = "0.7"                                             # MD5 checksum calculation

--- a/examples/horizons_lookup.rs
+++ b/examples/horizons_lookup.rs
@@ -1,0 +1,57 @@
+//! Look up solar system objects by name using the HORIZONS lookup API.
+//!
+//! Demonstrates searching for asteroids, comets, and other objects
+//! by name or designation.
+//!
+//! Run with: `cargo run --example horizons_lookup`
+
+use starfield::horizons::{HorizonsClient, ObjectGroup};
+
+fn main() -> starfield::Result<()> {
+    let client = HorizonsClient::new()?;
+
+    // Look up Apophis (a well-known near-Earth asteroid)
+    println!("Looking up 'Apophis'...");
+    let response = client.lookup("Apophis", Some(ObjectGroup::Asteroid))?;
+    println!("  Found {} match(es)", response.count());
+    if let Some(results) = &response.result {
+        for r in results {
+            println!(
+                "  - {} (designation: {}, SPK-ID: {})",
+                r.name.as_deref().unwrap_or("?"),
+                r.pdes.as_deref().unwrap_or("?"),
+                r.spkid.as_deref().unwrap_or("?"),
+            );
+        }
+    }
+
+    // Look up Halley's Comet
+    println!("\nLooking up 'Halley'...");
+    let response = client.lookup("Halley", Some(ObjectGroup::Comet))?;
+    println!("  Found {} match(es)", response.count());
+    if let Some(results) = &response.result {
+        for r in results {
+            println!(
+                "  - {} (designation: {})",
+                r.name.as_deref().unwrap_or("?"),
+                r.pdes.as_deref().unwrap_or("?"),
+            );
+        }
+    }
+
+    // Look up a major body
+    println!("\nLooking up 'Europa'...");
+    let response = client.lookup("Europa", None)?;
+    println!("  Found {} match(es)", response.count());
+    if let Some(results) = &response.result {
+        for r in results {
+            println!(
+                "  - {} (SPK-ID: {})",
+                r.name.as_deref().unwrap_or("?"),
+                r.spkid.as_deref().unwrap_or("?"),
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/examples/horizons_vectors.rs
+++ b/examples/horizons_vectors.rs
@@ -1,0 +1,56 @@
+//! Fetch Mars state vectors from the HORIZONS API.
+//!
+//! Demonstrates querying Cartesian position and velocity vectors for
+//! a planet relative to the Solar System Barycenter.
+//!
+//! Run with: `cargo run --example horizons_vectors`
+
+use starfield::horizons::parser;
+use starfield::horizons::{Center, Command, EphemerisRequest, HorizonsClient, TimeSpec};
+
+fn main() -> starfield::Result<()> {
+    let client = HorizonsClient::new()?;
+
+    // Request Mars state vectors for the first week of 2024
+    let request = EphemerisRequest::vectors(
+        Command::MajorBody(499), // Mars
+        Center::SolarSystemBarycenter,
+        TimeSpec::Range {
+            start: "2024-01-01".into(),
+            stop: "2024-01-08".into(),
+            step: "1 d".into(),
+        },
+    );
+
+    println!("Querying HORIZONS for Mars state vectors...");
+    let response = client.query(&request)?;
+
+    let result = response
+        .result
+        .as_ref()
+        .expect("No result in HORIZONS response");
+
+    let block = parser::extract_ephemeris_block(result)?;
+    let rows = parser::parse_vector_rows(block)?;
+
+    println!("\nMars state vectors (AU, AU/day) relative to SSB:");
+    println!(
+        "{:<14} {:>15} {:>15} {:>15} {:>12}",
+        "JD (TDB)", "X", "Y", "Z", "Range (AU)"
+    );
+    println!("{}", "-".repeat(75));
+
+    for row in &rows {
+        println!(
+            "{:<14.1} {:>15.10} {:>15.10} {:>15.10} {:>12.8}",
+            row.jd_tdb,
+            row.x,
+            row.y,
+            row.z,
+            row.range.unwrap_or(0.0),
+        );
+    }
+
+    println!("\n{} data points retrieved.", rows.len());
+    Ok(())
+}

--- a/src/data/horizons.rs
+++ b/src/data/horizons.rs
@@ -1,0 +1,728 @@
+//! HTTP client for the NASA JPL HORIZONS ephemeris computation service.
+//!
+//! HORIZONS computes positions, velocities, and observational quantities
+//! for over 1.5 million solar system objects. This module provides a
+//! type-safe Rust interface to both the ephemeris API and the lookup API.
+//!
+//! No API key or authentication is required.
+
+use crate::{Result, StarfieldError};
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// Base URL for the HORIZONS ephemeris API
+const HORIZONS_API_URL: &str = "https://ssd.jpl.nasa.gov/api/horizons.api";
+
+/// Base URL for the HORIZONS lookup API
+const HORIZONS_LOOKUP_URL: &str = "https://ssd.jpl.nasa.gov/api/horizons_lookup.api";
+
+/// Target body specification for the COMMAND parameter.
+///
+/// Different syntax rules apply to major bodies vs small bodies.
+/// The semicolon suffix for small bodies is handled automatically.
+#[derive(Debug, Clone)]
+pub enum Command {
+    /// Major body by NAIF ID (e.g., 499 for Mars, 10 for Sun, 301 for Moon)
+    MajorBody(i32),
+    /// Asteroid by IAU number (semicolon appended automatically)
+    Asteroid(u32),
+    /// Comet by designation string (e.g., "73P")
+    Comet(String),
+    /// Object by provisional designation (e.g., "1999 AN10")
+    Designation(String),
+    /// Object by name (case-insensitive search, semicolon appended)
+    Name(String),
+}
+
+impl Command {
+    /// Convert to the query string value expected by the HORIZONS API
+    pub fn to_query_value(&self) -> String {
+        match self {
+            Command::MajorBody(id) => format!("{}", id),
+            Command::Asteroid(num) => format!("{};", num),
+            Command::Comet(des) => format!("{};", des),
+            Command::Designation(des) => format!("DES={};", des),
+            Command::Name(name) => format!("{};", name),
+        }
+    }
+}
+
+/// Ephemeris output type
+#[derive(Debug, Clone, Copy)]
+pub enum EphemType {
+    /// Observer-table: sky-plane observables (RA/Dec, magnitude, etc.)
+    Observer,
+    /// Vectors: Cartesian state vectors (X, Y, Z, VX, VY, VZ)
+    Vectors,
+    /// Elements: osculating Keplerian orbital elements
+    Elements,
+}
+
+impl EphemType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            EphemType::Observer => "OBSERVER",
+            EphemType::Vectors => "VECTORS",
+            EphemType::Elements => "ELEMENTS",
+        }
+    }
+}
+
+/// Observer or coordinate center specification
+#[derive(Debug, Clone)]
+pub enum Center {
+    /// Body center by NAIF ID (e.g., 399 for geocentric, 0 for SSB)
+    BodyCenter(i32),
+    /// Observatory site code at a body (e.g., "675@399" for Palomar)
+    Site(String),
+    /// Geocentric (equivalent to BodyCenter(500@399))
+    Geocentric,
+    /// Solar System Barycenter
+    SolarSystemBarycenter,
+}
+
+impl Center {
+    fn to_query_value(&self) -> String {
+        match self {
+            Center::BodyCenter(id) => format!("500@{}", id),
+            Center::Site(code) => code.clone(),
+            Center::Geocentric => "500@399".to_string(),
+            Center::SolarSystemBarycenter => "500@0".to_string(),
+        }
+    }
+}
+
+/// Time specification for ephemeris requests
+#[derive(Debug, Clone)]
+pub enum TimeSpec {
+    /// Time range with start, stop, and step size
+    Range {
+        /// Start time (e.g., "2024-01-01", "2024-01-01 12:00", "JD2451545.0")
+        start: String,
+        /// Stop time
+        stop: String,
+        /// Step size (e.g., "1 d", "1 h", "30 m", "10", "1 MONTH")
+        step: String,
+    },
+    /// Discrete list of Julian Day numbers (TDB)
+    JulianDayList(Vec<f64>),
+}
+
+/// Output distance/time units for vector and elements ephemerides
+#[derive(Debug, Clone, Copy)]
+pub enum OutputUnits {
+    /// Kilometers and seconds
+    KmS,
+    /// Astronomical units and days
+    AuD,
+    /// Kilometers and days
+    KmD,
+}
+
+impl OutputUnits {
+    fn as_str(&self) -> &'static str {
+        match self {
+            OutputUnits::KmS => "KM-S",
+            OutputUnits::AuD => "AU-D",
+            OutputUnits::KmD => "KM-D",
+        }
+    }
+}
+
+/// Reference plane for vector or elements output
+#[derive(Debug, Clone, Copy)]
+pub enum ReferencePlane {
+    /// Ecliptic and mean equinox of reference epoch
+    Ecliptic,
+    /// Body-centered reference frame (ICRF)
+    Frame,
+    /// Body equator and node of date
+    BodyEquator,
+}
+
+impl ReferencePlane {
+    fn as_str(&self) -> &'static str {
+        match self {
+            ReferencePlane::Ecliptic => "ECLIPTIC",
+            ReferencePlane::Frame => "FRAME",
+            ReferencePlane::BodyEquator => "BODY EQUATOR",
+        }
+    }
+}
+
+/// Vector table content type
+#[derive(Debug, Clone, Copy)]
+pub enum VecTable {
+    /// Position only: X, Y, Z
+    Position,
+    /// State vector: X, Y, Z, VX, VY, VZ
+    State,
+    /// State + extras: X, Y, Z, VX, VY, VZ, LT, RG, RR (default)
+    StateExtras,
+    /// Position + extras: X, Y, Z, LT, RG, RR
+    PositionExtras,
+    /// Velocity only: VX, VY, VZ
+    Velocity,
+    /// Extras only: LT, RG, RR
+    Extras,
+}
+
+impl VecTable {
+    fn as_str(&self) -> &'static str {
+        match self {
+            VecTable::Position => "1",
+            VecTable::State => "2",
+            VecTable::StateExtras => "3",
+            VecTable::PositionExtras => "4",
+            VecTable::Velocity => "5",
+            VecTable::Extras => "6",
+        }
+    }
+}
+
+/// Aberration correction for vector output
+#[derive(Debug, Clone, Copy)]
+pub enum VecCorrection {
+    /// Geometric (no correction)
+    None,
+    /// Light-time corrected (astrometric)
+    LightTime,
+    /// Light-time + stellar aberration (apparent)
+    LightTimeAberration,
+}
+
+impl VecCorrection {
+    fn as_str(&self) -> &'static str {
+        match self {
+            VecCorrection::None => "NONE",
+            VecCorrection::LightTime => "LT",
+            VecCorrection::LightTimeAberration => "LT+S",
+        }
+    }
+}
+
+/// Request builder for HORIZONS ephemeris queries
+#[derive(Debug, Clone)]
+pub struct EphemerisRequest {
+    /// Target body
+    pub command: Command,
+    /// Ephemeris type
+    pub ephem_type: EphemType,
+    /// Coordinate center
+    pub center: Center,
+    /// Time specification
+    pub time_spec: TimeSpec,
+    /// Include object data header (default: false)
+    pub obj_data: bool,
+    /// Vector table type
+    pub vec_table: Option<VecTable>,
+    /// Output units
+    pub out_units: Option<OutputUnits>,
+    /// Vector aberration correction
+    pub vec_corr: Option<VecCorrection>,
+    /// Reference plane
+    pub ref_plane: Option<ReferencePlane>,
+    /// Observer quantity codes (comma-separated, e.g., "1,9,20,23")
+    pub quantities: Option<String>,
+    /// RA/Dec angle format: "HMS" or "DEG"
+    pub ang_format: Option<String>,
+    /// Enable CSV-format output
+    pub csv_format: bool,
+    /// Extra precision in RA/Dec
+    pub extra_prec: bool,
+}
+
+impl EphemerisRequest {
+    /// Create a request for Cartesian state vectors
+    pub fn vectors(command: Command, center: Center, time_spec: TimeSpec) -> Self {
+        Self {
+            command,
+            ephem_type: EphemType::Vectors,
+            center,
+            time_spec,
+            obj_data: false,
+            vec_table: Some(VecTable::StateExtras),
+            out_units: Some(OutputUnits::AuD),
+            vec_corr: Some(VecCorrection::None),
+            ref_plane: Some(ReferencePlane::Ecliptic),
+            quantities: None,
+            ang_format: None,
+            csv_format: true,
+            extra_prec: false,
+        }
+    }
+
+    /// Create a request for observer-table data (RA/Dec, magnitude, etc.)
+    pub fn observer(command: Command, center: Center, time_spec: TimeSpec) -> Self {
+        Self {
+            command,
+            ephem_type: EphemType::Observer,
+            center,
+            time_spec,
+            obj_data: false,
+            vec_table: None,
+            out_units: None,
+            vec_corr: None,
+            ref_plane: None,
+            quantities: Some("1,9,20,23".to_string()),
+            ang_format: Some("DEG".to_string()),
+            csv_format: true,
+            extra_prec: true,
+        }
+    }
+
+    /// Create a request for osculating Keplerian orbital elements
+    pub fn elements(command: Command, center: Center, time_spec: TimeSpec) -> Self {
+        Self {
+            command,
+            ephem_type: EphemType::Elements,
+            center,
+            time_spec,
+            obj_data: false,
+            vec_table: None,
+            out_units: Some(OutputUnits::AuD),
+            vec_corr: None,
+            ref_plane: Some(ReferencePlane::Ecliptic),
+            quantities: None,
+            ang_format: None,
+            csv_format: true,
+            extra_prec: false,
+        }
+    }
+
+    /// Build query parameters for the HTTP request
+    fn to_query_params(&self) -> Vec<(String, String)> {
+        let mut params: Vec<(String, String)> = Vec::new();
+
+        params.push(("format".into(), "json".into()));
+        params.push((
+            "COMMAND".into(),
+            format!("'{}'", self.command.to_query_value()),
+        ));
+        params.push(("MAKE_EPHEM".into(), "YES".into()));
+        params.push(("EPHEM_TYPE".into(), self.ephem_type.as_str().into()));
+        params.push((
+            "CENTER".into(),
+            format!("'{}'", self.center.to_query_value()),
+        ));
+
+        match &self.time_spec {
+            TimeSpec::Range { start, stop, step } => {
+                params.push(("START_TIME".into(), format!("'{}'", start)));
+                params.push(("STOP_TIME".into(), format!("'{}'", stop)));
+                params.push(("STEP_SIZE".into(), format!("'{}'", step)));
+            }
+            TimeSpec::JulianDayList(jds) => {
+                let tlist: Vec<String> = jds.iter().map(|jd| format!("{}", jd)).collect();
+                params.push(("TLIST".into(), tlist.join(",")));
+            }
+        }
+
+        if self.obj_data {
+            params.push(("OBJ_DATA".into(), "YES".into()));
+        } else {
+            params.push(("OBJ_DATA".into(), "NO".into()));
+        }
+
+        if let Some(vt) = &self.vec_table {
+            params.push(("VEC_TABLE".into(), format!("'{}'", vt.as_str())));
+        }
+
+        if let Some(units) = &self.out_units {
+            params.push(("OUT_UNITS".into(), format!("'{}'", units.as_str())));
+        }
+
+        if let Some(corr) = &self.vec_corr {
+            params.push(("VEC_CORR".into(), format!("'{}'", corr.as_str())));
+        }
+
+        if let Some(plane) = &self.ref_plane {
+            params.push(("REF_PLANE".into(), format!("'{}'", plane.as_str())));
+        }
+
+        if let Some(quant) = &self.quantities {
+            params.push(("QUANTITIES".into(), format!("'{}'", quant)));
+        }
+
+        if let Some(fmt) = &self.ang_format {
+            params.push(("ANG_FORMAT".into(), format!("'{}'", fmt)));
+        }
+
+        if self.csv_format {
+            params.push(("CSV_FORMAT".into(), "YES".into()));
+        }
+
+        if self.extra_prec {
+            params.push(("EXTRA_PREC".into(), "YES".into()));
+        }
+
+        params
+    }
+}
+
+/// API response signature common to all HORIZONS endpoints
+#[derive(Debug, Clone, Deserialize)]
+pub struct Signature {
+    pub source: String,
+    pub version: String,
+}
+
+/// Raw JSON response from the HORIZONS ephemeris API
+#[derive(Debug, Clone, Deserialize)]
+pub struct HorizonsResponse {
+    pub signature: Option<Signature>,
+    /// Full text output (for OBSERVER, VECTORS, ELEMENTS, APPROACH types)
+    pub result: Option<String>,
+    /// Base64-encoded SPK binary (for SPK ephemeris type)
+    pub spk: Option<String>,
+    /// Suggested filename for SPK output
+    pub spk_file_id: Option<String>,
+}
+
+/// Object group filter for the lookup API
+#[derive(Debug, Clone, Copy)]
+pub enum ObjectGroup {
+    /// Asteroids only
+    Asteroid,
+    /// Comets only
+    Comet,
+    /// Planets only
+    Planet,
+    /// Natural satellites only
+    Satellite,
+    /// Spacecraft only
+    Spacecraft,
+    /// All major bodies (planets + satellites + spacecraft)
+    MajorBody,
+    /// All small bodies (asteroids + comets)
+    SmallBody,
+}
+
+impl ObjectGroup {
+    fn as_str(&self) -> &'static str {
+        match self {
+            ObjectGroup::Asteroid => "ast",
+            ObjectGroup::Comet => "com",
+            ObjectGroup::Planet => "pln",
+            ObjectGroup::Satellite => "sat",
+            ObjectGroup::Spacecraft => "sct",
+            ObjectGroup::MajorBody => "mb",
+            ObjectGroup::SmallBody => "sb",
+        }
+    }
+}
+
+/// A single match from the lookup API
+#[derive(Debug, Clone, Deserialize)]
+pub struct LookupMatch {
+    /// Primary designation
+    pub pdes: Option<String>,
+    /// Object name
+    pub name: Option<String>,
+    /// SPK-ID
+    pub spkid: Option<String>,
+    /// Alternate designations
+    pub alias: Option<Vec<String>>,
+}
+
+/// Response from the HORIZONS lookup API
+#[derive(Debug, Clone, Deserialize)]
+pub struct LookupResponse {
+    pub signature: Option<Signature>,
+    /// Number of matches (as string from the API)
+    pub count: Option<String>,
+    /// Match results (present when count >= 1)
+    pub result: Option<Vec<LookupMatch>>,
+}
+
+impl LookupResponse {
+    /// Get the match count as a number
+    pub fn count(&self) -> usize {
+        self.count
+            .as_ref()
+            .and_then(|c| c.parse().ok())
+            .unwrap_or(0)
+    }
+}
+
+/// HTTP client for the HORIZONS API
+pub struct HorizonsClient {
+    client: reqwest::blocking::Client,
+}
+
+impl HorizonsClient {
+    /// Create a new HORIZONS API client
+    pub fn new() -> Result<Self> {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(60))
+            .build()
+            .map_err(|e| {
+                StarfieldError::DataError(format!("Failed to create HTTP client: {}", e))
+            })?;
+        Ok(Self { client })
+    }
+
+    /// Execute an ephemeris query and return the raw response
+    pub fn query(&self, request: &EphemerisRequest) -> Result<HorizonsResponse> {
+        let params = request.to_query_params();
+        let response = self
+            .client
+            .get(HORIZONS_API_URL)
+            .query(&params)
+            .send()
+            .map_err(|e| StarfieldError::DataError(format!("HORIZONS request failed: {}", e)))?;
+
+        if !response.status().is_success() {
+            return Err(StarfieldError::DataError(format!(
+                "HORIZONS API returned HTTP {}",
+                response.status()
+            )));
+        }
+
+        let body: HorizonsResponse = response.json().map_err(|e| {
+            StarfieldError::DataError(format!("Failed to parse HORIZONS response: {}", e))
+        })?;
+
+        // Check for HORIZONS-level errors in the result text
+        if let Some(ref result) = body.result {
+            if result.contains("Cannot interpret target body")
+                || result.contains("No ephemeris for target")
+                || result.contains("Ambiguous target name")
+                || result.contains("No matches found")
+            {
+                return Err(StarfieldError::DataError(format!(
+                    "HORIZONS error: {}",
+                    extract_error_message(result)
+                )));
+            }
+        }
+
+        Ok(body)
+    }
+
+    /// Look up an object by name, designation, or SPK-ID
+    pub fn lookup(&self, sstr: &str, group: Option<ObjectGroup>) -> Result<LookupResponse> {
+        let mut params: HashMap<&str, String> = HashMap::new();
+        params.insert("sstr", sstr.to_string());
+        params.insert("format", "json".to_string());
+        if let Some(g) = group {
+            params.insert("group", g.as_str().to_string());
+        }
+
+        let response = self
+            .client
+            .get(HORIZONS_LOOKUP_URL)
+            .query(&params)
+            .send()
+            .map_err(|e| StarfieldError::DataError(format!("HORIZONS lookup failed: {}", e)))?;
+
+        if !response.status().is_success() {
+            return Err(StarfieldError::DataError(format!(
+                "HORIZONS lookup API returned HTTP {}",
+                response.status()
+            )));
+        }
+
+        let body: LookupResponse = response.json().map_err(|e| {
+            StarfieldError::DataError(format!("Failed to parse lookup response: {}", e))
+        })?;
+
+        Ok(body)
+    }
+}
+
+/// Extract a concise error message from HORIZONS result text
+fn extract_error_message(result: &str) -> String {
+    // HORIZONS embeds errors in the full text output.
+    // Try to find the most relevant line.
+    for line in result.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("Cannot interpret")
+            || trimmed.starts_with("No ephemeris")
+            || trimmed.starts_with("Ambiguous target")
+            || trimmed.starts_with("No matches")
+            || trimmed.starts_with("No site matches")
+        {
+            return trimmed.to_string();
+        }
+    }
+    // Fallback: first 200 chars
+    result.chars().take(200).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_command_major_body() {
+        assert_eq!(Command::MajorBody(499).to_query_value(), "499");
+        assert_eq!(Command::MajorBody(10).to_query_value(), "10");
+        assert_eq!(Command::MajorBody(0).to_query_value(), "0");
+        assert_eq!(Command::MajorBody(-170).to_query_value(), "-170");
+    }
+
+    #[test]
+    fn test_command_asteroid() {
+        assert_eq!(Command::Asteroid(433).to_query_value(), "433;");
+        assert_eq!(Command::Asteroid(1).to_query_value(), "1;");
+    }
+
+    #[test]
+    fn test_command_comet() {
+        assert_eq!(Command::Comet("73P".to_string()).to_query_value(), "73P;");
+    }
+
+    #[test]
+    fn test_command_designation() {
+        assert_eq!(
+            Command::Designation("1999 AN10".to_string()).to_query_value(),
+            "DES=1999 AN10;"
+        );
+    }
+
+    #[test]
+    fn test_command_name() {
+        assert_eq!(
+            Command::Name("Apophis".to_string()).to_query_value(),
+            "Apophis;"
+        );
+    }
+
+    #[test]
+    fn test_center_values() {
+        assert_eq!(Center::Geocentric.to_query_value(), "500@399");
+        assert_eq!(Center::SolarSystemBarycenter.to_query_value(), "500@0");
+        assert_eq!(Center::BodyCenter(10).to_query_value(), "500@10");
+        assert_eq!(
+            Center::Site("675@399".to_string()).to_query_value(),
+            "675@399"
+        );
+    }
+
+    #[test]
+    fn test_vectors_request_params() {
+        let req = EphemerisRequest::vectors(
+            Command::MajorBody(499),
+            Center::SolarSystemBarycenter,
+            TimeSpec::Range {
+                start: "2024-01-01".into(),
+                stop: "2024-01-02".into(),
+                step: "1 d".into(),
+            },
+        );
+        let params = req.to_query_params();
+        let map: HashMap<String, String> = params.into_iter().collect();
+
+        assert_eq!(map.get("COMMAND").unwrap(), "'499'");
+        assert_eq!(map.get("EPHEM_TYPE").unwrap(), "VECTORS");
+        assert_eq!(map.get("CENTER").unwrap(), "'500@0'");
+        assert_eq!(map.get("START_TIME").unwrap(), "'2024-01-01'");
+        assert_eq!(map.get("STOP_TIME").unwrap(), "'2024-01-02'");
+        assert_eq!(map.get("STEP_SIZE").unwrap(), "'1 d'");
+        assert_eq!(map.get("CSV_FORMAT").unwrap(), "YES");
+        assert_eq!(map.get("OUT_UNITS").unwrap(), "'AU-D'");
+    }
+
+    #[test]
+    fn test_observer_request_params() {
+        let req = EphemerisRequest::observer(
+            Command::MajorBody(499),
+            Center::Geocentric,
+            TimeSpec::Range {
+                start: "2024-01-01".into(),
+                stop: "2024-01-02".into(),
+                step: "1 d".into(),
+            },
+        );
+        let params = req.to_query_params();
+        let map: HashMap<String, String> = params.into_iter().collect();
+
+        assert_eq!(map.get("EPHEM_TYPE").unwrap(), "OBSERVER");
+        assert_eq!(map.get("CENTER").unwrap(), "'500@399'");
+        assert_eq!(map.get("QUANTITIES").unwrap(), "'1,9,20,23'");
+        assert_eq!(map.get("ANG_FORMAT").unwrap(), "'DEG'");
+        assert_eq!(map.get("EXTRA_PREC").unwrap(), "YES");
+    }
+
+    #[test]
+    fn test_elements_request_params() {
+        let req = EphemerisRequest::elements(
+            Command::Asteroid(433),
+            Center::BodyCenter(10),
+            TimeSpec::Range {
+                start: "2024-01-01".into(),
+                stop: "2024-02-01".into(),
+                step: "1 d".into(),
+            },
+        );
+        let params = req.to_query_params();
+        let map: HashMap<String, String> = params.into_iter().collect();
+
+        assert_eq!(map.get("COMMAND").unwrap(), "'433;'");
+        assert_eq!(map.get("EPHEM_TYPE").unwrap(), "ELEMENTS");
+        assert_eq!(map.get("REF_PLANE").unwrap(), "'ECLIPTIC'");
+    }
+
+    #[test]
+    fn test_tlist_params() {
+        let req = EphemerisRequest::vectors(
+            Command::MajorBody(499),
+            Center::SolarSystemBarycenter,
+            TimeSpec::JulianDayList(vec![2451545.0, 2451546.0]),
+        );
+        let params = req.to_query_params();
+        let map: HashMap<String, String> = params.into_iter().collect();
+
+        assert_eq!(map.get("TLIST").unwrap(), "2451545,2451546");
+        assert!(map.get("START_TIME").is_none());
+    }
+
+    #[test]
+    fn test_error_extraction() {
+        let result = "Some header\n  Cannot interpret target body\nMore text";
+        assert_eq!(
+            extract_error_message(result),
+            "Cannot interpret target body"
+        );
+    }
+
+    #[test]
+    fn test_lookup_response_count() {
+        let resp = LookupResponse {
+            signature: None,
+            count: Some("5".to_string()),
+            result: None,
+        };
+        assert_eq!(resp.count(), 5);
+
+        let resp_none = LookupResponse {
+            signature: None,
+            count: None,
+            result: None,
+        };
+        assert_eq!(resp_none.count(), 0);
+    }
+
+    #[test]
+    #[ignore]
+    fn test_horizons_api_reachable() {
+        let client = reqwest::blocking::Client::new();
+        let resp = client
+            .head(HORIZONS_API_URL)
+            .send()
+            .expect("HORIZONS API unreachable");
+        assert!(resp.status().is_success() || resp.status().as_u16() == 405);
+    }
+
+    #[test]
+    #[ignore]
+    fn test_lookup_api_reachable() {
+        let client = reqwest::blocking::Client::new();
+        let resp = client
+            .head(HORIZONS_LOOKUP_URL)
+            .send()
+            .expect("HORIZONS lookup API unreachable");
+        assert!(resp.status().is_success() || resp.status().as_u16() == 405);
+    }
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -5,6 +5,7 @@
 
 mod downloader;
 mod gaia_downloader;
+pub mod horizons;
 
 pub use downloader::{
     download_hipparcos, download_or_cache, ensure_cache_dir, get_cache_dir, resolve_url,

--- a/src/horizons/mod.rs
+++ b/src/horizons/mod.rs
@@ -1,0 +1,46 @@
+//! HORIZONS API client for NASA JPL's solar system ephemeris service.
+//!
+//! This module provides access to the [HORIZONS](https://ssd.jpl.nasa.gov/horizons/)
+//! on-line solar system data and ephemeris computation service. It can compute
+//! positions, velocities, and observational quantities for over 1.5 million
+//! solar system objects including planets, moons, asteroids, comets, and spacecraft.
+//!
+//! No API key or authentication is required.
+//!
+//! # Quick Start
+//!
+//! ```no_run
+//! use starfield::horizons::{HorizonsClient, EphemerisRequest, Command, Center, TimeSpec};
+//! use starfield::horizons::parser;
+//!
+//! let client = HorizonsClient::new().unwrap();
+//!
+//! // Get Mars state vectors relative to the Solar System Barycenter
+//! let request = EphemerisRequest::vectors(
+//!     Command::MajorBody(499),
+//!     Center::SolarSystemBarycenter,
+//!     TimeSpec::Range {
+//!         start: "2024-01-01".into(),
+//!         stop: "2024-01-02".into(),
+//!         step: "1 d".into(),
+//!     },
+//! );
+//!
+//! let response = client.query(&request).unwrap();
+//! let block = parser::extract_ephemeris_block(response.result.as_ref().unwrap()).unwrap();
+//! let rows = parser::parse_vector_rows(block).unwrap();
+//!
+//! for row in &rows {
+//!     println!("JD {}: ({}, {}, {}) AU", row.jd_tdb, row.x, row.y, row.z);
+//! }
+//! ```
+
+pub mod parser;
+
+pub use crate::data::horizons::{
+    Center, Command, EphemType, EphemerisRequest, HorizonsClient, HorizonsResponse, LookupMatch,
+    LookupResponse, ObjectGroup, OutputUnits, ReferencePlane, Signature, TimeSpec, VecCorrection,
+    VecTable,
+};
+
+pub use parser::{ElementsRow, ObserverRow, VectorRow};

--- a/src/horizons/parser.rs
+++ b/src/horizons/parser.rs
@@ -1,0 +1,401 @@
+//! Parser for HORIZONS text output.
+//!
+//! HORIZONS returns ephemeris data as formatted text with the actual data
+//! delimited by `$$SOE` (Start of Ephemeris) and `$$EOE` (End of Ephemeris)
+//! markers. This module extracts and parses the data between those markers.
+
+use crate::{Result, StarfieldError};
+
+/// A single row of Cartesian state vector data from HORIZONS
+#[derive(Debug, Clone)]
+pub struct VectorRow {
+    /// Julian Date (TDB)
+    pub jd_tdb: f64,
+    /// Calendar date string (e.g., "A.D. 2024-Jan-01 00:00:00.0000")
+    pub calendar_date: String,
+    /// X position
+    pub x: f64,
+    /// Y position
+    pub y: f64,
+    /// Z position
+    pub z: f64,
+    /// X velocity
+    pub vx: f64,
+    /// Y velocity
+    pub vy: f64,
+    /// Z velocity
+    pub vz: f64,
+    /// One-way light time (seconds)
+    pub light_time: Option<f64>,
+    /// Range from coordinate center
+    pub range: Option<f64>,
+    /// Range rate (radial velocity)
+    pub range_rate: Option<f64>,
+}
+
+/// A single row of observer-table data from HORIZONS
+#[derive(Debug, Clone)]
+pub struct ObserverRow {
+    /// Julian Date (TDB or UT depending on request)
+    pub jd: f64,
+    /// Calendar date string
+    pub calendar_date: String,
+    /// All parsed fields as key-value pairs.
+    /// Keys depend on the QUANTITIES requested.
+    pub fields: Vec<(String, String)>,
+}
+
+/// A single row of osculating orbital elements from HORIZONS
+#[derive(Debug, Clone)]
+pub struct ElementsRow {
+    /// Julian Date (TDB)
+    pub jd_tdb: f64,
+    /// Calendar date string
+    pub calendar_date: String,
+    /// Eccentricity
+    pub eccentricity: f64,
+    /// Periapsis distance (AU or km depending on OUT_UNITS)
+    pub periapsis_dist: f64,
+    /// Inclination (degrees)
+    pub inclination: f64,
+    /// Longitude of ascending node (degrees)
+    pub long_asc_node: f64,
+    /// Argument of perihelion (degrees)
+    pub arg_perihelion: f64,
+    /// Time of periapsis passage (Julian Date TDB)
+    pub time_periapsis: f64,
+    /// Mean motion (degrees per time unit)
+    pub mean_motion: f64,
+    /// Mean anomaly (degrees)
+    pub mean_anomaly: f64,
+    /// True anomaly (degrees)
+    pub true_anomaly: f64,
+    /// Semi-major axis (AU or km)
+    pub semi_major_axis: Option<f64>,
+    /// Apoapsis distance (AU or km)
+    pub apoapsis_dist: Option<f64>,
+    /// Orbital period (time units)
+    pub period: Option<f64>,
+}
+
+/// Extract the ephemeris data block between $$SOE and $$EOE markers
+pub fn extract_ephemeris_block(result: &str) -> Result<&str> {
+    let soe = result.find("$$SOE").ok_or_else(|| {
+        StarfieldError::DataError("HORIZONS response missing $$SOE marker".to_string())
+    })?;
+    let eoe = result.find("$$EOE").ok_or_else(|| {
+        StarfieldError::DataError("HORIZONS response missing $$EOE marker".to_string())
+    })?;
+
+    if eoe <= soe {
+        return Err(StarfieldError::DataError(
+            "$$EOE appears before $$SOE in HORIZONS response".to_string(),
+        ));
+    }
+
+    // Skip past the $$SOE line
+    let start = soe + "$$SOE".len();
+    Ok(result[start..eoe].trim())
+}
+
+/// Parse CSV-format vector rows from a HORIZONS ephemeris block.
+///
+/// Expects CSV output from a VECTORS request with VEC_TABLE='3' (state + extras).
+/// Each record spans multiple CSV lines in the HORIZONS output.
+/// With CSV_FORMAT=YES, each row is: JDTDB, Calendar Date, X, Y, Z, VX, VY, VZ, LT, RG, RR,
+pub fn parse_vector_rows(block: &str) -> Result<Vec<VectorRow>> {
+    let mut rows = Vec::new();
+
+    // In CSV mode with VEC_TABLE=3, each record is a single CSV line:
+    // JDTDB, CalendarDate(TDB), X, Y, Z, VX, VY, VZ, LT, RG, RR,
+    for line in block.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let fields: Vec<&str> = line.split(',').map(|f| f.trim()).collect();
+
+        // We need at least JDTDB + calendar date + X/Y/Z + VX/VY/VZ = 8 fields
+        if fields.len() < 8 {
+            continue;
+        }
+
+        let jd_tdb = parse_f64(fields[0], "JDTDB")?;
+        let calendar_date = fields[1].trim().to_string();
+        let x = parse_f64(fields[2], "X")?;
+        let y = parse_f64(fields[3], "Y")?;
+        let z = parse_f64(fields[4], "Z")?;
+        let vx = parse_f64(fields[5], "VX")?;
+        let vy = parse_f64(fields[6], "VY")?;
+        let vz = parse_f64(fields[7], "VZ")?;
+
+        let light_time = fields.get(8).and_then(|f| f.trim().parse().ok());
+        let range = fields.get(9).and_then(|f| f.trim().parse().ok());
+        let range_rate = fields.get(10).and_then(|f| f.trim().parse().ok());
+
+        rows.push(VectorRow {
+            jd_tdb,
+            calendar_date,
+            x,
+            y,
+            z,
+            vx,
+            vy,
+            vz,
+            light_time,
+            range,
+            range_rate,
+        });
+    }
+
+    if rows.is_empty() {
+        return Err(StarfieldError::DataError(
+            "No vector rows parsed from HORIZONS output".to_string(),
+        ));
+    }
+
+    Ok(rows)
+}
+
+/// Parse CSV-format elements rows from a HORIZONS ephemeris block.
+///
+/// Expects CSV output from an ELEMENTS request.
+/// Fields: JDTDB, Calendar Date, EC, QR, IN, OM, W, Tp, N, MA, TA, A, AD, PR,
+pub fn parse_elements_rows(block: &str) -> Result<Vec<ElementsRow>> {
+    let mut rows = Vec::new();
+
+    for line in block.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let fields: Vec<&str> = line.split(',').map(|f| f.trim()).collect();
+
+        // JDTDB, Cal, EC, QR, IN, OM, W, Tp, N, MA, TA = 11 required fields
+        if fields.len() < 11 {
+            continue;
+        }
+
+        let jd_tdb = parse_f64(fields[0], "JDTDB")?;
+        let calendar_date = fields[1].trim().to_string();
+        let eccentricity = parse_f64(fields[2], "EC")?;
+        let periapsis_dist = parse_f64(fields[3], "QR")?;
+        let inclination = parse_f64(fields[4], "IN")?;
+        let long_asc_node = parse_f64(fields[5], "OM")?;
+        let arg_perihelion = parse_f64(fields[6], "W")?;
+        let time_periapsis = parse_f64(fields[7], "Tp")?;
+        let mean_motion = parse_f64(fields[8], "N")?;
+        let mean_anomaly = parse_f64(fields[9], "MA")?;
+        let true_anomaly = parse_f64(fields[10], "TA")?;
+
+        let semi_major_axis = fields.get(11).and_then(|f| f.trim().parse().ok());
+        let apoapsis_dist = fields.get(12).and_then(|f| f.trim().parse().ok());
+        let period = fields.get(13).and_then(|f| f.trim().parse().ok());
+
+        rows.push(ElementsRow {
+            jd_tdb,
+            calendar_date,
+            eccentricity,
+            periapsis_dist,
+            inclination,
+            long_asc_node,
+            arg_perihelion,
+            time_periapsis,
+            mean_motion,
+            mean_anomaly,
+            true_anomaly,
+            semi_major_axis,
+            apoapsis_dist,
+            period,
+        });
+    }
+
+    if rows.is_empty() {
+        return Err(StarfieldError::DataError(
+            "No elements rows parsed from HORIZONS output".to_string(),
+        ));
+    }
+
+    Ok(rows)
+}
+
+/// Parse CSV-format observer rows from a HORIZONS ephemeris block.
+///
+/// Observer output is highly variable depending on the QUANTITIES requested.
+/// This parser preserves all fields as string key-value pairs for maximum
+/// flexibility. The header line above $$SOE in the full HORIZONS result
+/// describes the columns.
+pub fn parse_observer_rows(block: &str, column_names: &[String]) -> Result<Vec<ObserverRow>> {
+    let mut rows = Vec::new();
+
+    for line in block.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let fields: Vec<&str> = line.split(',').map(|f| f.trim()).collect();
+
+        // Need at least JD + calendar date
+        if fields.len() < 2 {
+            continue;
+        }
+
+        let jd = match fields[0].trim().parse::<f64>() {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let calendar_date = fields[1].trim().to_string();
+
+        let mut named_fields = Vec::new();
+        for (i, value) in fields.iter().enumerate().skip(2) {
+            let name = column_names
+                .get(i)
+                .cloned()
+                .unwrap_or_else(|| format!("col_{}", i));
+            named_fields.push((name, value.trim().to_string()));
+        }
+
+        rows.push(ObserverRow {
+            jd,
+            calendar_date,
+            fields: named_fields,
+        });
+    }
+
+    if rows.is_empty() {
+        return Err(StarfieldError::DataError(
+            "No observer rows parsed from HORIZONS output".to_string(),
+        ));
+    }
+
+    Ok(rows)
+}
+
+/// Extract column header names from the HORIZONS result text.
+///
+/// The header line appears just before $$SOE and contains comma-separated
+/// column names when CSV_FORMAT=YES.
+pub fn extract_column_names(result: &str) -> Vec<String> {
+    // Find the line just before $$SOE that contains column headers
+    // In CSV mode, this is typically 2 lines above $$SOE
+    if let Some(soe_pos) = result.find("$$SOE") {
+        let before_soe = &result[..soe_pos];
+        // Walk backwards through non-empty lines
+        for line in before_soe.lines().rev() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('*') {
+                continue;
+            }
+            // If this line contains commas, treat it as the header
+            if trimmed.contains(',') {
+                return trimmed.split(',').map(|s| s.trim().to_string()).collect();
+            }
+            break;
+        }
+    }
+    Vec::new()
+}
+
+/// Parse a float field, returning a descriptive error on failure
+fn parse_f64(s: &str, field_name: &str) -> Result<f64> {
+    s.trim().parse::<f64>().map_err(|_| {
+        StarfieldError::DataError(format!(
+            "Failed to parse HORIZONS field '{}': '{}'",
+            field_name,
+            s.trim()
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_VECTOR_RESULT: &str = r#"
+Some header text
+*******************************************************************************
+$$SOE
+ 2460310.500000000, A.D. 2024-Jan-01 00:00:00.0000,  1.326568771901361E+00,  5.455289002498498E-01, -3.687818081498823E-02,
+ -4.614386613412735E-03,  1.215675362101498E-02,  3.666153662394858E-04,  8.779022975988899E+02,  1.437395883016715E+00, -7.233449301483814E-03,
+ 2460311.500000000, A.D. 2024-Jan-02 00:00:00.0000,  1.321949252701283E+00,  5.576645505098201E-01, -3.650923764498134E-02,
+ -4.717340113418924E-03,  1.210584432101125E-02,  3.659843772394121E-04,  8.800843285988132E+02,  1.439962814016513E+00, -7.128930451483291E-03,
+$$EOE
+*******************************************************************************
+"#;
+
+    #[test]
+    fn test_extract_ephemeris_block() {
+        let block = extract_ephemeris_block(SAMPLE_VECTOR_RESULT).unwrap();
+        assert!(block.contains("2460310.500000000"));
+        assert!(block.contains("2460311.500000000"));
+        assert!(!block.contains("$$SOE"));
+        assert!(!block.contains("$$EOE"));
+    }
+
+    #[test]
+    fn test_extract_block_missing_soe() {
+        let result = "no markers here";
+        assert!(extract_ephemeris_block(result).is_err());
+    }
+
+    #[test]
+    fn test_parse_vector_rows() {
+        // HORIZONS CSV vector output: each record is on one long line
+        let csv_block = concat!(
+            " 2460310.500000000, A.D. 2024-Jan-01 00:00:00.0000,",
+            "  1.326568771901361E+00,  5.455289002498498E-01, -3.687818081498823E-02,",
+            " -4.614386613412735E-03,  1.215675362101498E-02,  3.666153662394858E-04,",
+            "  8.779022975988899E+02,  1.437395883016715E+00, -7.233449301483814E-03,\n",
+            " 2460311.500000000, A.D. 2024-Jan-02 00:00:00.0000,",
+            "  1.321949252701283E+00,  5.576645505098201E-01, -3.650923764498134E-02,",
+            " -4.717340113418924E-03,  1.210584432101125E-02,  3.659843772394121E-04,",
+            "  8.800843285988132E+02,  1.439962814016513E+00, -7.128930451483291E-03,",
+        );
+
+        let rows = parse_vector_rows(csv_block).unwrap();
+        assert_eq!(rows.len(), 2);
+
+        let r = &rows[0];
+        assert!((r.jd_tdb - 2460310.5).abs() < 1e-6);
+        assert!(r.calendar_date.contains("2024-Jan-01"));
+        assert!((r.x - 1.326568771901361).abs() < 1e-10);
+        assert!((r.vx - (-4.614386613412735e-3)).abs() < 1e-15);
+        assert!(r.light_time.is_some());
+        assert!(r.range.is_some());
+        assert!(r.range_rate.is_some());
+    }
+
+    #[test]
+    fn test_parse_elements_rows() {
+        let csv_block = " 2460310.500000000, A.D. 2024-Jan-01 00:00:00.0000,  9.339510776498570E-02,  1.381216248476880E+00,  1.848158649553816E+00,  4.951408556629253E+01,  2.867137790700476E+02,  2459928.15625,  5.240760835577432E-01,  2.001564523577853E+02,  1.965743625481955E+02,  1.523662486197090E+00,  1.665908723917300E+00,  6.870988429561428E+02,\n";
+
+        let rows = parse_elements_rows(csv_block).unwrap();
+        assert_eq!(rows.len(), 1);
+
+        let r = &rows[0];
+        assert!((r.jd_tdb - 2460310.5).abs() < 1e-6);
+        assert!((r.eccentricity - 9.339510776498570e-2).abs() < 1e-10);
+        assert!((r.inclination - 1.848158649553816).abs() < 1e-10);
+        assert!(r.semi_major_axis.is_some());
+        assert!((r.semi_major_axis.unwrap() - 1.523662486197090).abs() < 1e-10);
+        assert!(r.period.is_some());
+    }
+
+    #[test]
+    fn test_extract_column_names() {
+        let result =
+            "Header\n  Date__(UT)__HR:MN, , R.A._____(ICRF)___DEC, Unk,\n$$SOE\ndata\n$$EOE\n";
+        let names = extract_column_names(result);
+        assert!(names.len() >= 2);
+        assert!(names[0].contains("Date"));
+    }
+
+    #[test]
+    fn test_parse_f64() {
+        assert!((parse_f64("  1.5E+02  ", "test").unwrap() - 150.0).abs() < 1e-10);
+        assert!(parse_f64("not_a_number", "test").is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod eclipselib;
 pub mod elementslib;
 pub mod errors;
 pub mod framelib;
+pub mod horizons;
 pub mod image;
 pub mod jplephem;
 pub mod keplerlib;
@@ -197,6 +198,34 @@ impl Loader {
     /// Load a timescale for time conversions
     pub fn timescale(&self) -> time::Timescale {
         time::Timescale::default()
+    }
+
+    /// Create a HORIZONS API client for querying JPL ephemeris data.
+    ///
+    /// HORIZONS computes positions, velocities, and observational quantities
+    /// for over 1.5 million solar system objects.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use starfield::horizons::{EphemerisRequest, Command, Center, TimeSpec};
+    ///
+    /// let loader = starfield::Loader::new();
+    /// let client = loader.horizons_client().unwrap();
+    ///
+    /// let request = EphemerisRequest::vectors(
+    ///     Command::MajorBody(499),
+    ///     Center::SolarSystemBarycenter,
+    ///     TimeSpec::Range {
+    ///         start: "2024-01-01".into(),
+    ///         stop: "2024-01-02".into(),
+    ///         step: "1 d".into(),
+    ///     },
+    /// );
+    /// let response = client.query(&request).unwrap();
+    /// ```
+    pub fn horizons_client(&self) -> Result<horizons::HorizonsClient> {
+        horizons::HorizonsClient::new()
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds a type-safe Rust client for NASA JPL's HORIZONS ephemeris computation service
- Supports VECTORS, OBSERVER, and ELEMENTS ephemeris types via `EphemerisRequest` builder
- Includes object lookup API for searching by name, designation, or SPK-ID
- Parses `$$SOE`/`$$EOE` text blocks into typed `VectorRow`, `ObserverRow`, `ElementsRow` structs
- Integrates with `Loader::horizons_client()` for consistent API access

## New files

- `src/data/horizons.rs` — HTTP client, request builder, response types
- `src/horizons/mod.rs` — Public module with re-exports and docs
- `src/horizons/parser.rs` — Ephemeris text block parser
- `examples/horizons_vectors.rs` — Mars state vector query example
- `examples/horizons_lookup.rs` — Object lookup example

## Test plan

- [x] Unit tests for command encoding, request parameter construction, response parsing
- [x] Parser tests with hardcoded HORIZONS output fixtures
- [x] `cargo fmt` and `cargo clippy` clean
- [x] All 347 existing tests pass
- [ ] Integration tests (marked `#[ignore]`) verify live API connectivity