### PR TITLE
Reintegrate jplephem as internal module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,40 +1,10 @@
 # Changelog
 
+## 0.10.2
+
+- Reintegrate jplephem as an internal module (removes external crate dependency)
+
 ## 0.10.0
-
-### Breaking: jplephem extracted to standalone crate
-
-The internal `src/jplephem/` module has been replaced by a dependency on
-`starfield-jplephem` from the `starfield-datasources` workspace.
-
-**For most users, nothing changes** -- `starfield::jplephem::SpiceKernel` and all
-other paths still work via re-export.
-
-**If you used `starfield::planetlib::PlanetState`**: It is now re-exported from
-`starfield_jplephem::PlanetState`. The struct layout is identical.
-
-**If you called `.compute_at()`, `.compute_km()`, or `.at()` on SpiceKernel**:
-These methods now come from an extension trait. Add:
-```rust
-use starfield::jplephem_ext::SpiceKernelExt;
-```
-
-### Modernizing to use datasource crates directly
-
-For new projects, consider depending on the individual datasource crates
-from the `starfield-datasources` workspace instead of going through `starfield`:
-
-| Crate | Replaces |
-|---|---|
-| `starfield-jplephem` | `starfield::jplephem` |
-| `starfield-horizons` | `starfield::horizons` |
-| `starfield-sbdb` | `starfield::sbdb` |
-| `starfield-gaia` | `starfield::catalogs::gaia` + `starfield::data::gaia_downloader` |
-| `starfield-hipparcos` | `starfield::catalogs::hipparcos` + `starfield::data::downloader` |
-
-Or use the facade: `starfield-datasources` (feature flags for each source).
-
-Repo: https://github.com/OrbitalCommons/starfield-datasources
 
 ## 0.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.10.2
+## 0.11.0
 
 - Reintegrate jplephem as an internal module (removes external crate dependency)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starfield"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 authors = ["Matthew Goodman"]
 description = "Astronomical data reduction toolkit with star catalogs, coordinate systems, and star finding algorithms (inspired by skyfield)"
@@ -60,7 +60,7 @@ clap = { version = "4.5.40", features = ["derive"] }
 memmap2 = "0.9"
 uom = "0.37.0"
 sgp4 = "2.3.0"
-starfield-jplephem = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", version = "0.1.0" }
+
 
 [dev-dependencies]
 criterion = "0.5" # Benchmarking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starfield"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 authors = ["Matthew Goodman"]
 description = "Astronomical data reduction toolkit with star catalogs, coordinate systems, and star finding algorithms (inspired by skyfield)"

--- a/src/jplephem/calendar.rs
+++ b/src/jplephem/calendar.rs
@@ -1,0 +1,88 @@
+//! Calendar date and Julian date conversion functions
+
+/// Convert Julian day integer to calendar date (year, month, day)
+///
+/// Uses the proleptic Gregorian calendar unless `julian_before` is set to a
+/// specific Julian day, in which case the Julian calendar is used for dates
+/// older than that.
+pub fn compute_calendar_date(jd_integer: i32, julian_before: Option<i32>) -> (i32, i32, i32) {
+    let use_gregorian = match julian_before {
+        None => true,
+        Some(jb) => jd_integer >= jb,
+    };
+
+    // See the Explanatory Supplement to the Astronomical Almanac 15.11.
+    let f = jd_integer + 1401;
+    let f = if use_gregorian {
+        f + ((4 * jd_integer + 274277) / 146097 * 3 / 4 - 38)
+    } else {
+        f
+    };
+
+    let e = 4 * f + 3;
+    let g = (e % 1461) / 4;
+    let h = 5 * g + 2;
+    let day = (h % 153) / 5 + 1;
+    let month = (h / 153 + 2) % 12 + 1;
+    let year = e / 1461 - 4716 + (12 + 2 - month) / 12;
+
+    (year, month, day)
+}
+
+/// Convert (year, month, day) to Julian date float
+pub fn compute_julian_date(year: i32, month: i32, day: f64) -> f64 {
+    let day_int = day.floor() as i32;
+    let jd_noon = compute_julian_day(year, month, day_int);
+    (jd_noon as f64 - 0.5) + day.fract()
+}
+
+/// Convert (year, month, day) to Julian day integer (proleptic Gregorian)
+pub fn compute_julian_day(year: i32, month: i32, day: i32) -> i32 {
+    let janfeb = month < 3;
+    1461 * (year + 4800 - if janfeb { 1 } else { 0 }) / 4
+        + 367 * (month - 2 + if janfeb { 12 } else { 0 }) / 12
+        - 3 * ((year + 4900 - if janfeb { 1 } else { 0 }) / 100) / 4
+        - 32075
+        + day
+}
+
+/// Format a Julian date as YYYY-MM-DD
+pub fn format_date(jd: f64) -> String {
+    let (year, month, day) = calendar_date_from_float(jd);
+    format!("{:04}-{:02}-{:02}", year, month, day)
+}
+
+/// Convert a floating-point Julian date to a calendar date
+pub fn calendar_date_from_float(jd: f64) -> (i32, i32, i32) {
+    let i = (jd + 0.5) as i32;
+    compute_calendar_date(i, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_julian_day_conversion() {
+        assert_eq!(compute_julian_day(2000, 1, 1), 2451545);
+        assert_eq!(compute_julian_day(2020, 1, 1), 2458850);
+        assert_eq!(compute_julian_day(1969, 7, 20), 2440423);
+        assert_eq!(compute_julian_day(1900, 1, 1), 2415021);
+    }
+
+    #[test]
+    fn test_calendar_date_conversion() {
+        assert_eq!(compute_calendar_date(2451545, None), (2000, 1, 1));
+        assert_eq!(compute_calendar_date(2458850, None), (2020, 1, 1));
+        assert_eq!(compute_calendar_date(2440423, None), (1969, 7, 20));
+        assert_eq!(compute_calendar_date(2415021, None), (1900, 1, 1));
+    }
+
+    #[test]
+    fn test_julian_date_conversion() {
+        assert_eq!(compute_julian_date(2000, 1, 1.0), 2451544.5);
+        assert_eq!(compute_julian_date(2020, 1, 1.5), 2458850.0);
+        assert_eq!(compute_julian_date(1969, 7, 20.0), 2440422.5);
+        assert_eq!(compute_julian_date(1900, 1, 1.0), 2415020.5);
+    }
+}

--- a/src/jplephem/chebyshev.rs
+++ b/src/jplephem/chebyshev.rs
@@ -1,0 +1,205 @@
+//! Chebyshev polynomial functionality for ephemeris interpolation
+//!
+//! Chebyshev polynomials are used in JPL ephemerides for interpolating
+//! positions and velocities of celestial bodies from ephemeris data.
+
+use super::errors::{JplephemError, Result};
+
+/// Chebyshev polynomial representation and evaluation
+///
+/// Stores the coefficients of a Chebyshev polynomial expansion
+/// and provides methods to evaluate the polynomial and its derivatives.
+#[derive(Debug, Clone)]
+pub struct ChebyshevPolynomial {
+    coefficients: Vec<f64>,
+}
+
+impl ChebyshevPolynomial {
+    /// Create a new Chebyshev polynomial with the given coefficients
+    ///
+    /// Coefficients are ordered from lowest to highest degree:
+    /// `[c0, c1, c2, ..., cn]` where the polynomial is:
+    /// `f(x) = c0*T0(x) + c1*T1(x) + c2*T2(x) + ... + cn*Tn(x)`
+    pub fn new(coefficients: Vec<f64>) -> Self {
+        Self { coefficients }
+    }
+
+    /// Evaluate the Chebyshev polynomial at point x in [-1, 1]
+    ///
+    /// Uses Clenshaw's recurrence for numerical stability.
+    pub fn evaluate(&self, x: f64) -> f64 {
+        if self.coefficients.is_empty() {
+            return 0.0;
+        }
+        let n = self.coefficients.len();
+        if n == 1 {
+            return self.coefficients[0];
+        }
+
+        // Clenshaw recurrence: more stable than direct evaluation
+        let mut b_k_plus_1 = 0.0;
+        let mut b_k_plus_2 = 0.0;
+        for i in (1..n).rev() {
+            let b_k = 2.0 * x * b_k_plus_1 - b_k_plus_2 + self.coefficients[i];
+            b_k_plus_2 = b_k_plus_1;
+            b_k_plus_1 = b_k;
+        }
+        self.coefficients[0] + x * b_k_plus_1 - b_k_plus_2
+    }
+
+    /// Calculate the derivative of the Chebyshev polynomial at point x
+    ///
+    /// Uses the relation dT_n(x)/dx = n * U_{n-1}(x) where U is the
+    /// Chebyshev polynomial of the second kind.
+    pub fn derivative(&self, x: f64) -> f64 {
+        if self.coefficients.len() <= 1 {
+            return 0.0;
+        }
+
+        let mut result = 0.0;
+        for i in 1..self.coefficients.len() {
+            let n = i as f64;
+            result += self.coefficients[i] * n * Self::chebyshev_u(i - 1, x);
+        }
+        result
+    }
+
+    /// Compute U_n(x), the Chebyshev polynomial of the second kind
+    fn chebyshev_u(n: usize, x: f64) -> f64 {
+        match n {
+            0 => 1.0,
+            1 => 2.0 * x,
+            _ => {
+                let mut u_prev2 = 1.0;
+                let mut u_prev1 = 2.0 * x;
+                let mut u_n = 0.0;
+                for _ in 2..=n {
+                    u_n = 2.0 * x * u_prev1 - u_prev2;
+                    u_prev2 = u_prev1;
+                    u_prev1 = u_n;
+                }
+                u_n
+            }
+        }
+    }
+
+    /// Get the degree of the polynomial
+    pub fn degree(&self) -> usize {
+        self.coefficients.len().saturating_sub(1)
+    }
+
+    /// Get a reference to the coefficients
+    pub fn coefficients(&self) -> &[f64] {
+        &self.coefficients
+    }
+}
+
+/// Normalize a time value to [-1, 1] for Chebyshev evaluation
+///
+/// # Arguments
+/// * `time` - The time to normalize
+/// * `midpoint` - The midpoint of the time interval
+/// * `radius` - The half-length of the time interval
+pub fn normalize_time(time: f64, midpoint: f64, radius: f64) -> Result<f64> {
+    if radius <= 0.0 {
+        return Err(JplephemError::Other(
+            "Invalid radius for time normalization: must be positive".to_string(),
+        ));
+    }
+
+    let normalized = (time - midpoint) / radius;
+
+    if !(-1.0 - 1e-9..=1.0 + 1e-9).contains(&normalized) {
+        return Err(JplephemError::OutOfRangeError {
+            jd: time,
+            start_jd: midpoint - radius,
+            end_jd: midpoint + radius,
+        });
+    }
+
+    // Clamp to [-1, 1] to handle floating point edge cases
+    Ok(normalized.clamp(-1.0, 1.0))
+}
+
+/// Rescale a derivative from normalized time to physical time
+///
+/// When evaluating derivatives of Chebyshev polynomials, we get the derivative
+/// with respect to normalized time. This rescales to physical time units.
+pub fn rescale_derivative(deriv_normalized: f64, radius: f64) -> Result<f64> {
+    if radius <= 0.0 {
+        return Err(JplephemError::Other(
+            "Invalid radius for derivative rescaling: must be positive".to_string(),
+        ));
+    }
+    Ok(deriv_normalized / radius)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_chebyshev_constant() {
+        let poly = ChebyshevPolynomial::new(vec![5.0]);
+        assert_eq!(poly.evaluate(-1.0), 5.0);
+        assert_eq!(poly.evaluate(0.0), 5.0);
+        assert_eq!(poly.evaluate(1.0), 5.0);
+        assert_eq!(poly.derivative(0.0), 0.0);
+    }
+
+    #[test]
+    fn test_chebyshev_linear() {
+        // f(x) = 3 + 2x
+        let poly = ChebyshevPolynomial::new(vec![3.0, 2.0]);
+        assert!((poly.evaluate(-1.0) - 1.0).abs() < 1e-12);
+        assert!((poly.evaluate(0.0) - 3.0).abs() < 1e-12);
+        assert!((poly.evaluate(1.0) - 5.0).abs() < 1e-12);
+        assert!((poly.derivative(0.0) - 2.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_chebyshev_quadratic() {
+        // T2(x) = 2x² - 1, so f(x) = 3 + 2x + (2x² - 1) = 2 + 2x + 2x²
+        let poly = ChebyshevPolynomial::new(vec![3.0, 2.0, 1.0]);
+        assert!((poly.evaluate(-1.0) - 2.0).abs() < 1e-12);
+        assert!((poly.evaluate(0.0) - 2.0).abs() < 1e-12);
+        assert!((poly.evaluate(1.0) - 6.0).abs() < 1e-12);
+        // f'(x) = 2 + 4x
+        assert!((poly.derivative(-1.0) - (-2.0)).abs() < 1e-12);
+        assert!((poly.derivative(0.0) - 2.0).abs() < 1e-12);
+        assert!((poly.derivative(1.0) - 6.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_x_squared_approximation() {
+        // x^2 = (T2(x) + 1)/2, coefficients [0.5, 0, 0.5]
+        let poly = ChebyshevPolynomial::new(vec![0.5, 0.0, 0.5]);
+        for i in 0..=10 {
+            let x = -1.0 + i as f64 * 0.2;
+            let expected = x * x;
+            assert!(
+                (expected - poly.evaluate(x)).abs() < 1e-12,
+                "Bad approximation at x={x}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_time_normalization() {
+        let mid = 100.0;
+        let rad = 10.0;
+        assert_eq!(normalize_time(100.0, mid, rad).unwrap(), 0.0);
+        assert_eq!(normalize_time(90.0, mid, rad).unwrap(), -1.0);
+        assert_eq!(normalize_time(110.0, mid, rad).unwrap(), 1.0);
+        assert_eq!(normalize_time(95.0, mid, rad).unwrap(), -0.5);
+        assert!(normalize_time(79.0, mid, rad).is_err());
+        assert!(normalize_time(121.0, mid, rad).is_err());
+        assert!(normalize_time(100.0, mid, 0.0).is_err());
+    }
+
+    #[test]
+    fn test_derivative_rescaling() {
+        assert_eq!(rescale_derivative(5.0, 10.0).unwrap(), 0.5);
+        assert!(rescale_derivative(5.0, 0.0).is_err());
+    }
+}

--- a/src/jplephem/daf.rs
+++ b/src/jplephem/daf.rs
@@ -1,0 +1,428 @@
+//! Double Array File (DAF) format reader for SPICE files
+//!
+//! Handles reading NAIF's DAF binary format, used for SPK and PCK files.
+
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use byteorder::{BigEndian, ByteOrder, LittleEndian};
+use memmap2::{Mmap, MmapOptions};
+
+use super::errors::{io_err, JplephemError, Result};
+
+const RECORD_SIZE: usize = 1024;
+const DOUBLE_SIZE: usize = 8;
+
+/// DAF file endianness
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Endian {
+    Big,
+    Little,
+}
+
+/// Double Array File (DAF) reader
+pub struct DAF {
+    pub path: PathBuf,
+    file: Option<Mutex<File>>,
+    /// File ID word (e.g. "DAF/SPK", "DAF/PCK")
+    pub locidw: String,
+    /// Number of double-precision components per summary
+    pub nd: u32,
+    /// Number of integer components per summary
+    pub ni: u32,
+    /// Forward pointer to first summary record
+    pub fward: u32,
+    /// Backward pointer to last summary record
+    pub bward: u32,
+    /// First free address
+    pub free: u32,
+    /// Internal file name
+    pub ifname: String,
+    /// Byte order
+    pub endian: Endian,
+    /// Memory map for efficient access
+    map: Option<Mmap>,
+    /// In-memory byte buffer (used by `from_bytes`)
+    bytes: Option<Vec<u8>>,
+    /// Size of each summary entry in bytes
+    summary_step: usize,
+    /// Size of each summary entry in double-words
+    summary_length: usize,
+}
+
+impl DAF {
+    /// Open a DAF file at the given path
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path_buf = path.as_ref().to_path_buf();
+        let file = File::open(&path_buf).map_err(|e| io_err(&path_buf, e))?;
+
+        let mut daf = DAF {
+            path: path_buf,
+            file: Some(Mutex::new(file)),
+            locidw: String::new(),
+            nd: 0,
+            ni: 0,
+            fward: 0,
+            bward: 0,
+            free: 0,
+            ifname: String::new(),
+            endian: Endian::Little,
+            map: None,
+            bytes: None,
+            summary_step: 0,
+            summary_length: 0,
+        };
+
+        daf.read_header()?;
+        daf.setup_memory_map()?;
+
+        daf.summary_length = daf.nd as usize + (daf.ni as usize).div_ceil(2);
+        daf.summary_step = 8 * daf.summary_length;
+
+        Ok(daf)
+    }
+
+    /// Create a DAF from an in-memory byte buffer
+    ///
+    /// Parses the same binary format as a file, but from `&[u8]`.
+    /// Useful with `include_bytes!()` for compile-time embedded assets.
+    pub fn from_bytes(data: &[u8]) -> Result<Self> {
+        if data.len() < RECORD_SIZE {
+            return Err(JplephemError::InvalidFormat(
+                "Data too small for a DAF file".to_string(),
+            ));
+        }
+
+        let mut daf = DAF {
+            path: PathBuf::from("<memory>"),
+            file: None,
+            locidw: String::new(),
+            nd: 0,
+            ni: 0,
+            fward: 0,
+            bward: 0,
+            free: 0,
+            ifname: String::new(),
+            endian: Endian::Little,
+            map: None,
+            bytes: Some(data.to_vec()),
+            summary_step: 0,
+            summary_length: 0,
+        };
+
+        daf.read_header()?;
+
+        daf.summary_length = daf.nd as usize + (daf.ni as usize).div_ceil(2);
+        daf.summary_step = 8 * daf.summary_length;
+
+        Ok(daf)
+    }
+
+    fn read_header(&mut self) -> Result<()> {
+        let header = self.read_record(1)?;
+
+        let locidw = String::from_utf8_lossy(&header[0..8])
+            .trim_end()
+            .to_string();
+
+        // Determine endianness: ND and NI should be small values (1-10)
+        let nd_le = LittleEndian::read_u32(&header[8..12]);
+        let ni_le = LittleEndian::read_u32(&header[12..16]);
+        let nd_be = BigEndian::read_u32(&header[8..12]);
+        let ni_be = BigEndian::read_u32(&header[12..16]);
+
+        let endian = if nd_le > 0 && nd_le < 10 && ni_le > 0 && ni_le < 10 {
+            Endian::Little
+        } else if nd_be > 0 && nd_be < 10 && ni_be > 0 && ni_be < 10 {
+            Endian::Big
+        } else {
+            return Err(JplephemError::InvalidFormat(format!(
+                "Cannot determine endianness: LE({nd_le},{ni_le}) BE({nd_be},{ni_be})"
+            )));
+        };
+
+        // DAF header layout:
+        //   0..8    LOCIDW (8 bytes, ASCII)
+        //   8..12   ND (u32)
+        //   12..16  NI (u32)
+        //   16..76  LOCIFN (60 bytes, internal filename)
+        //   76..80  FWARD (u32, first summary record)
+        //   80..84  BWARD (u32, last summary record)
+        //   84..88  FREE (u32, first free address)
+        let (nd, ni, fward, bward, free) = match endian {
+            Endian::Little => (
+                LittleEndian::read_u32(&header[8..12]),
+                LittleEndian::read_u32(&header[12..16]),
+                LittleEndian::read_u32(&header[76..80]),
+                LittleEndian::read_u32(&header[80..84]),
+                LittleEndian::read_u32(&header[84..88]),
+            ),
+            Endian::Big => (
+                BigEndian::read_u32(&header[8..12]),
+                BigEndian::read_u32(&header[12..16]),
+                BigEndian::read_u32(&header[76..80]),
+                BigEndian::read_u32(&header[80..84]),
+                BigEndian::read_u32(&header[84..88]),
+            ),
+        };
+
+        let ifname = String::from_utf8_lossy(&header[16..76])
+            .trim_end()
+            .to_string();
+
+        self.locidw = locidw;
+        self.nd = nd;
+        self.ni = ni;
+        self.fward = fward;
+        self.bward = bward;
+        self.free = free;
+        self.ifname = ifname;
+        self.endian = endian;
+
+        if self.fward == 0 || self.bward == 0 {
+            return Err(JplephemError::InvalidFormat(format!(
+                "Invalid DAF header: nd={nd}, ni={ni}, fward={fward}, bward={bward}"
+            )));
+        }
+
+        Ok(())
+    }
+
+    fn setup_memory_map(&mut self) -> Result<()> {
+        if let Some(ref mut mutex) = self.file {
+            let file = mutex.get_mut().unwrap();
+            if let Ok(file_clone) = file.try_clone() {
+                if let Ok(mmap) = unsafe { MmapOptions::new().map(&file_clone) } {
+                    self.map = Some(mmap);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn get_file(&self) -> Result<std::sync::MutexGuard<'_, std::fs::File>> {
+        self.file
+            .as_ref()
+            .ok_or_else(|| JplephemError::Other("No file handle (in-memory DAF)".to_string()))?
+            .lock()
+            .map_err(|_| JplephemError::Other("Failed to lock file".to_string()))
+    }
+
+    /// Read a 1024-byte record at the given record number (1-indexed)
+    pub fn read_record(&self, record_number: usize) -> Result<Vec<u8>> {
+        if record_number < 1 {
+            return Err(JplephemError::InvalidFormat(format!(
+                "Invalid record number: {record_number}"
+            )));
+        }
+        let offset = (record_number - 1) * RECORD_SIZE;
+
+        // Try in-memory bytes first
+        if let Some(ref bytes) = self.bytes {
+            if offset + RECORD_SIZE <= bytes.len() {
+                return Ok(bytes[offset..offset + RECORD_SIZE].to_vec());
+            }
+            return Err(JplephemError::InvalidFormat(format!(
+                "Record {record_number} out of range for in-memory data ({} bytes)",
+                bytes.len()
+            )));
+        }
+
+        // Try memory map
+        if let Some(ref map) = self.map {
+            if offset + RECORD_SIZE <= map.len() {
+                return Ok(map[offset..offset + RECORD_SIZE].to_vec());
+            }
+        }
+
+        // Fall back to file I/O
+        let mut file = self.get_file()?;
+        let mut buffer = vec![0u8; RECORD_SIZE];
+        file.seek(SeekFrom::Start(offset as u64))
+            .map_err(|e| io_err(&self.path, e))?;
+        file.read_exact(&mut buffer)
+            .map_err(|e| io_err(&self.path, e))?;
+        Ok(buffer)
+    }
+
+    /// Read comments from the comment area (records 2..fward)
+    pub fn comments(&self) -> Result<String> {
+        let fward = self.fward as usize;
+        if fward <= 2 {
+            return Ok(String::new());
+        }
+
+        let mut comments = String::new();
+        for record_number in 2..fward {
+            let record = self.read_record(record_number)?;
+            let text = String::from_utf8_lossy(&record);
+            comments.push_str(&text);
+        }
+
+        Ok(comments
+            .trim_end_matches(|c: char| c == '\0' || c.is_whitespace())
+            .to_string())
+    }
+
+    /// Read summary records and extract segment metadata
+    ///
+    /// Returns pairs of (name_bytes, summary_values) where summary_values
+    /// contains ND doubles followed by NI integers (as f64).
+    pub fn summaries(&self) -> Result<Vec<(Vec<u8>, Vec<f64>)>> {
+        let mut result = Vec::new();
+        let mut visited = std::collections::HashSet::new();
+
+        if self.fward == 0 || self.fward > 10000 {
+            return Err(JplephemError::InvalidFormat(format!(
+                "Invalid forward pointer: {}",
+                self.fward
+            )));
+        }
+
+        let mut record_number = self.fward as usize;
+
+        while record_number > 0 {
+            if !visited.insert(record_number) {
+                break; // Cycle detected
+            }
+
+            let summary_data = self.read_record(record_number)?;
+            let name_data = self.read_record(record_number + 1)?;
+
+            // First 24 bytes: NEXT (f64), PREV (f64), NSUM (f64)
+            let next = self.read_f64_from_bytes(&summary_data[0..8]) as usize;
+            let _prev = self.read_f64_from_bytes(&summary_data[8..16]) as usize;
+            let n_summaries = self.read_f64_from_bytes(&summary_data[16..24]) as usize;
+
+            let max_summaries = (RECORD_SIZE - 24) / self.summary_step.max(1);
+            if n_summaries > max_summaries {
+                return Err(JplephemError::InvalidFormat(format!(
+                    "Too many summaries in record {record_number}: {n_summaries} > {max_summaries}"
+                )));
+            }
+
+            for i in 0..n_summaries {
+                let name_start = i * self.summary_step;
+                let name_end = (name_start + self.summary_step).min(name_data.len());
+                let name = name_data[name_start..name_end].to_vec();
+
+                let summary_start = 24 + i * self.summary_step;
+
+                let mut values = Vec::with_capacity(self.nd as usize + self.ni as usize);
+
+                // Read ND double-precision values
+                for j in 0..self.nd as usize {
+                    let pos = summary_start + j * 8;
+                    if pos + 8 <= summary_data.len() {
+                        values.push(self.read_f64_from_bytes(&summary_data[pos..pos + 8]));
+                    }
+                }
+
+                // Read NI integer values (packed as pairs of i32 into 8-byte slots)
+                let int_start = summary_start + (self.nd as usize * 8);
+                for j in 0..self.ni as usize {
+                    let double_idx = j / 2;
+                    let int_offset = j % 2;
+                    let pos = int_start + double_idx * 8 + int_offset * 4;
+
+                    if pos + 4 <= summary_data.len() {
+                        let value = match self.endian {
+                            Endian::Big => BigEndian::read_i32(&summary_data[pos..pos + 4]) as f64,
+                            Endian::Little => {
+                                LittleEndian::read_i32(&summary_data[pos..pos + 4]) as f64
+                            }
+                        };
+                        values.push(value);
+                    }
+                }
+
+                result.push((name, values));
+            }
+
+            if next == 0 || next == record_number {
+                break;
+            }
+            record_number = next;
+        }
+
+        if result.is_empty() {
+            return Err(JplephemError::InvalidFormat(
+                "No summaries found in DAF file".to_string(),
+            ));
+        }
+
+        Ok(result)
+    }
+
+    /// Read an array of f64 values from the file (1-indexed addresses)
+    pub fn read_array(&self, start: usize, end: usize) -> Result<Vec<f64>> {
+        if start < 1 || end < start {
+            return Err(JplephemError::InvalidFormat(format!(
+                "Invalid array bounds: start={start}, end={end}"
+            )));
+        }
+
+        let length = end - start + 1;
+
+        // Helper: decode f64 values from a byte slice
+        let decode_slice = |slice: &[u8], count: usize| -> Vec<f64> {
+            let mut result = Vec::with_capacity(count);
+            for i in 0..count {
+                let pos = i * DOUBLE_SIZE;
+                let value = match self.endian {
+                    Endian::Big => BigEndian::read_f64(&slice[pos..pos + DOUBLE_SIZE]),
+                    Endian::Little => LittleEndian::read_f64(&slice[pos..pos + DOUBLE_SIZE]),
+                };
+                result.push(value);
+            }
+            result
+        };
+
+        let byte_start = (start - 1) * DOUBLE_SIZE;
+        let byte_end = byte_start + length * DOUBLE_SIZE;
+
+        // Try in-memory bytes first
+        if let Some(ref bytes) = self.bytes {
+            if byte_end <= bytes.len() {
+                return Ok(decode_slice(&bytes[byte_start..byte_end], length));
+            }
+            return Err(JplephemError::InvalidFormat(format!(
+                "Array bounds [{start}..{end}] out of range for in-memory data ({} bytes)",
+                bytes.len()
+            )));
+        }
+
+        // Try memory map
+        if let Some(ref map) = self.map {
+            if byte_end <= map.len() {
+                return Ok(decode_slice(&map[byte_start..byte_end], length));
+            }
+        }
+
+        // Fall back to file I/O
+        let mut file = self.get_file()?;
+        file.seek(SeekFrom::Start(byte_start as u64))
+            .map_err(|e| io_err(&self.path, e))?;
+
+        let mut buffer = vec![0u8; length * DOUBLE_SIZE];
+        file.read_exact(&mut buffer)
+            .map_err(|e| io_err(&self.path, e))?;
+
+        Ok(decode_slice(&buffer, length))
+    }
+
+    /// Map an array of f64 values (alias for read_array, uses mmap when available)
+    pub fn map_array(&self, start: usize, end: usize) -> Result<Vec<f64>> {
+        self.read_array(start, end)
+    }
+
+    /// Read an f64 from a byte slice using the file's endianness
+    fn read_f64_from_bytes(&self, bytes: &[u8]) -> f64 {
+        match self.endian {
+            Endian::Big => BigEndian::read_f64(bytes),
+            Endian::Little => LittleEndian::read_f64(bytes),
+        }
+    }
+}

--- a/src/jplephem/errors.rs
+++ b/src/jplephem/errors.rs
@@ -1,0 +1,50 @@
+//! Error types for the jplephem module
+
+use std::path::PathBuf;
+use thiserror::Error;
+
+/// Main error type for jplephem functionality
+#[derive(Error, Debug)]
+pub enum JplephemError {
+    /// Error when a file I/O operation fails
+    #[error("File I/O error on {path:?}: {source}")]
+    FileError {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// Error when a date is outside the range covered by the ephemeris
+    #[error("Date JD {jd} is outside ephemeris range ({start_jd}..{end_jd})")]
+    OutOfRangeError { jd: f64, start_jd: f64, end_jd: f64 },
+
+    /// Error when the file format is invalid or unsupported
+    #[error("Invalid file format: {0}")]
+    InvalidFormat(String),
+
+    /// Error when a memory mapping operation fails
+    #[error("Memory mapping error: {0}")]
+    MemoryMapError(String),
+
+    /// Error when the requested body is not found in the ephemeris
+    #[error("Body not found: center={center}, target={target}")]
+    BodyNotFound { center: i32, target: i32 },
+
+    /// Error when the data type is not supported
+    #[error("Unsupported SPK data type: {0}")]
+    UnsupportedDataType(i32),
+
+    /// Other errors
+    #[error("{0}")]
+    Other(String),
+}
+
+/// Result type for jplephem operations
+pub type Result<T> = std::result::Result<T, JplephemError>;
+
+/// Convert a std::io::Error to JplephemError with path context
+pub fn io_err(path: impl Into<PathBuf>, err: std::io::Error) -> JplephemError {
+    JplephemError::FileError {
+        path: path.into(),
+        source: err,
+    }
+}

--- a/src/jplephem/kernel.rs
+++ b/src/jplephem/kernel.rs
@@ -1,0 +1,228 @@
+//! High-level SpiceKernel API for planetary position lookups
+//!
+//! Provides a Skyfield-style interface where you load a BSP file, look up
+//! a body by name, and compute its position at a given time.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use nalgebra::{Point3, Vector3};
+
+use super::errors::{JplephemError, Result};
+use super::names::target_id;
+use super::spk::{jd_to_seconds, SPK};
+
+/// AU in kilometers (IAU 2012 exact definition)
+pub const AU_KM: f64 = 149_597_870.700;
+/// Seconds per day
+pub const S_PER_DAY: f64 = 86400.0;
+
+/// State of a body: position in AU and velocity in AU/day relative to SSB
+#[derive(Debug, Clone)]
+pub struct PlanetState {
+    /// Position in AU relative to SSB
+    pub position: Point3<f64>,
+    /// Velocity in AU/day relative to SSB
+    pub velocity: Vector3<f64>,
+}
+
+/// A loaded SPK kernel with named body access and segment chain resolution
+pub struct SpiceKernel {
+    spk: SPK,
+    /// Precomputed chains: target_id -> list of (center, target) segment pairs
+    chains: HashMap<i32, Vec<(i32, i32)>>,
+}
+
+impl SpiceKernel {
+    /// Open a BSP/SPK file and precompute segment chains
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let spk = SPK::open(path)?;
+        let chains = Self::build_chains(&spk);
+        Ok(SpiceKernel { spk, chains })
+    }
+
+    /// Create a SpiceKernel from an in-memory byte buffer
+    ///
+    /// Parses the same binary SPK/BSP format as `open`, but from `&[u8]`.
+    /// Useful with `include_bytes!()` for compile-time embedded ephemeris data.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// static BSP_DATA: &[u8] = include_bytes!("de421.bsp");
+    /// let mut kernel = SpiceKernel::from_bytes(BSP_DATA).unwrap();
+    /// ```
+    pub fn from_bytes(data: &[u8]) -> Result<Self> {
+        let spk = SPK::from_bytes(data)?;
+        let chains = Self::build_chains(&spk);
+        Ok(SpiceKernel { spk, chains })
+    }
+
+    /// Build BFS chains from SSB (0) to every reachable target body
+    fn build_chains(spk: &SPK) -> HashMap<i32, Vec<(i32, i32)>> {
+        let mut adj: HashMap<i32, Vec<(i32, i32)>> = HashMap::new();
+        for seg in &spk.segments {
+            adj.entry(seg.center)
+                .or_default()
+                .push((seg.center, seg.target));
+        }
+
+        let mut chains = HashMap::new();
+        let mut queue = std::collections::VecDeque::new();
+        let mut parent: HashMap<i32, (i32, i32)> = HashMap::new();
+
+        queue.push_back(0i32);
+        parent.insert(0, (0, 0)); // sentinel
+
+        while let Some(node) = queue.pop_front() {
+            if let Some(edges) = adj.get(&node) {
+                for &(center, target) in edges {
+                    if let std::collections::hash_map::Entry::Vacant(e) = parent.entry(target) {
+                        e.insert((center, target));
+                        queue.push_back(target);
+                    }
+                }
+            }
+        }
+
+        for &target_id in parent.keys() {
+            if target_id == 0 {
+                continue;
+            }
+            let mut chain = Vec::new();
+            let mut current = target_id;
+            while current != 0 {
+                if let Some(&(center, target)) = parent.get(&current) {
+                    if center == 0 && target == 0 {
+                        break;
+                    }
+                    chain.push((center, target));
+                    current = center;
+                } else {
+                    break;
+                }
+            }
+            chain.reverse();
+            chains.insert(target_id, chain);
+        }
+
+        chains
+    }
+
+    /// Get a VectorFunction for a body by name or numeric ID string
+    ///
+    /// Supported names: "earth", "mars", "moon", "sun", "mercury", "venus",
+    /// "jupiter", "saturn", "uranus", "neptune", "pluto", "earth barycenter", etc.
+    pub fn get(&self, name: &str) -> Result<VectorFunction> {
+        let id = self.resolve_name(name)?;
+
+        let chain = self.chains.get(&id).ok_or_else(|| {
+            JplephemError::Other(format!(
+                "No path from SSB to body {id} ('{name}') in this kernel"
+            ))
+        })?;
+
+        Ok(VectorFunction {
+            target_id: id,
+            target_name: name.to_string(),
+            chain: chain.clone(),
+        })
+    }
+
+    /// Resolve a name to a NAIF ID
+    fn resolve_name(&self, name: &str) -> Result<i32> {
+        // Try parsing as numeric ID first
+        if let Ok(id) = name.parse::<i32>() {
+            return Ok(id);
+        }
+
+        target_id(name).ok_or_else(|| JplephemError::Other(format!("Unknown body name: '{name}'")))
+    }
+
+    /// Compute position and velocity for a chain of segments at a given TDB seconds.
+    ///
+    /// Returns raw (km, km/s) values from the underlying SPK data.
+    pub fn compute_chain_pub(
+        &mut self,
+        chain: &[(i32, i32)],
+        tdb_seconds: f64,
+    ) -> Result<(Vector3<f64>, Vector3<f64>)> {
+        let mut total_pos = Vector3::new(0.0, 0.0, 0.0);
+        let mut total_vel = Vector3::new(0.0, 0.0, 0.0);
+
+        for &(center, target) in chain {
+            let seg = self.spk.get_segment_mut(center, target)?;
+            let (pos, vel) = seg.compute_and_differentiate(tdb_seconds, 0.0)?;
+            total_pos += pos;
+            total_vel += vel;
+        }
+
+        Ok((total_pos, total_vel))
+    }
+
+    /// Compute a body's state at a given Julian Date (TDB)
+    ///
+    /// Returns PlanetState with position in AU and velocity in AU/day,
+    /// relative to the Solar System Barycenter (SSB).
+    pub fn compute_at_jd(&mut self, name: &str, jd_tdb: f64) -> Result<PlanetState> {
+        let vf = self.get(name)?;
+        let tdb_seconds = jd_to_seconds(jd_tdb);
+        let (pos_km, vel_km_s) = self.compute_chain_pub(&vf.chain, tdb_seconds)?;
+
+        Ok(PlanetState {
+            position: Point3::new(pos_km.x / AU_KM, pos_km.y / AU_KM, pos_km.z / AU_KM),
+            velocity: Vector3::new(
+                vel_km_s.x * S_PER_DAY / AU_KM,
+                vel_km_s.y * S_PER_DAY / AU_KM,
+                vel_km_s.z * S_PER_DAY / AU_KM,
+            ),
+        })
+    }
+
+    /// Compute raw position and velocity in km and km/s at a given Julian Date (TDB)
+    pub fn compute_km_jd(
+        &mut self,
+        name: &str,
+        jd_tdb: f64,
+    ) -> Result<(Vector3<f64>, Vector3<f64>)> {
+        let vf = self.get(name)?;
+        let tdb_seconds = jd_to_seconds(jd_tdb);
+        self.compute_chain_pub(&vf.chain, tdb_seconds)
+    }
+
+    /// Access the underlying SPK for direct segment access
+    pub fn spk(&self) -> &SPK {
+        &self.spk
+    }
+
+    /// Access the underlying SPK mutably for computation
+    pub fn spk_mut(&mut self) -> &mut SPK {
+        &mut self.spk
+    }
+}
+
+/// Represents a resolved path from SSB to a target body
+///
+/// Holds the chain of (center, target) segment pairs that must be summed
+/// to compute the body's position relative to the SSB.
+#[derive(Debug, Clone)]
+pub struct VectorFunction {
+    /// NAIF ID of the target body
+    pub target_id: i32,
+    /// Human-readable name
+    pub target_name: String,
+    /// Chain of (center, target) pairs from SSB to this body
+    pub chain: Vec<(i32, i32)>,
+}
+
+impl std::fmt::Display for VectorFunction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "VectorFunction({} [{}], {} segments)",
+            self.target_name,
+            self.target_id,
+            self.chain.len()
+        )
+    }
+}

--- a/src/jplephem/mod.rs
+++ b/src/jplephem/mod.rs
@@ -1,0 +1,50 @@
+//! JPL Ephemeris module for high-precision planetary positions
+//!
+//! This module provides functionality for reading and interpreting JPL Development
+//! Ephemerides (DE) files, which contain position and velocity data for solar
+//! system bodies stored as Chebyshev polynomial coefficients in SPICE SPK format.
+//!
+//! # Supported Ephemerides
+//!
+//! Any SPK/BSP file using data types 2 (Chebyshev position), 3 (Chebyshev
+//! position + velocity), or 21 (Modified Difference Array) is supported.
+//! This includes all standard JPL planetary ephemerides:
+//!
+//! | Ephemeris | Time Span | Size | Notes |
+//! |-----------|-----------|------|-------|
+//! | DE405 | 1599–2201 | ~55 MB | Legacy, widely used |
+//! | DE421 | 1900–2050 | ~17 MB | Compact, good for near-term work |
+//! | DE430t | 1550–2650 | ~115 MB | Truncated DE430 |
+//! | DE440 | 1550–2650 | ~114 MB | Current standard, fits to modern data |
+//! | DE441 | −13200–17191 | ~3.1 GB | Extended time span for deep-past/future |
+//!
+//! NAIF satellite kernels (e.g. `jup365.bsp`) are also supported.
+//!
+//! # Main Components
+//!
+//! - [`daf`] - Double Array File format reader (underlying binary container)
+//! - [`spk`] - Spacecraft Planet Kernel format reader
+//! - [`kernel`] - High-level SpiceKernel API with named body access
+//! - [`chebyshev`] - Chebyshev polynomial interpolation
+//! - [`spk_type21`] - SPK Type 21 Modified Difference Array interpolation
+//! - [`names`] - NAIF body name/ID mappings
+//! - [`calendar`] - Julian date and calendar conversions
+
+pub mod calendar;
+pub mod chebyshev;
+pub mod daf;
+pub mod errors;
+pub mod kernel;
+pub mod names;
+pub mod pck;
+pub mod spk;
+pub mod spk_type21;
+
+#[cfg(test)]
+mod tests;
+
+pub use self::chebyshev::{normalize_time, rescale_derivative, ChebyshevPolynomial};
+pub use self::errors::JplephemError;
+pub use self::kernel::{PlanetState, SpiceKernel, AU_KM, S_PER_DAY};
+pub use self::pck::PCK;
+pub use self::spk::SPK;

--- a/src/jplephem/names.rs
+++ b/src/jplephem/names.rs
@@ -1,0 +1,91 @@
+//! Standard SPICE target names and ID numbers
+
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+
+lazy_static! {
+    static ref TARGET_NAMES: HashMap<i32, &'static str> = {
+        let mut m = HashMap::new();
+        for &(id, name) in TARGET_NAME_PAIRS.iter() {
+            m.entry(id).or_insert(name);
+        }
+        m
+    };
+    static ref TARGET_IDS: HashMap<String, i32> = {
+        let mut m = HashMap::new();
+        for &(id, name) in TARGET_NAME_PAIRS.iter() {
+            m.insert(name.to_lowercase(), id);
+        }
+        m
+    };
+}
+
+/// Get the canonical name of a target given its ID number
+pub fn target_name(id: i32) -> Option<&'static str> {
+    TARGET_NAMES.get(&id).copied()
+}
+
+/// Alias for target_name
+pub fn get_target_name(id: i32) -> Option<&'static str> {
+    target_name(id)
+}
+
+/// Get the ID number of a target given its name (case-insensitive)
+pub fn target_id(name: &str) -> Option<i32> {
+    TARGET_IDS.get(&name.to_lowercase()).copied()
+}
+
+/// Pairs of (id, name) for celestial bodies
+const TARGET_NAME_PAIRS: &[(i32, &str)] = &[
+    (0, "SOLAR SYSTEM BARYCENTER"),
+    (0, "SSB"),
+    (1, "MERCURY BARYCENTER"),
+    (2, "VENUS BARYCENTER"),
+    (3, "EARTH BARYCENTER"),
+    (3, "EMB"),
+    (3, "EARTH MOON BARYCENTER"),
+    (3, "EARTH-MOON BARYCENTER"),
+    (4, "MARS BARYCENTER"),
+    (5, "JUPITER BARYCENTER"),
+    (6, "SATURN BARYCENTER"),
+    (7, "URANUS BARYCENTER"),
+    (8, "NEPTUNE BARYCENTER"),
+    (9, "PLUTO BARYCENTER"),
+    (10, "SUN"),
+    (199, "MERCURY"),
+    (299, "VENUS"),
+    (399, "EARTH"),
+    (301, "MOON"),
+    (499, "MARS"),
+    (401, "PHOBOS"),
+    (402, "DEIMOS"),
+    (599, "JUPITER"),
+    (501, "IO"),
+    (502, "EUROPA"),
+    (503, "GANYMEDE"),
+    (504, "CALLISTO"),
+    (699, "SATURN"),
+    (799, "URANUS"),
+    (899, "NEPTUNE"),
+    (999, "PLUTO"),
+];
+
+/// Common NAIF target ID constants
+pub mod targets {
+    pub const SOLAR_SYSTEM_BARYCENTER: i32 = 0;
+    pub const MERCURY_BARYCENTER: i32 = 1;
+    pub const VENUS_BARYCENTER: i32 = 2;
+    pub const EARTH_MOON_BARYCENTER: i32 = 3;
+    pub const MARS_BARYCENTER: i32 = 4;
+    pub const JUPITER_BARYCENTER: i32 = 5;
+    pub const SATURN_BARYCENTER: i32 = 6;
+    pub const URANUS_BARYCENTER: i32 = 7;
+    pub const NEPTUNE_BARYCENTER: i32 = 8;
+    pub const PLUTO_BARYCENTER: i32 = 9;
+    pub const SUN: i32 = 10;
+    pub const MERCURY: i32 = 199;
+    pub const VENUS: i32 = 299;
+    pub const EARTH: i32 = 399;
+    pub const MOON: i32 = 301;
+    pub const MARS: i32 = 499;
+}

--- a/src/jplephem/pck.rs
+++ b/src/jplephem/pck.rs
@@ -1,0 +1,24 @@
+//! Planetary Constants Kernel (PCK) format stub
+//!
+//! PCK files contain rotation and orientation data for planets and moons.
+//! This is a placeholder for future implementation.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use super::daf::DAF;
+use super::errors::Result;
+
+/// Planetary Constants Kernel (PCK) file reader
+pub struct PCK {
+    /// The underlying DAF file
+    pub daf: Arc<DAF>,
+}
+
+impl PCK {
+    /// Open a PCK file at the given path
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let daf = Arc::new(DAF::open(path)?);
+        Ok(PCK { daf })
+    }
+}

--- a/src/jplephem/spk.rs
+++ b/src/jplephem/spk.rs
@@ -1,0 +1,547 @@
+//! Spacecraft Planet Kernel (SPK) format reader
+//!
+//! Reads NASA SPICE SPK files containing position and velocity data
+//! for solar system bodies, stored as Chebyshev polynomial coefficients
+//! or Modified Difference Arrays.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use nalgebra::Vector3;
+
+use super::calendar::calendar_date_from_float;
+use super::chebyshev::{normalize_time, rescale_derivative, ChebyshevPolynomial};
+use super::daf::DAF;
+use super::errors::{JplephemError, Result};
+use super::names::get_target_name;
+use super::spk_type21::Type21Data;
+
+/// Type 2 record coefficients: (midpoint, radius, x_coeffs, y_coeffs, z_coeffs)
+type Type2Coeffs = (f64, f64, Vec<f64>, Vec<f64>, Vec<f64>);
+/// Type 3 record coefficients: (midpoint, radius, (pos_xyz), (vel_xyz))
+type Type3Coeffs = (
+    f64,
+    f64,
+    (Vec<f64>, Vec<f64>, Vec<f64>),
+    (Vec<f64>, Vec<f64>, Vec<f64>),
+);
+
+/// J2000 epoch as Julian date
+const T0: f64 = 2451545.0;
+/// Seconds per day
+const S_PER_DAY: f64 = 86400.0;
+
+/// Convert seconds since J2000 to Julian date
+pub fn seconds_to_jd(seconds: f64) -> f64 {
+    T0 + seconds / S_PER_DAY
+}
+
+/// Convert Julian date to seconds since J2000
+pub fn jd_to_seconds(jd: f64) -> f64 {
+    (jd - T0) * S_PER_DAY
+}
+
+/// Spacecraft Planet Kernel (SPK) file reader
+pub struct SPK {
+    /// The underlying DAF file
+    pub daf: Arc<DAF>,
+    /// Segments in the file
+    pub segments: Vec<Segment>,
+    /// Map of (center, target) pairs to segment indices
+    pairs: HashMap<(i32, i32), usize>,
+}
+
+/// A segment containing ephemeris data for a specific body pair
+pub struct Segment {
+    daf: Arc<DAF>,
+    /// Segment source label
+    pub source: String,
+    /// Start epoch in TDB seconds since J2000
+    pub start_second: f64,
+    /// End epoch in TDB seconds since J2000
+    pub end_second: f64,
+    /// Target body NAIF ID
+    pub target: i32,
+    /// Center body NAIF ID
+    pub center: i32,
+    /// Reference frame ID
+    pub frame: i32,
+    /// SPK data type (2=Chebyshev position, 3=Chebyshev pos+vel, 21=MDA)
+    pub data_type: i32,
+    /// Start index in file (1-indexed double-words)
+    pub start_i: usize,
+    /// End index in file (1-indexed double-words)
+    pub end_i: usize,
+    /// Start Julian date
+    pub start_jd: f64,
+    /// End Julian date
+    pub end_jd: f64,
+    /// Cached segment data
+    data: Option<SegmentData>,
+}
+
+/// Cached coefficient data for a segment
+#[derive(Clone)]
+enum SegmentData {
+    /// Type 2/3 Chebyshev polynomial data
+    Chebyshev {
+        init: f64,
+        intlen: f64,
+        coefficients: Vec<f64>,
+        /// (n_records, n_components, n_coeffs_per_component)
+        shape: (usize, usize, usize),
+        record_size: usize,
+        data_type: i32,
+    },
+    /// Type 21 Modified Difference Array data
+    Type21(Type21Data),
+}
+
+impl SPK {
+    /// Open an SPK file at the given path
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let daf = Arc::new(DAF::open(path)?);
+
+        let mut spk = SPK {
+            daf,
+            segments: Vec::new(),
+            pairs: HashMap::new(),
+        };
+
+        spk.parse_segments()?;
+        Ok(spk)
+    }
+
+    /// Create an SPK from an in-memory byte buffer
+    pub fn from_bytes(data: &[u8]) -> Result<Self> {
+        let daf = Arc::new(DAF::from_bytes(data)?);
+
+        let mut spk = SPK {
+            daf,
+            segments: Vec::new(),
+            pairs: HashMap::new(),
+        };
+
+        spk.parse_segments()?;
+        Ok(spk)
+    }
+
+    fn parse_segments(&mut self) -> Result<()> {
+        let summaries = self.daf.summaries()?;
+
+        for (name, values) in summaries.iter() {
+            if values.len() < (self.daf.nd + self.daf.ni) as usize {
+                continue;
+            }
+
+            let source = String::from_utf8_lossy(name).trim_end().to_string();
+
+            let start_second = values[0];
+            let end_second = values[1];
+            let target = values[2] as i32;
+            let center = values[3] as i32;
+            let frame = values[4] as i32;
+            let data_type = values[5] as i32;
+            let start_i = values[6] as usize;
+            let end_i = values[7] as usize;
+
+            // Basic validation
+            if start_i == 0 || end_i < start_i {
+                continue;
+            }
+            if data_type != 2 && data_type != 3 && data_type != 21 {
+                continue;
+            }
+
+            let start_jd = seconds_to_jd(start_second);
+            let end_jd = seconds_to_jd(end_second);
+
+            let segment = Segment {
+                daf: Arc::clone(&self.daf),
+                source,
+                start_second,
+                end_second,
+                target,
+                center,
+                frame,
+                data_type,
+                start_i,
+                end_i,
+                start_jd,
+                end_jd,
+                data: None,
+            };
+
+            let idx = self.segments.len();
+            self.pairs.insert((center, target), idx);
+            self.segments.push(segment);
+        }
+
+        Ok(())
+    }
+
+    /// Get the segment for the given center and target body IDs
+    pub fn get_segment(&self, center: i32, target: i32) -> Result<&Segment> {
+        self.pairs
+            .get(&(center, target))
+            .map(|&idx| &self.segments[idx])
+            .ok_or(JplephemError::BodyNotFound { center, target })
+    }
+
+    /// Get a mutable reference to the segment for the given body pair
+    pub fn get_segment_mut(&mut self, center: i32, target: i32) -> Result<&mut Segment> {
+        let idx = *self
+            .pairs
+            .get(&(center, target))
+            .ok_or(JplephemError::BodyNotFound { center, target })?;
+        Ok(&mut self.segments[idx])
+    }
+
+    /// Read comments from the underlying DAF file
+    pub fn comments(&self) -> Result<String> {
+        self.daf.comments()
+    }
+}
+
+impl Segment {
+    /// Compute position (km) at the given time
+    ///
+    /// `tdb` and `tdb2` are TDB seconds since J2000, split for precision.
+    pub fn compute(&mut self, tdb: f64, tdb2: f64) -> Result<Vector3<f64>> {
+        let (position, _) = self.compute_and_differentiate(tdb, tdb2)?;
+        Ok(position)
+    }
+
+    /// Compute position (km) and velocity (km/s) at the given time
+    ///
+    /// `tdb` and `tdb2` are TDB seconds since J2000, split for precision.
+    pub fn compute_and_differentiate(
+        &mut self,
+        tdb: f64,
+        tdb2: f64,
+    ) -> Result<(Vector3<f64>, Vector3<f64>)> {
+        let et = tdb + tdb2;
+
+        if et < self.start_second || et > self.end_second {
+            return Err(JplephemError::OutOfRangeError {
+                jd: seconds_to_jd(et),
+                start_jd: self.start_jd,
+                end_jd: self.end_jd,
+            });
+        }
+
+        let data = self.load_data()?;
+
+        match data {
+            SegmentData::Chebyshev {
+                init,
+                intlen,
+                coefficients,
+                shape,
+                record_size,
+                data_type,
+            } => {
+                let record_index = Self::find_record_index(et, *init, *intlen, shape.0)?;
+
+                match data_type {
+                    2 => {
+                        let (record_mid, record_radius, coeffs_x, coeffs_y, coeffs_z) =
+                            Self::get_record_coefficients_type2(
+                                coefficients,
+                                record_index,
+                                *record_size,
+                                shape.2,
+                            )?;
+
+                        let t = normalize_time(et, record_mid, record_radius)?;
+
+                        let poly_x = ChebyshevPolynomial::new(coeffs_x);
+                        let poly_y = ChebyshevPolynomial::new(coeffs_y);
+                        let poly_z = ChebyshevPolynomial::new(coeffs_z);
+
+                        let position = Vector3::new(
+                            poly_x.evaluate(t),
+                            poly_y.evaluate(t),
+                            poly_z.evaluate(t),
+                        );
+
+                        let velocity = Vector3::new(
+                            rescale_derivative(poly_x.derivative(t), record_radius)?,
+                            rescale_derivative(poly_y.derivative(t), record_radius)?,
+                            rescale_derivative(poly_z.derivative(t), record_radius)?,
+                        );
+
+                        Ok((position, velocity))
+                    }
+                    3 => {
+                        let (record_mid, record_radius, pos_coeffs, vel_coeffs) =
+                            Self::get_record_coefficients_type3(
+                                coefficients,
+                                record_index,
+                                *record_size,
+                                shape.2,
+                            )?;
+
+                        let t = normalize_time(et, record_mid, record_radius)?;
+
+                        let poly_x = ChebyshevPolynomial::new(pos_coeffs.0);
+                        let poly_y = ChebyshevPolynomial::new(pos_coeffs.1);
+                        let poly_z = ChebyshevPolynomial::new(pos_coeffs.2);
+
+                        let poly_vx = ChebyshevPolynomial::new(vel_coeffs.0);
+                        let poly_vy = ChebyshevPolynomial::new(vel_coeffs.1);
+                        let poly_vz = ChebyshevPolynomial::new(vel_coeffs.2);
+
+                        let position = Vector3::new(
+                            poly_x.evaluate(t),
+                            poly_y.evaluate(t),
+                            poly_z.evaluate(t),
+                        );
+
+                        let velocity = Vector3::new(
+                            rescale_derivative(poly_vx.evaluate(t), record_radius)?,
+                            rescale_derivative(poly_vy.evaluate(t), record_radius)?,
+                            rescale_derivative(poly_vz.evaluate(t), record_radius)?,
+                        );
+
+                        Ok((position, velocity))
+                    }
+                    _ => Err(JplephemError::UnsupportedDataType(*data_type)),
+                }
+            }
+            SegmentData::Type21(type21_data) => type21_data.compute(et),
+        }
+    }
+
+    fn find_record_index(et: f64, init: f64, intlen: f64, n_records: usize) -> Result<usize> {
+        let elapsed = et - init;
+        if elapsed < 0.0 {
+            return Err(JplephemError::OutOfRangeError {
+                jd: seconds_to_jd(et),
+                start_jd: seconds_to_jd(init),
+                end_jd: seconds_to_jd(init + intlen * n_records as f64),
+            });
+        }
+        let mut index = (elapsed / intlen).floor() as usize;
+        // Clamp to last record for times at the exact end of the range
+        if index >= n_records {
+            if index == n_records {
+                index = n_records - 1;
+            } else {
+                return Err(JplephemError::OutOfRangeError {
+                    jd: seconds_to_jd(et),
+                    start_jd: seconds_to_jd(init),
+                    end_jd: seconds_to_jd(init + intlen * n_records as f64),
+                });
+            }
+        }
+        Ok(index)
+    }
+
+    fn get_record_coefficients_type2(
+        coefficients: &[f64],
+        record_index: usize,
+        record_size: usize,
+        n_coeffs: usize,
+    ) -> Result<Type2Coeffs> {
+        let record_start = record_index * record_size;
+        if record_start + 2 + 3 * n_coeffs > coefficients.len() {
+            return Err(JplephemError::InvalidFormat(
+                "Record index out of bounds".to_string(),
+            ));
+        }
+
+        let record_mid = coefficients[record_start];
+        let record_radius = coefficients[record_start + 1];
+
+        let x_start = record_start + 2;
+        let y_start = x_start + n_coeffs;
+        let z_start = y_start + n_coeffs;
+
+        let coeffs_x = coefficients[x_start..x_start + n_coeffs].to_vec();
+        let coeffs_y = coefficients[y_start..y_start + n_coeffs].to_vec();
+        let coeffs_z = coefficients[z_start..z_start + n_coeffs].to_vec();
+
+        Ok((record_mid, record_radius, coeffs_x, coeffs_y, coeffs_z))
+    }
+
+    fn get_record_coefficients_type3(
+        coefficients: &[f64],
+        record_index: usize,
+        record_size: usize,
+        n_coeffs: usize,
+    ) -> Result<Type3Coeffs> {
+        let record_start = record_index * record_size;
+        if record_start + 2 + 6 * n_coeffs > coefficients.len() {
+            return Err(JplephemError::InvalidFormat(
+                "Record index out of bounds".to_string(),
+            ));
+        }
+
+        let record_mid = coefficients[record_start];
+        let record_radius = coefficients[record_start + 1];
+
+        let x_start = record_start + 2;
+        let y_start = x_start + n_coeffs;
+        let z_start = y_start + n_coeffs;
+        let vx_start = z_start + n_coeffs;
+        let vy_start = vx_start + n_coeffs;
+        let vz_start = vy_start + n_coeffs;
+
+        let pos = (
+            coefficients[x_start..x_start + n_coeffs].to_vec(),
+            coefficients[y_start..y_start + n_coeffs].to_vec(),
+            coefficients[z_start..z_start + n_coeffs].to_vec(),
+        );
+        let vel = (
+            coefficients[vx_start..vx_start + n_coeffs].to_vec(),
+            coefficients[vy_start..vy_start + n_coeffs].to_vec(),
+            coefficients[vz_start..vz_start + n_coeffs].to_vec(),
+        );
+
+        Ok((record_mid, record_radius, pos, vel))
+    }
+
+    fn load_data(&mut self) -> Result<&SegmentData> {
+        if let Some(ref data) = self.data {
+            return Ok(data);
+        }
+
+        match self.data_type {
+            2 | 3 => {
+                let array = self.daf.read_array(self.start_i, self.end_i)?;
+                match self.data_type {
+                    2 => self.load_data_type_2(&array),
+                    3 => self.load_data_type_3(&array),
+                    _ => unreachable!(),
+                }
+            }
+            21 => self.load_data_type_21(),
+            _ => Err(JplephemError::UnsupportedDataType(self.data_type)),
+        }
+    }
+
+    fn load_data_type_2(&mut self, array: &[f64]) -> Result<&SegmentData> {
+        if array.len() < 4 {
+            return Err(JplephemError::InvalidFormat(
+                "Segment data too small for Type 2".to_string(),
+            ));
+        }
+
+        let n = array.len();
+        let init = array[n - 4];
+        let intlen = array[n - 3];
+        let rsize = array[n - 2] as usize;
+        let n_rec = array[n - 1] as usize;
+
+        if rsize < 5 {
+            return Err(JplephemError::InvalidFormat(format!(
+                "Invalid record size for Type 2: {rsize}"
+            )));
+        }
+
+        let n_coeffs = (rsize - 2) / 3;
+
+        let expected_size = n_rec * rsize + 4;
+        if array.len() != expected_size {
+            return Err(JplephemError::InvalidFormat(format!(
+                "Inconsistent array size: expected {expected_size}, got {}",
+                array.len()
+            )));
+        }
+
+        let coefficients = array[0..(n - 4)].to_vec();
+
+        self.data = Some(SegmentData::Chebyshev {
+            init,
+            intlen,
+            coefficients,
+            shape: (n_rec, 3, n_coeffs),
+            record_size: rsize,
+            data_type: self.data_type,
+        });
+        Ok(self.data.as_ref().unwrap())
+    }
+
+    fn load_data_type_3(&mut self, array: &[f64]) -> Result<&SegmentData> {
+        if array.len() < 4 {
+            return Err(JplephemError::InvalidFormat(
+                "Segment data too small for Type 3".to_string(),
+            ));
+        }
+
+        let n = array.len();
+        let init = array[n - 4];
+        let intlen = array[n - 3];
+        let rsize = array[n - 2] as usize;
+        let n_rec = array[n - 1] as usize;
+
+        if rsize < 8 {
+            return Err(JplephemError::InvalidFormat(format!(
+                "Invalid record size for Type 3: {rsize}"
+            )));
+        }
+
+        let n_coeffs = (rsize - 2) / 6;
+
+        let expected_size = n_rec * rsize + 4;
+        if array.len() != expected_size {
+            return Err(JplephemError::InvalidFormat(format!(
+                "Inconsistent array size: expected {expected_size}, got {}",
+                array.len()
+            )));
+        }
+
+        let coefficients = array[0..(n - 4)].to_vec();
+
+        self.data = Some(SegmentData::Chebyshev {
+            init,
+            intlen,
+            coefficients,
+            shape: (n_rec, 6, n_coeffs),
+            record_size: rsize,
+            data_type: self.data_type,
+        });
+        Ok(self.data.as_ref().unwrap())
+    }
+
+    fn load_data_type_21(&mut self) -> Result<&SegmentData> {
+        let type21_data = Type21Data::load(&self.daf, self.start_i, self.end_i)?;
+        self.data = Some(SegmentData::Type21(type21_data));
+        Ok(self.data.as_ref().unwrap())
+    }
+
+    /// Return a human-readable description of this segment
+    pub fn describe(&self, verbose: bool) -> String {
+        let start_date = calendar_date_from_float(self.start_jd);
+        let end_date = calendar_date_from_float(self.end_jd);
+        let start = format!("{}-{:02}-{:02}", start_date.0, start_date.1, start_date.2);
+        let end = format!("{}-{:02}-{:02}", end_date.0, end_date.1, end_date.2);
+
+        let center_name = get_target_name(self.center).unwrap_or("Unknown");
+        let target_name = get_target_name(self.target).unwrap_or("Unknown");
+
+        let mut text = format!(
+            "{start}..{end}  Type {}  {center_name} ({}) -> {target_name} ({})",
+            self.data_type, self.center, self.target
+        );
+
+        if verbose {
+            text.push_str(&format!("\n  frame={} source={}", self.frame, self.source));
+        }
+        text
+    }
+}
+
+impl std::fmt::Display for Segment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.describe(false))
+    }
+}
+
+impl std::fmt::Debug for Segment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.describe(true))
+    }
+}

--- a/src/jplephem/spk_type21.rs
+++ b/src/jplephem/spk_type21.rs
@@ -1,0 +1,463 @@
+//! SPK Type 21: Extended Modified Difference Arrays
+//!
+//! Type 21 segments store trajectory data using Modified Difference Arrays (MDA),
+//! the Shampine-Gordon polynomial interpolation method. This is the modern
+//! successor to Type 1, used by all Horizons-generated small-body SPK files
+//! since October 2018.
+//!
+//! Each record contains a reference epoch, stepsize function coefficients,
+//! reference position/velocity, and a modified divided difference table.
+//! Interpolation reconstructs position and velocity at any epoch within
+//! the record's coverage using the difference table recurrence.
+
+use std::sync::Arc;
+
+use nalgebra::Vector3;
+
+use super::daf::DAF;
+use super::errors::{JplephemError, Result};
+
+/// Maximum supported difference table order
+const MAXTRM: usize = 25;
+
+/// A parsed Type 21 MDA record
+#[derive(Debug, Clone)]
+struct MdaRecord {
+    /// Reference epoch (TDB seconds past J2000)
+    tl: f64,
+    /// Stepsize function coefficients (length MAXDIM)
+    g: Vec<f64>,
+    /// Reference position [x, y, z] in km
+    refpos: [f64; 3],
+    /// Reference velocity [vx, vy, vz] in km/s
+    refvel: [f64; 3],
+    /// Modified difference table, shape [3][MAXDIM] (one row per component)
+    dt: [Vec<f64>; 3],
+    /// Maximum integration order + 1
+    kqmax1: usize,
+    /// Integration order for each component [x, y, z]
+    kq: [usize; 3],
+}
+
+/// Parsed Type 21 segment data
+#[derive(Debug, Clone)]
+pub struct Type21Data {
+    /// MAXDIM for this segment (variable, unlike Type 1's fixed 15)
+    maxdim: usize,
+    /// Difference line size = 4 * MAXDIM + 11
+    dlsize: usize,
+    /// Number of records
+    n_records: usize,
+    /// Epoch table: one epoch per record (used for record lookup)
+    epoch_table: Vec<f64>,
+    /// Epoch directory for fast lookup when n_records > 100
+    epoch_dir: Vec<f64>,
+    /// All record data stored as flat f64 array
+    record_data: Vec<f64>,
+}
+
+impl Type21Data {
+    /// Load Type 21 segment data from a DAF file
+    ///
+    /// `start_i` and `end_i` are 1-indexed double-word addresses from the segment summary.
+    pub fn load(daf: &Arc<DAF>, start_i: usize, end_i: usize) -> Result<Self> {
+        // Last word of segment is MAXDIM, second-to-last is N (record count)
+        let maxdim_raw = daf.read_array(end_i, end_i)?;
+        let maxdim = maxdim_raw[0] as usize;
+
+        if maxdim > MAXTRM {
+            return Err(JplephemError::InvalidFormat(format!(
+                "Type 21 MAXDIM {maxdim} exceeds maximum supported {MAXTRM}"
+            )));
+        }
+        if maxdim == 0 {
+            return Err(JplephemError::InvalidFormat(
+                "Type 21 MAXDIM is zero".to_string(),
+            ));
+        }
+
+        let dlsize = 4 * maxdim + 11;
+
+        let n_records_raw = daf.read_array(end_i - 1, end_i - 1)?;
+        let n_records = n_records_raw[0] as usize;
+
+        if n_records == 0 {
+            return Err(JplephemError::InvalidFormat(
+                "Type 21 segment has zero records".to_string(),
+            ));
+        }
+
+        // Epoch directory count
+        let epoch_dir_count = if n_records > 100 {
+            (n_records - 1) / 100
+        } else {
+            0
+        };
+
+        // Read all record data: n_records * dlsize doubles starting at start_i
+        let record_end = start_i + n_records * dlsize - 1;
+        let record_data = daf.read_array(start_i, record_end)?;
+
+        // Epoch table follows records: n_records entries
+        let epoch_start = start_i + n_records * dlsize;
+        let epoch_end = epoch_start + n_records - 1;
+        let epoch_table = daf.read_array(epoch_start, epoch_end)?;
+
+        // Epoch directory follows epoch table (before N and MAXDIM)
+        let epoch_dir = if epoch_dir_count > 0 {
+            let dir_start = end_i - 1 - epoch_dir_count;
+            let dir_end = end_i - 2;
+            daf.read_array(dir_start, dir_end)?
+        } else {
+            Vec::new()
+        };
+
+        // Validate segment size
+        let expected_size = n_records * dlsize + n_records + epoch_dir_count + 2;
+        let actual_size = end_i - start_i + 1;
+        if actual_size != expected_size {
+            return Err(JplephemError::InvalidFormat(format!(
+                "Type 21 segment size mismatch: expected {expected_size}, got {actual_size} \
+                 (n_records={n_records}, dlsize={dlsize}, maxdim={maxdim}, epoch_dir={epoch_dir_count})"
+            )));
+        }
+
+        Ok(Type21Data {
+            maxdim,
+            dlsize,
+            n_records,
+            epoch_table,
+            epoch_dir,
+            record_data,
+        })
+    }
+
+    /// Find the record index for a given epoch (TDB seconds past J2000)
+    fn find_record_index(&self, et: f64) -> usize {
+        // Use epoch directory for initial bracket if available
+        let (search_start, search_end) = if !self.epoch_dir.is_empty() {
+            let mut bracket_end = self.n_records;
+            let mut bracket_start = self.epoch_dir.len() * 100 + 1;
+
+            for (i, &dir_epoch) in self.epoch_dir.iter().enumerate() {
+                if dir_epoch > et {
+                    bracket_end = (i + 1) * 100;
+                    bracket_start = i * 100 + 1;
+                    break;
+                }
+            }
+            (bracket_start, bracket_end)
+        } else {
+            (1, self.n_records)
+        };
+
+        // Linear scan within bracket (1-indexed)
+        let mut record_index = search_end;
+        for i in (search_start - 1)..search_end {
+            if self.epoch_table[i] > et {
+                record_index = i + 1;
+                break;
+            }
+        }
+
+        record_index
+    }
+
+    /// Parse a record from the flat data array
+    fn parse_record(&self, record_index: usize) -> Result<MdaRecord> {
+        let offset = (record_index - 1) * self.dlsize;
+        let rec = &self.record_data[offset..offset + self.dlsize];
+        let maxdim = self.maxdim;
+
+        let tl = rec[0];
+        let g = rec[1..1 + maxdim].to_vec();
+
+        // Reference position and velocity are interleaved:
+        // rec[maxdim+1] = x_pos, rec[maxdim+2] = x_vel
+        // rec[maxdim+3] = y_pos, rec[maxdim+4] = y_vel
+        // rec[maxdim+5] = z_pos, rec[maxdim+6] = z_vel
+        let refpos = [rec[maxdim + 1], rec[maxdim + 3], rec[maxdim + 5]];
+        let refvel = [rec[maxdim + 2], rec[maxdim + 4], rec[maxdim + 6]];
+
+        // Difference table: stored in column-major order (Fortran style)
+        // dt[component][order] with shape (MAXDIM, 3) in Fortran = 3 columns of MAXDIM each
+        let dt_flat = &rec[maxdim + 7..4 * maxdim + 7];
+        let dt_x = dt_flat[0..maxdim].to_vec();
+        let dt_y = dt_flat[maxdim..2 * maxdim].to_vec();
+        let dt_z = dt_flat[2 * maxdim..3 * maxdim].to_vec();
+
+        let kqmax1 = rec[4 * maxdim + 7] as usize;
+        let kq = [
+            rec[4 * maxdim + 8] as usize,
+            rec[4 * maxdim + 9] as usize,
+            rec[4 * maxdim + 10] as usize,
+        ];
+
+        if kqmax1 > maxdim + 1 {
+            return Err(JplephemError::InvalidFormat(format!(
+                "Type 21 KQMAX1 ({kqmax1}) exceeds MAXDIM+1 ({})",
+                maxdim + 1
+            )));
+        }
+
+        Ok(MdaRecord {
+            tl,
+            g,
+            refpos,
+            refvel,
+            dt: [dt_x, dt_y, dt_z],
+            kqmax1,
+            kq,
+        })
+    }
+
+    /// Compute position and velocity at the given epoch
+    ///
+    /// `et` is TDB seconds past J2000.
+    /// Returns (position_km, velocity_km_s).
+    pub fn compute(&self, et: f64) -> Result<(Vector3<f64>, Vector3<f64>)> {
+        let record_index = self.find_record_index(et);
+        let rec = self.parse_record(record_index)?;
+        evaluate_mda(&rec, et)
+    }
+}
+
+/// Evaluate Modified Difference Array interpolation for position and velocity
+///
+/// This implements the Shampine-Gordon recurrence as used by the NAIF SPICE
+/// toolkit and the spktype21 Python package.
+fn evaluate_mda(rec: &MdaRecord, et: f64) -> Result<(Vector3<f64>, Vector3<f64>)> {
+    let delta = et - rec.tl;
+    let kqmax1 = rec.kqmax1;
+
+    if kqmax1 < 2 {
+        return Err(JplephemError::InvalidFormat(format!(
+            "Type 21 KQMAX1 ({kqmax1}) must be >= 2"
+        )));
+    }
+
+    let mq2 = kqmax1 - 2;
+    let mut ks = kqmax1 - 1;
+
+    // Build factorial-like coefficients from the stepsize function
+    let mut fc = vec![0.0; MAXTRM + 3];
+    let mut wc = vec![0.0; MAXTRM + 3];
+    fc[0] = 1.0;
+
+    let mut tp = delta;
+    for j in 1..=mq2 {
+        if rec.g[j - 1] == 0.0 {
+            return Err(JplephemError::InvalidFormat(format!(
+                "Type 21 zero stepsize at index {j}"
+            )));
+        }
+        fc[j] = tp / rec.g[j - 1];
+        wc[j - 1] = delta / rec.g[j - 1];
+        tp = delta + rec.g[j - 1];
+    }
+
+    // Initialize W array with reciprocals
+    let mut w = vec![0.0; MAXTRM + 3];
+    for j in 1..=kqmax1 {
+        w[j - 1] = 1.0 / (j as f64);
+    }
+
+    // Compute position interpolation weights
+    let mut jx = 0usize;
+    let mut ks1 = ks as isize - 1;
+
+    while ks >= 2 {
+        jx += 1;
+        for j in 1..=jx {
+            w[j + ks - 1] = fc[j] * w[j + ks1 as usize - 1] - wc[j - 1] * w[j + ks - 1];
+        }
+        ks -= 1;
+        ks1 -= 1;
+    }
+
+    // Compute position for each component
+    let mut position = [0.0f64; 3];
+    for (i, pos) in position.iter_mut().enumerate() {
+        let kqq = rec.kq[i];
+        let mut sum = 0.0;
+        for j in (1..=kqq).rev() {
+            sum += rec.dt[i][j - 1] * w[j + ks - 1];
+        }
+        *pos = rec.refpos[i] + delta * (rec.refvel[i] + delta * sum);
+    }
+
+    // Compute velocity interpolation weights (one more reduction step)
+    for j in 1..=jx {
+        w[j + ks - 1] = fc[j] * w[j + ks1 as usize - 1] - wc[j - 1] * w[j + ks - 1];
+    }
+    ks -= 1;
+
+    // Compute velocity for each component
+    let mut velocity = [0.0f64; 3];
+    for (i, vel) in velocity.iter_mut().enumerate() {
+        let kqq = rec.kq[i];
+        let mut sum = 0.0;
+        for j in (1..=kqq).rev() {
+            sum += rec.dt[i][j - 1] * w[j + ks - 1];
+        }
+        *vel = rec.refvel[i] + delta * sum;
+    }
+
+    Ok((
+        Vector3::new(position[0], position[1], position[2]),
+        Vector3::new(velocity[0], velocity[1], velocity[2]),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal Type 21 record for testing the MDA evaluation
+    fn make_test_record(maxdim: usize) -> MdaRecord {
+        // A simple record: body at rest at (100, 200, 300) km
+        MdaRecord {
+            tl: 0.0,
+            g: vec![1.0; maxdim],
+            refpos: [100.0, 200.0, 300.0],
+            refvel: [0.0, 0.0, 0.0],
+            dt: [vec![0.0; maxdim], vec![0.0; maxdim], vec![0.0; maxdim]],
+            kqmax1: 2,
+            kq: [1, 1, 1],
+        }
+    }
+
+    #[test]
+    fn test_evaluate_mda_stationary() {
+        let rec = make_test_record(15);
+        let (pos, vel) = evaluate_mda(&rec, 0.0).unwrap();
+        assert!((pos.x - 100.0).abs() < 1e-12);
+        assert!((pos.y - 200.0).abs() < 1e-12);
+        assert!((pos.z - 300.0).abs() < 1e-12);
+        assert!(vel.x.abs() < 1e-12);
+        assert!(vel.y.abs() < 1e-12);
+        assert!(vel.z.abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_evaluate_mda_uniform_motion() {
+        // Body moving with constant velocity (10, -5, 3) km/s from (100, 200, 300)
+        // With zero difference table entries, position = refpos + delta * refvel
+        let rec = MdaRecord {
+            tl: 1000.0,
+            g: vec![1.0; 15],
+            refpos: [100.0, 200.0, 300.0],
+            refvel: [10.0, -5.0, 3.0],
+            dt: [vec![0.0; 15], vec![0.0; 15], vec![0.0; 15]],
+            kqmax1: 2,
+            kq: [1, 1, 1],
+        };
+
+        // Evaluate 10 seconds after reference epoch
+        let dt = 10.0;
+        let (pos, vel) = evaluate_mda(&rec, 1000.0 + dt).unwrap();
+
+        assert!(
+            (pos.x - (100.0 + 10.0 * dt)).abs() < 1e-10,
+            "x: {} vs {}",
+            pos.x,
+            100.0 + 10.0 * dt
+        );
+        assert!(
+            (pos.y - (200.0 - 5.0 * dt)).abs() < 1e-10,
+            "y: {} vs {}",
+            pos.y,
+            200.0 - 5.0 * dt
+        );
+        assert!(
+            (pos.z - (300.0 + 3.0 * dt)).abs() < 1e-10,
+            "z: {} vs {}",
+            pos.z,
+            300.0 + 3.0 * dt
+        );
+
+        // Velocity should be the constant refvel
+        assert!((vel.x - 10.0).abs() < 1e-10);
+        assert!((vel.y - (-5.0)).abs() < 1e-10);
+        assert!((vel.z - 3.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_evaluate_mda_at_reference_epoch() {
+        // At the reference epoch (delta=0), position should equal refpos
+        // and velocity should equal refvel regardless of difference table
+        let rec = MdaRecord {
+            tl: 5000.0,
+            g: vec![86400.0; 15],
+            refpos: [1.0e8, -2.0e7, 3.0e6],
+            refvel: [25.0, -10.0, 5.0],
+            dt: [vec![1e-5; 15], vec![2e-6; 15], vec![3e-7; 15]],
+            kqmax1: 8,
+            kq: [7, 7, 7],
+        };
+
+        let (pos, vel) = evaluate_mda(&rec, 5000.0).unwrap();
+        assert!((pos.x - 1.0e8).abs() < 1e-6);
+        assert!((pos.y - (-2.0e7)).abs() < 1e-6);
+        assert!((pos.z - 3.0e6).abs() < 1e-6);
+        assert!((vel.x - 25.0).abs() < 1e-10);
+        assert!((vel.y - (-10.0)).abs() < 1e-10);
+        assert!((vel.z - 5.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_evaluate_mda_zero_stepsize_error() {
+        let mut rec = make_test_record(15);
+        rec.kqmax1 = 4;
+        rec.kq = [3, 3, 3];
+        rec.g[0] = 0.0; // zero stepsize should cause error
+
+        let result = evaluate_mda(&rec, 1.0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_evaluate_mda_kqmax1_too_small() {
+        let mut rec = make_test_record(15);
+        rec.kqmax1 = 1; // must be >= 2
+
+        let result = evaluate_mda(&rec, 0.0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_type21_data_load_validation() {
+        // Verify that loading with invalid parameters produces errors
+        // (We can't easily construct a DAF in-memory here, so we test
+        // the record parsing and evaluation paths directly)
+        let maxdim = 15;
+        let dlsize = 4 * maxdim + 11;
+        assert_eq!(dlsize, 71);
+
+        let maxdim = 20;
+        let dlsize = 4 * maxdim + 11;
+        assert_eq!(dlsize, 91);
+    }
+
+    #[test]
+    fn test_find_record_index_small() {
+        // Test record finding with a small epoch table (no directory)
+        let data = Type21Data {
+            maxdim: 15,
+            dlsize: 71,
+            n_records: 5,
+            epoch_table: vec![100.0, 200.0, 300.0, 400.0, 500.0],
+            epoch_dir: vec![],
+            record_data: vec![0.0; 71 * 5],
+        };
+
+        // Before first epoch -> record 1
+        assert_eq!(data.find_record_index(50.0), 1);
+        // Between first and second -> record 1
+        assert_eq!(data.find_record_index(150.0), 2);
+        // Between second and third -> record 2
+        assert_eq!(data.find_record_index(250.0), 3);
+        // After all epochs -> last record
+        assert_eq!(data.find_record_index(600.0), 5);
+    }
+}

--- a/src/jplephem/tests.rs
+++ b/src/jplephem/tests.rs
@@ -1,0 +1,314 @@
+//! Tests for the jplephem module
+
+#[cfg(test)]
+mod tests {
+    use crate::jplephem::daf::DAF;
+    use crate::jplephem::errors::Result;
+    use crate::jplephem::kernel::SpiceKernel;
+    use crate::jplephem::spk::SPK;
+
+    fn test_data_path(filename: &str) -> String {
+        format!("test_data/{filename}")
+    }
+
+    #[test]
+    fn test_daf_open_de421() -> Result<()> {
+        let daf = DAF::open(test_data_path("de421.bsp"))?;
+        assert_eq!(daf.locidw, "DAF/SPK");
+        assert_eq!(daf.nd, 2);
+        assert_eq!(daf.ni, 6);
+        Ok(())
+    }
+
+    #[test]
+    fn test_daf_summaries() -> Result<()> {
+        let daf = DAF::open(test_data_path("de421.bsp"))?;
+        let summaries = daf.summaries()?;
+        assert_eq!(summaries.len(), 15, "DE421 should have 15 segments");
+        for (_name, values) in &summaries {
+            assert_eq!(
+                values.len(),
+                8,
+                "Each summary should have 8 values (2 doubles + 6 ints)"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_daf_read_array() -> Result<()> {
+        let daf = DAF::open(test_data_path("de421.bsp"))?;
+        let array = daf.read_array(1, 10)?;
+        assert_eq!(array.len(), 10);
+        // Values should not all be zero (real data)
+        assert!(
+            array.iter().any(|&v| v != 0.0),
+            "Array should contain non-zero data"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_daf_map_array_matches_read_array() -> Result<()> {
+        let daf = DAF::open(test_data_path("de421.bsp"))?;
+        let arr1 = daf.read_array(1, 100)?;
+        let arr2 = daf.map_array(1, 100)?;
+        assert_eq!(arr1.len(), arr2.len());
+        for (a, b) in arr1.iter().zip(arr2.iter()) {
+            assert_eq!(a, b);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_de421_load() -> Result<()> {
+        let spk = SPK::open(test_data_path("de421.bsp"))?;
+        assert_eq!(spk.daf.locidw, "DAF/SPK");
+        assert_eq!(spk.segments.len(), 15, "DE421 should have 15 segments");
+        Ok(())
+    }
+
+    #[test]
+    fn test_de421_date_range() -> Result<()> {
+        let spk = SPK::open(test_data_path("de421.bsp"))?;
+        let min_jd = spk
+            .segments
+            .iter()
+            .map(|s| s.start_jd)
+            .fold(f64::MAX, f64::min);
+        let max_jd = spk
+            .segments
+            .iter()
+            .map(|s| s.end_jd)
+            .fold(f64::MIN, f64::max);
+        assert!(
+            (min_jd - 2414864.50).abs() < 0.01,
+            "Expected start ~2414864.50, got {min_jd}"
+        );
+        assert!(
+            (max_jd - 2471184.50).abs() < 0.01,
+            "Expected end ~2471184.50, got {max_jd}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_de421_segment_ids() -> Result<()> {
+        let spk = SPK::open(test_data_path("de421.bsp"))?;
+
+        let expected_pairs = [
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (0, 4),
+            (0, 5),
+            (0, 6),
+            (0, 7),
+            (0, 8),
+            (0, 9),
+            (0, 10),
+            (3, 301),
+            (3, 399),
+            (1, 199),
+            (2, 299),
+            (4, 499),
+        ];
+
+        for (center, target) in expected_pairs {
+            assert!(
+                spk.segments
+                    .iter()
+                    .any(|s| s.center == center && s.target == target),
+                "Missing segment center={center}, target={target}"
+            );
+        }
+        assert_eq!(spk.segments.len(), expected_pairs.len());
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_segment() -> Result<()> {
+        let spk = SPK::open(test_data_path("de421.bsp"))?;
+        let seg = spk.get_segment(3, 301)?;
+        assert_eq!(seg.center, 3);
+        assert_eq!(seg.target, 301);
+        assert!(spk.get_segment(999, 999).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_compute_returns_nonzero() -> Result<()> {
+        let mut spk = SPK::open(test_data_path("de421.bsp"))?;
+        // Earth barycenter at J2000 (TDB seconds = 0)
+        let seg = spk.get_segment_mut(0, 3)?;
+        let pos = seg.compute(0.0, 0.0)?;
+        assert!(
+            pos.x != 0.0 || pos.y != 0.0 || pos.z != 0.0,
+            "Position should be nonzero"
+        );
+        assert!(pos.x.is_finite() && pos.y.is_finite() && pos.z.is_finite());
+        Ok(())
+    }
+
+    #[test]
+    fn test_compute_and_differentiate_returns_nonzero() -> Result<()> {
+        let mut spk = SPK::open(test_data_path("de421.bsp"))?;
+        let seg = spk.get_segment_mut(0, 3)?;
+        let (pos, vel) = seg.compute_and_differentiate(0.0, 0.0)?;
+        assert!(pos.norm() > 0.0, "Position should be nonzero");
+        assert!(vel.norm() > 0.0, "Velocity should be nonzero");
+        assert!(pos.x.is_finite() && pos.y.is_finite() && pos.z.is_finite());
+        assert!(vel.x.is_finite() && vel.y.is_finite() && vel.z.is_finite());
+        Ok(())
+    }
+
+    #[test]
+    fn test_out_of_range_error() -> Result<()> {
+        let mut spk = SPK::open(test_data_path("de421.bsp"))?;
+        let seg = spk.get_segment_mut(0, 3)?;
+        // Way in the future — should fail
+        let result = seg.compute(1e15, 0.0);
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_major_segments_compute_at_j2000() -> Result<()> {
+        let mut spk = SPK::open(test_data_path("de421.bsp"))?;
+        // Test the main planet barycenter segments (these all cover J2000)
+        let pairs = [
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (0, 4),
+            (0, 5),
+            (0, 6),
+            (0, 7),
+            (0, 8),
+            (0, 9),
+            (0, 10),
+            (3, 301),
+            (3, 399),
+        ];
+        for (center, target) in pairs {
+            let seg = spk.get_segment_mut(center, target)?;
+            let (pos, vel) = seg.compute_and_differentiate(0.0, 0.0)?;
+            assert!(
+                pos.norm() > 0.0,
+                "Segment ({center}->{target}) position should be nonzero at J2000"
+            );
+            assert!(
+                vel.norm() > 0.0,
+                "Segment ({center}->{target}) velocity should be nonzero at J2000"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_kernel_chain_resolution() -> Result<()> {
+        let kernel = SpiceKernel::open(test_data_path("de421.bsp"))?;
+
+        // Earth should have a 2-segment chain: SSB->EMB + EMB->Earth
+        let earth = kernel.get("earth")?;
+        assert_eq!(earth.chain.len(), 2);
+        assert_eq!(earth.chain[0], (0, 3));
+        assert_eq!(earth.chain[1], (3, 399));
+
+        // Moon: SSB->EMB + EMB->Moon
+        let moon = kernel.get("moon")?;
+        assert_eq!(moon.chain.len(), 2);
+        assert_eq!(moon.chain[0], (0, 3));
+        assert_eq!(moon.chain[1], (3, 301));
+
+        // Sun: directly SSB->Sun
+        let sun = kernel.get("sun")?;
+        assert_eq!(sun.chain.len(), 1);
+        assert_eq!(sun.chain[0], (0, 10));
+
+        // Mars: SSB->Mars Barycenter + Mars Barycenter->Mars
+        let mars = kernel.get("mars")?;
+        assert_eq!(mars.chain.len(), 2);
+        assert_eq!(mars.chain[0], (0, 4));
+        assert_eq!(mars.chain[1], (4, 499));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_kernel_compute_at_jd() -> Result<()> {
+        let mut kernel = SpiceKernel::open(test_data_path("de421.bsp"))?;
+        let state = kernel.compute_at_jd("earth", 2451545.0)?; // J2000
+
+        // Earth should be roughly 1 AU from SSB
+        let dist_au =
+            (state.position.x.powi(2) + state.position.y.powi(2) + state.position.z.powi(2)).sqrt();
+        assert!(
+            dist_au > 0.9 && dist_au < 1.1,
+            "Earth should be ~1 AU from SSB, got {dist_au}"
+        );
+
+        // Velocity should be roughly 30 km/s ≈ 0.0173 AU/day
+        let speed_au_day = state.velocity.norm();
+        assert!(
+            speed_au_day > 0.01 && speed_au_day < 0.03,
+            "Earth orbital speed should be ~0.017 AU/day, got {speed_au_day}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_kernel_numeric_id_lookup() -> Result<()> {
+        let kernel = SpiceKernel::open(test_data_path("de421.bsp"))?;
+        let earth = kernel.get("399")?;
+        assert_eq!(earth.target_id, 399);
+        Ok(())
+    }
+
+    #[test]
+    fn test_segment_describe() -> Result<()> {
+        let spk = SPK::open(test_data_path("de421.bsp"))?;
+        let desc = spk.segments[0].describe(false);
+        // Should contain date range and body names
+        assert!(!desc.is_empty());
+        assert!(desc.contains(".."));
+        Ok(())
+    }
+
+    #[test]
+    fn test_comments() -> Result<()> {
+        let spk = SPK::open(test_data_path("de421.bsp"))?;
+        // Just verify it doesn't crash — comment content varies
+        let _ = spk.comments();
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_bytes_matches_file() -> Result<()> {
+        let data = std::fs::read(test_data_path("de421.bsp")).unwrap();
+        let mut kernel = SpiceKernel::from_bytes(&data)?;
+
+        // Verify segment count matches file-based loading
+        assert_eq!(kernel.spk().segments.len(), 15);
+
+        // Verify computed positions match file-based loading
+        let state = kernel.compute_at_jd("earth", 2451545.0)?;
+        let dist_au =
+            (state.position.x.powi(2) + state.position.y.powi(2) + state.position.z.powi(2)).sqrt();
+        assert!(
+            dist_au > 0.9 && dist_au < 1.1,
+            "Earth should be ~1 AU from SSB, got {dist_au}"
+        );
+
+        // Compare with file-based kernel
+        let mut file_kernel = SpiceKernel::open(test_data_path("de421.bsp"))?;
+        let file_state = file_kernel.compute_at_jd("earth", 2451545.0)?;
+
+        assert_eq!(state.position.x, file_state.position.x);
+        assert_eq!(state.position.y, file_state.position.y);
+        assert_eq!(state.position.z, file_state.position.z);
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub mod errors;
 pub mod framelib;
 pub mod horizons;
 pub mod image;
-pub use starfield_jplephem as jplephem;
+pub mod jplephem;
 pub mod jplephem_ext;
 pub mod keplerlib;
 pub mod magnitudelib;


### PR DESCRIPTION
## Summary
- Brings jplephem back as `src/jplephem/` module instead of depending on external `starfield-jplephem` crate
- Removes the git dependency that blocked `cargo publish`
- Bumps version to 0.10.2 (already published to crates.io)

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `cargo clippy` clean
- [x] `cargo publish` succeeded