### PR TITLE
Security cleanup: 4 vulns → 0, 5 warnings → 3 + bump to 0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.12.3
+
+- Security cleanup. `cargo audit` count drops from **4 vulnerabilities + 5 warnings** to **0 vulnerabilities + 3 warnings**:
+  - Update `rustls-webpki` 0.103.10 → 0.103.13 — clears three vulnerabilities (CRL panic, wildcard / URI name-constraint bypasses) via transitive bump in the `reqwest` chain.
+  - Disable default features on `image`, enable only `png` + `jpeg` — prunes the `rav1e → {core2, rand 0.9, paste}` AVIF subtree that triggered three unmaintained-crate warnings. AVIF decode/encode is no longer available through `starfield`; consumers can enable it on their own `image` dep.
+  - Bump `pyo3` 0.19 → 0.24 and `numpy` 0.19 → 0.24 — clears `RUSTSEC-2025-0020` (`PyString::from_object` buffer overflow), affected only the `python-tests` dev feature. Bridge migrated to `Bound<'py, T>` / `&CStr` / `bind()` shapes.
+
 ## 0.12.2
 
 - `Timescale` now wraps `Arc<TimescaleInner>` internally so cloning a `Timescale` (or a `Time` that holds one) is a refcount bump rather than a deep copy of the delta-T / leap-second / polar-motion tables. Unblocks embedding `Time` as a field in row-like structures (catalog records, indexes). `set_polar_motion_table` uses `Arc::make_mut` for copy-on-write so pre-existing `Time`s see the pre-mutation table (#134).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starfield"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 authors = ["Matthew Goodman"]
 description = "Astronomical data reduction toolkit with star catalogs, coordinate systems, and star finding algorithms (inspired by skyfield)"
@@ -48,13 +48,16 @@ base64 = "0.22.1"
 indicatif = "0.17.11"  # Progress bars and indicators
 
 # Image processing
-image = "0.25"
+# Minimal feature set: AVIF (default) drags in rav1e → {core2, rand 0.9, paste}
+# — three of cargo-audit's warnings come from there and we don't decode AVIF.
+# Consumers that need additional formats can enable them in their own deps.
+image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 
 # Python comparison tests
 # These dependencies are only active when the python-tests feature is enabled
 anyhow = { version = "1.0", optional = true }
-pyo3 = { version = "0.19", optional = true } # Python bindings for testing against Python implementation
-numpy = { version = "0.19", optional = true }
+pyo3 = { version = "0.24", optional = true } # Python bindings for testing against Python implementation
+numpy = { version = "0.24", optional = true }
 once_cell = "1.21.3"
 clap = { version = "4.5.40", features = ["derive"] }
 memmap2 = "0.9"

--- a/src/pybridge/bridge.rs
+++ b/src/pybridge/bridge.rs
@@ -5,9 +5,11 @@
 
 use crate::pybridge::helpers::BridgeError;
 use pyo3::{
+    ffi::c_str,
     prelude::*,
-    types::{PyDict, PyList},
+    types::{PyAnyMethods, PyDict, PyList},
 };
+use std::ffi::CString;
 
 /// Python-Rust bridge for testing against the Python Skyfield implementation
 pub struct PyRustBridge {
@@ -40,15 +42,20 @@ impl PyRustBridge {
     /// Run Python code and return the result as a JSON value
     pub fn run_py_to_json(&self, code: &str) -> Result<String, BridgeError> {
         Python::with_gil(|py| {
-            let globals = self.py_globals.as_ref(py);
+            let globals = self.py_globals.bind(py);
 
             // load the helper code
             let helper_code = get_helper_code();
 
-            let get_result_code = "_result = rust.get_result()";
+            let get_result_code = c_str!("_result = rust.get_result()");
 
-            for code_block in [helper_code, code, get_result_code] {
-                println!("Running code block: \n{}", code_block);
+            // pyo3 0.24's `Python::run` takes `&CStr` rather than `&str` so
+            // pre-converted constants live longer than any temporary.
+            let helper_c = CString::new(helper_code).expect("helper.py contains a NUL byte");
+            let code_c = CString::new(code).expect("user-provided code contains a NUL byte");
+
+            for code_block in [helper_c.as_c_str(), code_c.as_c_str(), get_result_code] {
+                println!("Running code block: \n{}", code_block.to_string_lossy());
                 match py.run(code_block, Some(globals), None) {
                     Ok(_) => {}
                     Err(e) => {
@@ -60,7 +67,7 @@ impl PyRustBridge {
             }
 
             // Check if there's a result variable defined
-            match globals.get_item("_result") {
+            match globals.get_item("_result")? {
                 Some(value) => {
                     if let Ok(value) = value.extract::<String>() {
                         Ok(value)
@@ -82,7 +89,10 @@ impl PyRustBridge {
 fn format_py_error(py: Python, error: &PyErr) -> String {
     // Get exception type and message
     let exc_type = error.get_type(py);
-    let exc_name = exc_type.name().unwrap_or("Unknown");
+    let exc_name = match exc_type.name() {
+        Ok(name) => name.to_string(),
+        Err(_) => String::from("Unknown"),
+    };
 
     // Get value and traceback as strings if available
     let value = match error.value(py).str() {


### PR DESCRIPTION
\`cargo audit\` drops from **4 vulnerabilities + 5 unmaintained-crate warnings** to **0 vulnerabilities + 3 unmaintained warnings**. All three changes are surgical.

## What's in

**1. \`rustls-webpki\` 0.103.10 → 0.103.13** (pure \`cargo update\`)

Clears three vulnerabilities pulled in via reqwest:
- RUSTSEC-2026-0104: reachable panic in CRL parsing
- RUSTSEC-2026-0099: wildcard name-constraint bypass
- RUSTSEC-2026-0098: URI name-constraint bypass

**2. \`image\`: disable defaults, enable only \`png\` + \`jpeg\`**

\`image 0.25\` with default features pulls AVIF via \`ravif → rav1e\`, which drags \`rand 0.9\`, \`paste\`, and \`core2\` in as transitive deps — three of cargo-audit's unmaintained warnings + the publish-time \`core2\`-yanked warning. starfield itself doesn't decode AVIF; the only image consumer is \`examples/starfinders_demo\` (PNG / JPEG round-trips). Consumers that need AVIF can enable it on their own \`image\` dep.

**3. \`pyo3\` + \`numpy\` 0.19 → 0.24**

Clears RUSTSEC-2025-0020 (PyString::from_object buffer overflow), scoped to the \`python-tests\` dev feature only. Bridge migrated to pyo3 0.24 shapes:
- \`Py::as_ref(py)\` → \`Py::bind(py)\`
- \`py.run(&str, ...)\` → \`py.run(&CStr, ...)\` (helper code + user code converted via \`CString\`; constant 'get result' block uses \`c_str!\`)
- \`globals.get_item\` now returns \`Result<Option<_>>\`, propagate with \`?\`
- \`error.get_type(py).name()\` now returns \`Result<Bound<PyString>>\`

## What's still warning (informational)

- \`number_prefix\` (via \`indicatif\`) — unmaintained
- \`paste\` (via \`nalgebra → simba\`) — unmaintained
- \`rand\` 0.9.2 — narrow unsoundness advisory for custom-logger usage; we don't trigger it

All three are transitive through major deps; no upstream patched version exists yet. Would need a \`nalgebra\` / \`indicatif\` major bump to clear and that's out of scope for a security PR.

## Verification

- [x] \`cargo audit\` — 0 vulnerabilities (was 4)
- [x] \`cargo build\` clean
- [x] \`cargo build --features python-tests\` clean
- [x] \`cargo clippy --lib -- -D warnings\` clean
- [x] \`cargo test --lib\` — **464/464 pass**, no regressions
- [x] \`cargo test --features python-tests pybridge\` — 6/6 pass under pyo3 0.24
- [x] AstroPy Sérsic2D bridge test (\`test_surface_brightness_at_matches_astropy_sersic2d_via_bridge\`) — passes end-to-end with the new pyo3 + numpy