### PR TITLE
Bump version to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.12.0
+
+- Add `photometry` Cargo feature, off by default (#115, #116, #117)
+- Add `Photometry` trait + `Band` enum for per-band fluxes / extinction / k-correction (#115)
+- Add `RadialProfile` trait for measured azimuthally-averaged surface brightness (#116)
+- Add `IsophoteSeries` trait + `IsophoteSample` for radius-resolved axis ratio + position angle (#117)
+- Add `SersicProfile::b_n` and `SersicProfile::surface_brightness_at` Sérsic evaluator, cross-validated against `astropy.modeling.Sersic2D` (#122)
+
 ## 0.11.1
 
 - Add `MinimalCatalog::load_with_progress` progress-callback hook for large catalog loads (#110)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starfield"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 authors = ["Matthew Goodman"]
 description = "Astronomical data reduction toolkit with star catalogs, coordinate systems, and star finding algorithms (inspired by skyfield)"


### PR DESCRIPTION
Minor release bundling the new `photometry` feature: `Photometry` / `Band` (#115, PR #118), `RadialProfile` (#116, PR #119), `IsophoteSeries` (#117, PR #120), plus the `SersicProfile` evaluator (#122).