### PR TITLE
Bump version to 0.12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.5
+
+- Add `ProperMotion { pmra, pmdec }` struct (mas/yr, Gaia DR3 convention: `pmra` carries cos(dec), `pmdec` is a plain Dec rate). Lives in `framelib::inertial` next to `Equatorial`; re-exported through `coordinates` and the crate root so callers write `starfield::ProperMotion`. Includes `ZERO` const, `new()`, `magnitude()`, serde derives (#136)
+
 ## 0.12.4
 
 - `Time` is now `Send + Sync`. The lazy UT1 / TDB / delta-T caches were `Cell<Option<f64>>` (interior-mutable, single-threaded only); they're now `OnceLock<f64>`, which provides identical set-once cache semantics while making `Time` safe to share across threads. Unblocks embedding `Time` in `Arc<…>`-shared row structs (catalog records, indexes). Adds a compile-time `Send + Sync` assertion and a concurrent `tdb()` / `ut1()` / `delta_t()` consistency test as regression guards (#138).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starfield"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2021"
 authors = ["Matthew Goodman"]
 description = "Astronomical data reduction toolkit with star catalogs, coordinate systems, and star finding algorithms (inspired by skyfield)"


### PR DESCRIPTION
Patch release shipping the `ProperMotion` struct from #140 (closes #136).