### PR TITLE
Bump version to 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.1
+
+- Add `MinimalCatalog::load_with_progress` progress-callback hook for large catalog loads (#110)
+
 ## 0.11.0
 
 - Reintegrate jplephem as an internal module (removes external crate dependency)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starfield"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 authors = ["Matthew Goodman"]
 description = "Astronomical data reduction toolkit with star catalogs, coordinate systems, and star finding algorithms (inspired by skyfield)"


### PR DESCRIPTION
Patch release containing the new `MinimalCatalog::load_with_progress` hook from #111.