### PR TITLE
Upgrade ndarray 0.16 → 0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.13.0
+
+- Upgrade `ndarray` 0.16 → 0.17 (#148). Semver-incompatible for consumers of starfield's ndarray-typed catalog/`StarData` APIs, hence a minor bump.
+- Drop the unused `numpy` Rust crate dependency so the whole package — including the `python-tests` feature — resolves to a single ndarray 0.17 (it was the last pin holding 0.16). Python-side numpy is unaffected; it is reached via the pybridge.
+
 ## 0.12.6
 
 - Add serde derives for `SersicProfile` and `StarData` so downstream consumers can serialize catalog primitives directly (#143)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starfield"
-version = "0.12.6"
+version = "0.13.0"
 edition = "2021"
 authors = ["Matthew Goodman"]
 description = "Astronomical data reduction toolkit with star catalogs, coordinate systems, and star finding algorithms (inspired by skyfield)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ nalgebra = "0.32"           # Linear algebra
 time = "0.3"                # Time handling
 num = "0.4"                 # Numerical types
 lazy_static = "1.4"         # Lazy initialization
-ndarray = "0.16.1"            # N-dimensional arrays
+ndarray = "0.17"            # N-dimensional arrays
 
 # Data handling
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 # These dependencies are only active when the python-tests feature is enabled
 anyhow = { version = "1.0", optional = true }
 pyo3 = { version = "0.24", optional = true } # Python bindings for testing against Python implementation
-numpy = { version = "0.24", optional = true }
 once_cell = "1.21.3"
 clap = { version = "4.5.40", features = ["derive"] }
 memmap2 = "0.9"
@@ -73,7 +72,7 @@ tempfile = "3.8"  # Temporary file creation for tests
 # Dev dependencies
 
 [features]
-python-tests = ["pyo3", "numpy", "anyhow"]
+python-tests = ["pyo3", "anyhow"]
 # Optional traits for per-band photometry, measured radial surface-brightness
 # profiles, and isophote shape series. Gated behind a feature so consumers
 # that only need positions/magnitudes don't pay for the larger trait surface.


### PR DESCRIPTION
Upgrades `ndarray` from 0.16.1 to 0.17 so downstream consumers can unify their workspace on ndarray 0.17.

Closes #147

## Changes
- `Cargo.toml`: `ndarray = "0.16.1"` → `ndarray = "0.17"`
- Drop the unused `numpy` Rust crate dependency. It was never referenced from Rust (`import numpy as np` in tests is Python run through the pybridge against the *pip* numpy, not the crate), and it was the only remaining pin holding `ndarray 0.16` in the tree under the `python-tests` feature.

## Result
A single `ndarray 0.17.2` across the **entire** package, including `python-tests`:
```
cargo tree -i ndarray                    -> ndarray v0.17.2
cargo tree -i ndarray --features python-tests -> ndarray v0.17.2
```

## Validation
- `cargo build` — clean
- `cargo test` — 471 passed, 0 failed
- `cargo clippy` — clean
- `cargo check --features python-tests` — clean
- No source changes needed; the 0.16→0.17 API surface we use is unchanged.

## Notes
- `0.16 → 0.17` is semver-incompatible. A patch release will be cut after merge.