### PR TITLE
Add stop-ai PR attribution check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,12 @@
+name: PR Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-attribution:
+    name: Check AI Attribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: meawoppl/stop-ai@main

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -9,4 +9,4 @@ jobs:
     name: Check AI Attribution
     runs-on: ubuntu-latest
     steps:
-      - uses: meawoppl/stop-ai@main
+      - uses: meawoppl/stop-ai@v1


### PR DESCRIPTION
Adds the PR attribution check workflow, pinned to v1. Runs on every pull request and enforces the org attribution policy centrally.