### PR TITLE
Add synthetic orbit populations and SBDB snapshot diffing

### DIFF
--- a/src/catalogs/mod.rs
+++ b/src/catalogs/mod.rs
@@ -28,6 +28,7 @@ pub use minimal_catalog::{MinimalCatalog, MinimalStar, ProgressUpdate};
 pub use photometry::{Band, Photometry};
 #[cfg(feature = "photometry")]
 pub use radial_profile::RadialProfile;
+pub use synthetic::orbits::{InclinationModel, SyntheticOrbit, SyntheticOrbitPopulation};
 pub use synthetic::{
     create_fov_catalog, create_synthetic_catalog, MagnitudeDistribution, SpatialDistribution,
     SyntheticCatalogConfig,

--- a/src/catalogs/synthetic/mod.rs
+++ b/src/catalogs/synthetic/mod.rs
@@ -4,6 +4,11 @@
 //! for testing and development purposes. It uses statistical models of actual
 //! stellar magnitude and spatial distributions to create catalogs that
 //! approximate real-world astronomical data.
+//!
+//! The [`orbits`] submodule provides the small-body counterpart: seeded
+//! synthetic populations of heliocentric orbital elements.
+
+pub mod orbits;
 
 use rand::distr::{Distribution, Uniform};
 use rand::rngs::StdRng;

--- a/src/catalogs/synthetic/orbits.rs
+++ b/src/catalogs/synthetic/orbits.rs
@@ -1,0 +1,523 @@
+//! Synthetic small-body orbital population generators.
+//!
+//! The solar-system counterpart to the synthetic *star* generators in the
+//! parent module: seeded, reproducible populations of heliocentric orbital
+//! elements for injection/recovery testing, survey-bias studies, and
+//! dynamical experiments. The default configuration reproduces the
+//! scattered-disk/ETNO populations used in the Planet Nine literature
+//! (Batygin & Brown 2016; Khain et al. 2018).
+//!
+//! # Distributions
+//!
+//! Each generated orbit is drawn independently:
+//!
+//! - **Semi-major axis `a` and perihelion `q`**: uniform on the `q <= a`
+//!   wedge of the `[a_min, a_max] x [q_min, q_max]` rectangle. Eccentricity
+//!   follows as `e = 1 - q/a`.
+//! - **Inclination `i`**: one of [`InclinationModel::Planar`] (`i = 0`),
+//!   [`InclinationModel::HalfNormal`] (`|N(0, sigma)|`), or
+//!   [`InclinationModel::Rayleigh`] (the classic Brown 2001 debiased
+//!   Kuiper-belt form).
+//! - **Angles `Ω`, `ω`, `M`**: independent and uniform on `[0°, 360°)`.
+//!
+//! # Deterministic-N resampling
+//!
+//! Invalid `(a, q)` draws with `q > a` are *resampled in a loop*, never
+//! silently skipped, so `generate` always returns exactly `count` records
+//! for a given seed. (A skip-on-invalid loop returns fewer records than
+//! requested with the same wedge-shaped bias, just undocumented.)
+//!
+//! # Example
+//!
+//! ```
+//! use rand::rngs::StdRng;
+//! use rand::SeedableRng;
+//! use starfield::catalogs::synthetic::orbits::SyntheticOrbitPopulation;
+//!
+//! let mut rng = StdRng::seed_from_u64(42);
+//! let population = SyntheticOrbitPopulation::scattered_disk()
+//!     .with_count(100)
+//!     .generate(&mut rng)
+//!     .unwrap();
+//!
+//! assert_eq!(population.len(), 100);
+//! for orbit in &population {
+//!     assert!(orbit.perihelion() <= orbit.a);
+//!     assert!(orbit.e >= 0.0 && orbit.e < 1.0);
+//! }
+//! ```
+
+use rand::Rng;
+
+use crate::keplerlib::{mpcorb_orbit, KeplerOrbit};
+use crate::time::Time;
+use crate::{Result, StarfieldError};
+
+/// One synthetic heliocentric orbit as classical Keplerian elements.
+///
+/// Follows the JPL SBDB conventions used by [`crate::sbdb::SmallBodyOrbit`]:
+/// distances in AU, angles in degrees.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SyntheticOrbit {
+    /// Semi-major axis (AU)
+    pub a: f64,
+    /// Eccentricity
+    pub e: f64,
+    /// Inclination (degrees)
+    pub i_deg: f64,
+    /// Longitude of ascending node Ω (degrees)
+    pub omega_big_deg: f64,
+    /// Argument of perihelion ω (degrees)
+    pub omega_deg: f64,
+    /// Mean anomaly M (degrees)
+    pub mean_anomaly_deg: f64,
+}
+
+impl SyntheticOrbit {
+    /// Perihelion distance `q = a(1 - e)` in AU.
+    pub fn perihelion(&self) -> f64 {
+        self.a * (1.0 - self.e)
+    }
+
+    /// Aphelion distance `Q = a(1 + e)` in AU.
+    pub fn aphelion(&self) -> f64 {
+        self.a * (1.0 + self.e)
+    }
+
+    /// Longitude of perihelion `ϖ = ω + Ω` in degrees, wrapped to `[0°, 360°)`.
+    pub fn longitude_of_perihelion_deg(&self) -> f64 {
+        (self.omega_deg + self.omega_big_deg).rem_euclid(360.0)
+    }
+
+    /// Convert to a propagatable [`KeplerOrbit`].
+    ///
+    /// The elements are interpreted in the ecliptic frame (the MPC/SBDB
+    /// convention); the returned orbit carries the ecliptic-to-equatorial
+    /// rotation, exactly like [`mpcorb_orbit`]. `gm_km3_s2` is the central
+    /// body's GM in km³/s² (use [`crate::constants::GM_SUN`] for
+    /// heliocentric orbits).
+    ///
+    /// ```
+    /// use rand::rngs::StdRng;
+    /// use rand::SeedableRng;
+    /// use starfield::catalogs::synthetic::orbits::SyntheticOrbitPopulation;
+    /// use starfield::constants::GM_SUN;
+    /// use starfield::time::Timescale;
+    ///
+    /// let ts = Timescale::default();
+    /// let epoch = ts.tt_jd(2451545.0, None);
+    /// let mut rng = StdRng::seed_from_u64(7);
+    /// let population = SyntheticOrbitPopulation::scattered_disk()
+    ///     .with_count(3)
+    ///     .generate(&mut rng)
+    ///     .unwrap();
+    ///
+    /// let orbit = population[0].to_kepler_orbit(&epoch, GM_SUN, Some("synthetic-0"));
+    /// let position = orbit.at(&epoch);
+    /// ```
+    pub fn to_kepler_orbit(
+        &self,
+        epoch: &Time,
+        gm_km3_s2: f64,
+        target_name: Option<&str>,
+    ) -> KeplerOrbit {
+        mpcorb_orbit(
+            self.a,
+            self.e,
+            self.i_deg,
+            self.omega_big_deg,
+            self.omega_deg,
+            self.mean_anomaly_deg,
+            epoch,
+            gm_km3_s2,
+            target_name,
+        )
+    }
+}
+
+/// Inclination distribution for a synthetic population.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum InclinationModel {
+    /// All orbits in the reference plane (`i = 0`), for planar
+    /// phase-space studies.
+    Planar,
+    /// Half-normal: `i = |N(0, sigma)|`. The form used by the Planet Nine
+    /// scattered-disk simulations (e.g. Batygin & Brown 2016 with
+    /// `sigma_deg = 15`). Mean inclination is `sigma * sqrt(2/pi)`.
+    HalfNormal {
+        /// Standard deviation of the underlying normal (degrees).
+        sigma_deg: f64,
+    },
+    /// Rayleigh: `p(i) di ∝ i exp(-i²/2sigma²) di`, the standard debiased
+    /// Kuiper-belt inclination form (Brown 2001). Mean inclination is
+    /// `sigma * sqrt(pi/2)`.
+    Rayleigh {
+        /// Rayleigh scale parameter (degrees).
+        sigma_deg: f64,
+    },
+}
+
+/// Builder-style generator for synthetic small-body orbital populations.
+///
+/// See the [module docs](self) for the sampled distributions and the
+/// deterministic-N resampling guarantee. Defaults (via
+/// [`SyntheticOrbitPopulation::scattered_disk`] or `Default`) reproduce the
+/// Batygin & Brown (2016) scattered-disk test-particle population:
+/// `a` uniform in 150–550 AU, `q` uniform in 30–50 AU, half-normal
+/// inclination with `sigma = 15°`.
+///
+/// ```
+/// use rand::rngs::StdRng;
+/// use rand::SeedableRng;
+/// use starfield::catalogs::synthetic::orbits::{InclinationModel, SyntheticOrbitPopulation};
+///
+/// let mut rng = StdRng::seed_from_u64(1);
+/// let belt = SyntheticOrbitPopulation::new()
+///     .with_count(50)
+///     .with_semi_major_axis_range(39.0, 48.0)
+///     .with_perihelion_range(32.0, 45.0)
+///     .with_inclination(InclinationModel::Rayleigh { sigma_deg: 12.0 })
+///     .generate(&mut rng)
+///     .unwrap();
+/// assert_eq!(belt.len(), 50);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SyntheticOrbitPopulation {
+    /// Number of orbits to generate (always met exactly).
+    pub count: usize,
+    /// Semi-major axis minimum (AU).
+    pub a_min: f64,
+    /// Semi-major axis maximum (AU).
+    pub a_max: f64,
+    /// Perihelion distance minimum (AU).
+    pub q_min: f64,
+    /// Perihelion distance maximum (AU).
+    pub q_max: f64,
+    /// Inclination distribution.
+    pub inclination: InclinationModel,
+}
+
+impl Default for SyntheticOrbitPopulation {
+    fn default() -> Self {
+        Self {
+            count: 100,
+            a_min: 150.0,
+            a_max: 550.0,
+            q_min: 30.0,
+            q_max: 50.0,
+            inclination: InclinationModel::HalfNormal { sigma_deg: 15.0 },
+        }
+    }
+}
+
+impl SyntheticOrbitPopulation {
+    /// New generator with the scattered-disk defaults (see type docs).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The Batygin & Brown (2016) scattered-disk/ETNO population: `a`
+    /// uniform in 150–550 AU, `q` uniform in 30–50 AU, half-normal
+    /// inclination with `sigma = 15°`. Identical to [`Self::new`]; named
+    /// for discoverability.
+    pub fn scattered_disk() -> Self {
+        Self::default()
+    }
+
+    /// Set the number of orbits to generate.
+    pub fn with_count(mut self, count: usize) -> Self {
+        self.count = count;
+        self
+    }
+
+    /// Set the semi-major axis range (AU).
+    pub fn with_semi_major_axis_range(mut self, a_min: f64, a_max: f64) -> Self {
+        self.a_min = a_min;
+        self.a_max = a_max;
+        self
+    }
+
+    /// Set the perihelion distance range (AU).
+    pub fn with_perihelion_range(mut self, q_min: f64, q_max: f64) -> Self {
+        self.q_min = q_min;
+        self.q_max = q_max;
+        self
+    }
+
+    /// Set the inclination distribution.
+    pub fn with_inclination(mut self, model: InclinationModel) -> Self {
+        self.inclination = model;
+        self
+    }
+
+    /// Validate the configuration without generating.
+    ///
+    /// Errors if a range is inverted or non-positive, if an inclination
+    /// scale is negative, or if `q_min >= a_max` (the `q <= a` acceptance
+    /// region would be empty and resampling could never terminate).
+    pub fn validate(&self) -> Result<()> {
+        let err = |msg: String| Err(StarfieldError::DataError(msg));
+        // Written so NaN bounds also fail validation.
+        let range_ok = |lo: f64, hi: f64| lo > 0.0 && lo <= hi;
+        if !range_ok(self.a_min, self.a_max) {
+            return err(format!(
+                "invalid semi-major axis range [{}, {}] AU: need 0 < a_min <= a_max",
+                self.a_min, self.a_max
+            ));
+        }
+        if !range_ok(self.q_min, self.q_max) {
+            return err(format!(
+                "invalid perihelion range [{}, {}] AU: need 0 < q_min <= q_max",
+                self.q_min, self.q_max
+            ));
+        }
+        if self.q_min >= self.a_max {
+            return err(format!(
+                "empty (a, q) wedge: q_min = {} AU >= a_max = {} AU, no draw can satisfy q <= a",
+                self.q_min, self.a_max
+            ));
+        }
+        match self.inclination {
+            InclinationModel::Planar => {}
+            InclinationModel::HalfNormal { sigma_deg }
+            | InclinationModel::Rayleigh { sigma_deg } => {
+                // NaN also fails here.
+                let sigma_ok = sigma_deg >= 0.0;
+                if !sigma_ok {
+                    return err(format!("inclination sigma must be >= 0, got {sigma_deg}"));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Generate the population.
+    ///
+    /// Returns exactly [`count`](Self::count) orbits: invalid `(a, q)`
+    /// draws with `q > a` are resampled, not skipped, so the output is
+    /// uniform on the `q <= a` wedge of the configured rectangle and the
+    /// count is deterministic for a given seed.
+    pub fn generate<R: Rng + ?Sized>(&self, rng: &mut R) -> Result<Vec<SyntheticOrbit>> {
+        self.validate()?;
+
+        let mut orbits = Vec::with_capacity(self.count);
+        for _ in 0..self.count {
+            // Resample (not skip) invalid q > a draws — see module docs.
+            let (a, e) = loop {
+                let a = uniform(rng, self.a_min, self.a_max);
+                let q = uniform(rng, self.q_min, self.q_max);
+                if q <= a {
+                    // e = 1 - q/a in [0, 1); q >= q_min > 0 keeps e < 1.
+                    break (a, 1.0 - q / a);
+                }
+            };
+
+            let i_deg = match self.inclination {
+                InclinationModel::Planar => 0.0,
+                InclinationModel::HalfNormal { sigma_deg } => {
+                    sigma_deg * standard_normal(rng).abs()
+                }
+                InclinationModel::Rayleigh { sigma_deg } => sigma_deg * rayleigh_unit(rng),
+            };
+
+            orbits.push(SyntheticOrbit {
+                a,
+                e,
+                i_deg,
+                omega_big_deg: uniform(rng, 0.0, 360.0),
+                omega_deg: uniform(rng, 0.0, 360.0),
+                mean_anomaly_deg: uniform(rng, 0.0, 360.0),
+            });
+        }
+        Ok(orbits)
+    }
+}
+
+/// Uniform draw on `[lo, hi)`.
+fn uniform<R: Rng + ?Sized>(rng: &mut R, lo: f64, hi: f64) -> f64 {
+    lo + rng.random::<f64>() * (hi - lo)
+}
+
+/// Standard normal draw via Box-Muller (avoids a rand_distr dependency),
+/// matching the approach used by `statslib`.
+fn standard_normal<R: Rng + ?Sized>(rng: &mut R) -> f64 {
+    let u1: f64 = rng.random::<f64>().max(f64::MIN_POSITIVE);
+    let u2: f64 = rng.random();
+    (-2.0 * u1.ln()).sqrt() * (std::f64::consts::TAU * u2).cos()
+}
+
+/// Unit-scale Rayleigh draw by inverse-CDF: `sqrt(-2 ln U)` with `U` in (0, 1].
+fn rayleigh_unit<R: Rng + ?Sized>(rng: &mut R) -> f64 {
+    let u: f64 = (1.0 - rng.random::<f64>()).max(f64::MIN_POSITIVE);
+    (-2.0 * u.ln()).sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::GM_SUN;
+    use crate::time::Timescale;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    #[test]
+    fn test_deterministic_count() {
+        // Exactly N even though many (a, q) draws land in the rejected
+        // q > a corner (a in [31, 60], q in [30, 59] overlaps heavily).
+        let mut rng = StdRng::seed_from_u64(42);
+        let pop = SyntheticOrbitPopulation::new()
+            .with_count(500)
+            .with_semi_major_axis_range(31.0, 60.0)
+            .with_perihelion_range(30.0, 59.0)
+            .generate(&mut rng)
+            .unwrap();
+        assert_eq!(pop.len(), 500);
+    }
+
+    #[test]
+    fn test_same_seed_reproduces() {
+        let config = SyntheticOrbitPopulation::scattered_disk().with_count(64);
+        let a = config.generate(&mut StdRng::seed_from_u64(7)).unwrap();
+        let b = config.generate(&mut StdRng::seed_from_u64(7)).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_elements_within_configured_ranges() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let config = SyntheticOrbitPopulation::scattered_disk().with_count(400);
+        let pop = config.generate(&mut rng).unwrap();
+
+        for orbit in &pop {
+            assert!(
+                orbit.a >= config.a_min && orbit.a < config.a_max,
+                "a = {} out of [{}, {})",
+                orbit.a,
+                config.a_min,
+                config.a_max
+            );
+            let q = orbit.perihelion();
+            assert!(
+                q >= config.q_min - 1e-9 && q < config.q_max,
+                "q = {} out of [{}, {})",
+                q,
+                config.q_min,
+                config.q_max
+            );
+            assert!(orbit.e >= 0.0 && orbit.e < 1.0, "e = {}", orbit.e);
+            assert!(orbit.i_deg >= 0.0, "i = {}", orbit.i_deg);
+            for angle in [orbit.omega_big_deg, orbit.omega_deg, orbit.mean_anomaly_deg] {
+                assert!((0.0..360.0).contains(&angle), "angle = {angle}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_half_normal_inclination_mean() {
+        // For half-normal with sigma = 15°, E[i] = sigma * sqrt(2/pi).
+        let mut rng = StdRng::seed_from_u64(123);
+        let pop = SyntheticOrbitPopulation::scattered_disk()
+            .with_count(10_000)
+            .generate(&mut rng)
+            .unwrap();
+        let expected = 15.0 * (2.0 / std::f64::consts::PI).sqrt();
+        let actual: f64 = pop.iter().map(|o| o.i_deg).sum::<f64>() / pop.len() as f64;
+        let relative_error = (actual - expected).abs() / expected;
+        assert!(
+            relative_error < 0.05,
+            "mean i = {actual:.3} vs expected {expected:.3}"
+        );
+    }
+
+    #[test]
+    fn test_rayleigh_inclination_mean() {
+        // For Rayleigh with sigma = 12°, E[i] = sigma * sqrt(pi/2).
+        let mut rng = StdRng::seed_from_u64(456);
+        let pop = SyntheticOrbitPopulation::new()
+            .with_count(10_000)
+            .with_inclination(InclinationModel::Rayleigh { sigma_deg: 12.0 })
+            .generate(&mut rng)
+            .unwrap();
+        let expected = 12.0 * (std::f64::consts::PI / 2.0).sqrt();
+        let actual: f64 = pop.iter().map(|o| o.i_deg).sum::<f64>() / pop.len() as f64;
+        let relative_error = (actual - expected).abs() / expected;
+        assert!(
+            relative_error < 0.05,
+            "mean i = {actual:.3} vs expected {expected:.3}"
+        );
+    }
+
+    #[test]
+    fn test_planar_inclination() {
+        let mut rng = StdRng::seed_from_u64(9);
+        let pop = SyntheticOrbitPopulation::new()
+            .with_count(20)
+            .with_inclination(InclinationModel::Planar)
+            .generate(&mut rng)
+            .unwrap();
+        assert!(pop.iter().all(|o| o.i_deg == 0.0));
+    }
+
+    #[test]
+    fn test_invalid_configs_rejected() {
+        let mut rng = StdRng::seed_from_u64(1);
+        // Inverted a range.
+        assert!(SyntheticOrbitPopulation::new()
+            .with_semi_major_axis_range(550.0, 150.0)
+            .generate(&mut rng)
+            .is_err());
+        // Inverted q range.
+        assert!(SyntheticOrbitPopulation::new()
+            .with_perihelion_range(50.0, 30.0)
+            .generate(&mut rng)
+            .is_err());
+        // Empty wedge: q_min >= a_max would loop forever if not rejected.
+        assert!(SyntheticOrbitPopulation::new()
+            .with_semi_major_axis_range(100.0, 150.0)
+            .with_perihelion_range(150.0, 200.0)
+            .generate(&mut rng)
+            .is_err());
+        // Negative inclination scale.
+        assert!(SyntheticOrbitPopulation::new()
+            .with_inclination(InclinationModel::HalfNormal { sigma_deg: -1.0 })
+            .generate(&mut rng)
+            .is_err());
+    }
+
+    #[test]
+    fn test_derived_quantities() {
+        let orbit = SyntheticOrbit {
+            a: 500.0,
+            e: 0.9,
+            i_deg: 10.0,
+            omega_big_deg: 300.0,
+            omega_deg: 100.0,
+            mean_anomaly_deg: 0.0,
+        };
+        assert!((orbit.perihelion() - 50.0).abs() < 1e-12);
+        assert!((orbit.aphelion() - 950.0).abs() < 1e-12);
+        // 300 + 100 = 400 wraps to 40.
+        assert!((orbit.longitude_of_perihelion_deg() - 40.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_to_kepler_orbit_distance_in_radial_bounds() {
+        let ts = Timescale::default();
+        let epoch = ts.tt_jd(2_451_545.0, None);
+        let mut rng = StdRng::seed_from_u64(99);
+        let pop = SyntheticOrbitPopulation::scattered_disk()
+            .with_count(10)
+            .generate(&mut rng)
+            .unwrap();
+
+        for (n, orbit) in pop.iter().enumerate() {
+            let kepler = orbit.to_kepler_orbit(&epoch, GM_SUN, Some(&format!("synth-{n}")));
+            let r = kepler.at(&epoch).position.norm();
+            let (q, big_q) = (orbit.perihelion(), orbit.aphelion());
+            assert!(
+                r >= q * (1.0 - 1e-9) && r <= big_q * (1.0 + 1e-9),
+                "r = {r} outside [{q}, {big_q}]"
+            );
+        }
+    }
+}

--- a/src/sbdb/mod.rs
+++ b/src/sbdb/mod.rs
@@ -17,6 +17,10 @@
 //!
 //! No API key or authentication is required.
 //!
+//! The [`snapshot`] submodule provides an offline element-diff utility for
+//! keeping frozen (hand-transcribed) element tables honest against live
+//! SBDB lookups.
+//!
 //! # Quick Start
 //!
 //! ```no_run
@@ -41,7 +45,13 @@
 //! ```
 
 pub mod query;
+pub mod snapshot;
 pub mod types;
+
+pub use snapshot::{
+    diff_against_live, diff_elements, Element, ElementDiff, ElementSnapshot, LiveElements,
+    Tolerances,
+};
 
 pub use crate::data::sbdb::{
     CadParams, CadResponse, FireballParams, FireballResponse, SbdbClient, SbdbLookupResponse,

--- a/src/sbdb/snapshot.rs
+++ b/src/sbdb/snapshot.rs
@@ -1,0 +1,568 @@
+//! Frozen-snapshot element tables and live-SBDB drift detection.
+//!
+//! A common data-hygiene pattern for small-body work: a crate carries a
+//! *frozen snapshot* of orbital elements (provenance-commented constants
+//! that regression tests pin against, so builds and tests stay
+//! deterministic and offline), and a separate, network-gated check diffs
+//! that snapshot against live SBDB lookups with per-element tolerances.
+//! Frozen tables are usually transcribed by hand, and hand transcription
+//! rots silently — in one downstream workspace a ~30 m near-Earth asteroid
+//! ended up listed as a 110 AU trans-Neptunian object, and a scrambled
+//! semi-major-axis column displaced a whole resonance analysis by tens of
+//! AU. This module is the offline diff core that catches both.
+//!
+//! # The frozen-snapshot + drift-allowlist pattern
+//!
+//! Orbit solutions are not constants: JPL refits as observed arcs
+//! lengthen and republishes elements at new epochs. For distant
+//! high-eccentricity objects the perihelion distance `q`, inclination `i`,
+//! and node `Ω` are well constrained, while `a` and `e` are strongly
+//! correlated and drift together along their fit degeneracy — fractional
+//! shifts in `a` of a few ×0.1% are routine between solution epochs, and
+//! the longest-period objects (e.g. Sedna, 506 → 544 AU between solutions)
+//! can move by several percent or more while `q`, `i`, `Ω`, and `H` stay
+//! put. A snapshot that deliberately pins *paper-epoch* solutions will
+//! therefore accumulate legitimate `a`/`e` diffs over time.
+//!
+//! An out-of-tolerance diff means one of two things, both of which a human
+//! should look at:
+//!
+//! 1. **Transcription error** — fix the snapshot.
+//! 2. **Genuine solution drift** — either update the snapshot (re-pinning
+//!    every downstream regression value that depends on it) or, if the
+//!    snapshot intentionally pins a historical solution, record the known
+//!    drift in the snapshot's provenance comment (a drift allowlist) so
+//!    the next reviewer does not "fix" it back.
+//!
+//! # Offline vs network
+//!
+//! [`diff_elements`] and everything it touches are pure and unit-tested
+//! offline. Only [`diff_against_live`] performs network lookups, and its
+//! test is `#[ignore]`d like the other live SBDB tests.
+//!
+//! # Example
+//!
+//! ```
+//! use starfield::sbdb::snapshot::{diff_elements, Element, ElementSnapshot, LiveElements, Tolerances};
+//!
+//! let snapshot = ElementSnapshot {
+//!     name: "Sedna".to_string(),
+//!     designation: "Sedna".to_string(),
+//!     a: Some(506.0),
+//!     e: Some(0.85),
+//!     i_deg: Some(11.9),
+//!     omega_deg: Some(311.5),
+//!     omega_big_deg: Some(144.5),
+//!     h_mag: Some(1.6),
+//! };
+//!
+//! // A later JPL solution has drifted along the a-e degeneracy.
+//! let live = LiveElements {
+//!     a: Some(544.0),
+//!     e: Some(0.855),
+//!     i_deg: Some(11.9),
+//!     omega_deg: Some(311.4),
+//!     omega_big_deg: Some(144.4),
+//!     h_mag: Some(1.5),
+//!     ..Default::default()
+//! };
+//!
+//! let diffs = diff_elements(&snapshot, &live, &Tolerances::published_table());
+//! assert_eq!(diffs.len(), 1);
+//! assert_eq!(diffs[0].element, Element::SemiMajorAxis);
+//! ```
+
+use crate::data::sbdb::{SbdbClient, SbdbLookupResponse};
+use crate::{Result, StarfieldError};
+
+/// Which orbital element a diff refers to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Element {
+    /// Semi-major axis a (AU)
+    SemiMajorAxis,
+    /// Eccentricity e
+    Eccentricity,
+    /// Inclination i (degrees)
+    Inclination,
+    /// Argument of perihelion ω (degrees)
+    ArgPerihelion,
+    /// Longitude of ascending node Ω (degrees)
+    AscendingNode,
+    /// Absolute magnitude H
+    AbsoluteMagnitude,
+}
+
+impl Element {
+    /// Short human-readable label.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Element::SemiMajorAxis => "a [AU]",
+            Element::Eccentricity => "e",
+            Element::Inclination => "i [deg]",
+            Element::ArgPerihelion => "omega [deg]",
+            Element::AscendingNode => "Omega [deg]",
+            Element::AbsoluteMagnitude => "H [mag]",
+        }
+    }
+
+    /// Whether the element is an angle in degrees (delta is wrap-aware).
+    pub fn is_angle(&self) -> bool {
+        matches!(
+            self,
+            Element::Inclination | Element::ArgPerihelion | Element::AscendingNode
+        )
+    }
+}
+
+/// One row of a frozen table, in the form the differ compares. Elements
+/// the table does not carry are `None` and are skipped.
+#[derive(Debug, Clone, Default)]
+pub struct ElementSnapshot {
+    /// Human-readable name used in diff reports.
+    pub name: String,
+    /// SBDB search string (`sstr`) used for the live lookup.
+    pub designation: String,
+    /// Semi-major axis (AU)
+    pub a: Option<f64>,
+    /// Eccentricity
+    pub e: Option<f64>,
+    /// Inclination (degrees)
+    pub i_deg: Option<f64>,
+    /// Argument of perihelion (degrees)
+    pub omega_deg: Option<f64>,
+    /// Longitude of ascending node (degrees)
+    pub omega_big_deg: Option<f64>,
+    /// Absolute magnitude H
+    pub h_mag: Option<f64>,
+}
+
+/// Osculating elements from a live SBDB lookup, decoupled from the
+/// response types so the diff logic can be unit-tested offline.
+#[derive(Debug, Clone, Default)]
+pub struct LiveElements {
+    /// Semi-major axis (AU)
+    pub a: Option<f64>,
+    /// Eccentricity
+    pub e: Option<f64>,
+    /// Inclination (degrees)
+    pub i_deg: Option<f64>,
+    /// Argument of perihelion (degrees)
+    pub omega_deg: Option<f64>,
+    /// Longitude of ascending node (degrees)
+    pub omega_big_deg: Option<f64>,
+    /// Absolute magnitude H
+    pub h_mag: Option<f64>,
+    /// Epoch of osculation (JD TDB)
+    pub epoch_jd: Option<f64>,
+    /// JPL orbit solution ID (provenance for reports)
+    pub orbit_id: Option<String>,
+}
+
+impl LiveElements {
+    /// Flatten an SBDB lookup response into the fields the differ uses.
+    ///
+    /// Errors if the response carries no orbit block — for a snapshot
+    /// table a missing orbit is a table bug (bad designation), not drift.
+    pub fn from_lookup(response: &SbdbLookupResponse) -> Result<Self> {
+        let orbit = response.orbit.as_ref().ok_or_else(|| {
+            StarfieldError::DataError(format!(
+                "SBDB returned no orbit for {:?}",
+                response.object.designation
+            ))
+        })?;
+        Ok(LiveElements {
+            a: orbit.semi_major_axis,
+            e: orbit.eccentricity,
+            i_deg: orbit.inclination,
+            omega_deg: orbit.arg_perihelion,
+            omega_big_deg: orbit.long_asc_node,
+            h_mag: response.phys_par.as_ref().and_then(|p| p.abs_magnitude_h),
+            epoch_jd: orbit.epoch_jd,
+            orbit_id: orbit.orbit_id.clone(),
+        })
+    }
+}
+
+/// Per-element comparison tolerances. Each is the *total* allowed
+/// |live − snapshot|: an allowance for orbit-solution drift plus the
+/// rounding half-width of the snapshot itself.
+#[derive(Debug, Clone, Copy)]
+pub struct Tolerances {
+    /// Fractional tolerance on a (relative to the snapshot value).
+    pub a_frac: f64,
+    /// Absolute floor on the a tolerance (AU) — covers table rounding.
+    pub a_abs: f64,
+    /// Absolute tolerance on e.
+    pub e_abs: f64,
+    /// Absolute tolerance on i, ω, Ω (degrees, wrap-aware).
+    pub angle_deg: f64,
+    /// Absolute tolerance on H (mag).
+    pub h_mag: f64,
+}
+
+impl Tolerances {
+    /// Tolerances for tables transcribed at typical *published-table*
+    /// precision: a rounded to the AU (±0.5), e to 0.01 (±0.005), angles
+    /// to 0.1° (±0.05), H to 0.1 (±0.05). On top of the rounding:
+    ///
+    /// - a: 1% fractional drift. For distant high-eccentricity orbits a is
+    ///   the loosest-constrained element (strongly correlated with e); a
+    ///   few ×0.1% is routine between solution epochs and ~1% is reached
+    ///   by the longest-period objects. Beyond 1% is worth a human look.
+    /// - e: 0.01 — drift in e tracks a at the few ×0.001 level,
+    ///   comparable to the table's own rounding.
+    /// - angles: 0.5° — i, ω, Ω are typically stable to ≲0.1° once an
+    ///   orbit is multi-opposition; 0.5° flags real solution changes.
+    /// - H: 0.5 mag — SBDB absolute magnitudes are re-derived photometric
+    ///   fits and routinely move by a few tenths, independent of
+    ///   astrometry.
+    pub fn published_table() -> Self {
+        Tolerances {
+            a_frac: 0.01,
+            a_abs: 1.0,
+            e_abs: 0.01,
+            angle_deg: 0.5,
+            h_mag: 0.5,
+        }
+    }
+
+    /// Tolerances for tables transcribed at (near) full SBDB precision
+    /// (a to 0.1 AU, e to 1e-4, angles to 0.01°). The same drift physics
+    /// as [`Tolerances::published_table`] but tighter, appropriate for a
+    /// recently frozen, unrounded snapshot: 0.5% in a, 0.005 in e, 0.1°
+    /// in angles.
+    pub fn full_precision() -> Self {
+        Tolerances {
+            a_frac: 0.005,
+            a_abs: 0.2,
+            e_abs: 0.005,
+            angle_deg: 0.1,
+            h_mag: 0.5,
+        }
+    }
+
+    fn for_element(&self, element: Element, snapshot_value: f64) -> f64 {
+        match element {
+            Element::SemiMajorAxis => (self.a_frac * snapshot_value.abs()).max(self.a_abs),
+            Element::Eccentricity => self.e_abs,
+            Element::Inclination | Element::ArgPerihelion | Element::AscendingNode => {
+                self.angle_deg
+            }
+            Element::AbsoluteMagnitude => self.h_mag,
+        }
+    }
+}
+
+/// One out-of-tolerance element: which object, which element, what the
+/// frozen table says, what JPL says now, and by how much they disagree.
+#[derive(Debug, Clone)]
+pub struct ElementDiff {
+    /// Object name (from the snapshot table).
+    pub object: String,
+    /// Which element drifted.
+    pub element: Element,
+    /// Value in the frozen table.
+    pub snapshot: f64,
+    /// Live SBDB value.
+    pub live: f64,
+    /// live − snapshot (wrap-aware for angles, in the element's units).
+    pub delta: f64,
+    /// The tolerance that was exceeded (same units).
+    pub tolerance: f64,
+    /// JPL orbit solution ID of the live lookup, if reported.
+    pub orbit_id: Option<String>,
+}
+
+impl std::fmt::Display for ElementDiff {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}: {} snapshot {} vs live {} (delta {:+.4}, tolerance {:.4}{})",
+            self.object,
+            self.element.label(),
+            self.snapshot,
+            self.live,
+            self.delta,
+            self.tolerance,
+            match &self.orbit_id {
+                Some(id) => format!(", JPL soln {id}"),
+                None => String::new(),
+            }
+        )
+    }
+}
+
+/// Signed angle difference `to − from` in degrees, wrapped to (−180°, 180°].
+///
+/// ```
+/// use starfield::sbdb::snapshot::angle_delta_deg;
+/// assert!((angle_delta_deg(359.9, 0.3) - 0.4).abs() < 1e-9);
+/// assert!((angle_delta_deg(0.3, 359.9) + 0.4).abs() < 1e-9);
+/// ```
+pub fn angle_delta_deg(from: f64, to: f64) -> f64 {
+    let mut d = (to - from).rem_euclid(360.0);
+    if d > 180.0 {
+        d -= 360.0;
+    }
+    d
+}
+
+/// Diff one snapshot row against live elements. Returns only the elements
+/// whose |delta| exceeds tolerance; elements missing on either side are
+/// skipped (snapshot tables only carry `Some` for vetted columns, and
+/// SBDB always reports the Keplerian set for real objects).
+pub fn diff_elements(
+    snapshot: &ElementSnapshot,
+    live: &LiveElements,
+    tolerances: &Tolerances,
+) -> Vec<ElementDiff> {
+    let pairs = [
+        (Element::SemiMajorAxis, snapshot.a, live.a),
+        (Element::Eccentricity, snapshot.e, live.e),
+        (Element::Inclination, snapshot.i_deg, live.i_deg),
+        (Element::ArgPerihelion, snapshot.omega_deg, live.omega_deg),
+        (
+            Element::AscendingNode,
+            snapshot.omega_big_deg,
+            live.omega_big_deg,
+        ),
+        (Element::AbsoluteMagnitude, snapshot.h_mag, live.h_mag),
+    ];
+
+    let mut diffs = Vec::new();
+    for (element, snapshot_value, live_value) in pairs {
+        let (Some(s), Some(l)) = (snapshot_value, live_value) else {
+            continue;
+        };
+        let delta = if element.is_angle() {
+            angle_delta_deg(s, l)
+        } else {
+            l - s
+        };
+        let tolerance = tolerances.for_element(element, s);
+        if delta.abs() > tolerance {
+            diffs.push(ElementDiff {
+                object: snapshot.name.clone(),
+                element,
+                snapshot: s,
+                live: l,
+                delta,
+                tolerance,
+                orbit_id: live.orbit_id.clone(),
+            });
+        }
+    }
+    diffs
+}
+
+/// Diff a snapshot table against live SBDB lookups (network).
+///
+/// Errors on the first failed lookup or orbit-less response — for a
+/// snapshot table a missing object is a table bug, not drift. Otherwise
+/// returns every out-of-tolerance element across the whole table; an
+/// empty result means the table still matches JPL to within normal
+/// solution drift.
+pub fn diff_against_live(
+    client: &SbdbClient,
+    snapshots: &[ElementSnapshot],
+    tolerances: &Tolerances,
+) -> Result<Vec<ElementDiff>> {
+    let mut diffs = Vec::new();
+    for snapshot in snapshots {
+        let response = client.lookup(&snapshot.designation)?;
+        let live = LiveElements::from_lookup(&response)?;
+        diffs.extend(diff_elements(snapshot, &live, tolerances));
+    }
+    Ok(diffs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot() -> ElementSnapshot {
+        ElementSnapshot {
+            name: "Testna".to_string(),
+            designation: "Testna".to_string(),
+            a: Some(500.0),
+            e: Some(0.85),
+            i_deg: Some(11.9),
+            omega_deg: Some(311.5),
+            omega_big_deg: Some(144.5),
+            h_mag: Some(1.6),
+        }
+    }
+
+    fn matching_live() -> LiveElements {
+        LiveElements {
+            a: Some(500.0),
+            e: Some(0.85),
+            i_deg: Some(11.9),
+            omega_deg: Some(311.5),
+            omega_big_deg: Some(144.5),
+            h_mag: Some(1.6),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_identical_elements_no_diff() {
+        let diffs = diff_elements(
+            &snapshot(),
+            &matching_live(),
+            &Tolerances::published_table(),
+        );
+        assert!(diffs.is_empty(), "{diffs:?}");
+    }
+
+    #[test]
+    fn test_drift_within_tolerance_no_diff() {
+        // 0.4% in a, half the e tolerance, 0.3 deg in omega, 0.2 mag in H:
+        // all within the documented published-table allowances.
+        let live = LiveElements {
+            a: Some(502.0),
+            e: Some(0.855),
+            i_deg: Some(11.9),
+            omega_deg: Some(311.8),
+            omega_big_deg: Some(144.5),
+            h_mag: Some(1.8),
+            ..Default::default()
+        };
+        let diffs = diff_elements(&snapshot(), &live, &Tolerances::published_table());
+        assert!(diffs.is_empty(), "{diffs:?}");
+    }
+
+    #[test]
+    fn test_semi_major_axis_drift_flagged() {
+        let live = LiveElements {
+            a: Some(540.0), // 8% — way beyond the 1% allowance
+            ..matching_live()
+        };
+        let diffs = diff_elements(&snapshot(), &live, &Tolerances::published_table());
+        assert_eq!(diffs.len(), 1);
+        let d = &diffs[0];
+        assert_eq!(d.element, Element::SemiMajorAxis);
+        assert_eq!(d.object, "Testna");
+        assert_eq!(d.snapshot, 500.0);
+        assert_eq!(d.live, 540.0);
+        assert!((d.delta - 40.0).abs() < 1e-12);
+        assert!((d.tolerance - 5.0).abs() < 1e-12); // 1% of 500
+    }
+
+    #[test]
+    fn test_multiple_elements_flagged_independently() {
+        let live = LiveElements {
+            e: Some(0.88),     // |delta e| = 0.03 > 0.01
+            i_deg: Some(13.0), // 1.1 deg > 0.5
+            ..matching_live()
+        };
+        let diffs = diff_elements(&snapshot(), &live, &Tolerances::published_table());
+        let elements: Vec<Element> = diffs.iter().map(|d| d.element).collect();
+        assert_eq!(
+            elements,
+            vec![Element::Eccentricity, Element::Inclination],
+            "{diffs:?}"
+        );
+    }
+
+    #[test]
+    fn test_angle_delta_is_wrap_aware() {
+        // 359.9 vs 0.3 is a 0.4 deg difference, not 359.6.
+        assert!((angle_delta_deg(359.9, 0.3) - 0.4).abs() < 1e-9);
+        assert!((angle_delta_deg(0.3, 359.9) + 0.4).abs() < 1e-9);
+
+        let snap = ElementSnapshot {
+            omega_deg: Some(359.9),
+            ..snapshot()
+        };
+        let live = LiveElements {
+            omega_deg: Some(0.3),
+            ..matching_live()
+        };
+        let diffs = diff_elements(&snap, &live, &Tolerances::published_table());
+        assert!(
+            diffs.is_empty(),
+            "wrap-around must not be flagged: {diffs:?}"
+        );
+    }
+
+    #[test]
+    fn test_missing_elements_skipped() {
+        // A snapshot that only carries a, e, i ignores live omega/Omega/H.
+        let snap = ElementSnapshot {
+            omega_deg: None,
+            omega_big_deg: None,
+            h_mag: None,
+            ..snapshot()
+        };
+        let live = LiveElements {
+            omega_deg: Some(100.0),    // wildly different but not compared
+            omega_big_deg: Some(10.0), // ditto
+            h_mag: None,
+            ..matching_live()
+        };
+        let diffs = diff_elements(&snap, &live, &Tolerances::published_table());
+        assert!(diffs.is_empty(), "{diffs:?}");
+    }
+
+    #[test]
+    fn test_full_precision_is_tighter() {
+        // 0.7% in a passes published_table (1%) but fails full_precision (0.5%).
+        let live = LiveElements {
+            a: Some(503.5),
+            ..matching_live()
+        };
+        assert!(diff_elements(&snapshot(), &live, &Tolerances::published_table()).is_empty());
+        let diffs = diff_elements(&snapshot(), &live, &Tolerances::full_precision());
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].element, Element::SemiMajorAxis);
+    }
+
+    #[test]
+    fn test_diff_display_names_object_and_element() {
+        let live = LiveElements {
+            a: Some(540.0),
+            orbit_id: Some("12".to_string()),
+            ..matching_live()
+        };
+        let diffs = diff_elements(&snapshot(), &live, &Tolerances::published_table());
+        let msg = diffs[0].to_string();
+        assert!(msg.contains("Testna"), "{msg}");
+        assert!(msg.contains("a [AU]"), "{msg}");
+        assert!(msg.contains("540"), "{msg}");
+        assert!(msg.contains("JPL soln 12"), "{msg}");
+    }
+
+    /// Live-network check: a published-precision Sedna snapshot diffed
+    /// against the current JPL solution. q, i, and Omega are stable across
+    /// solution epochs; a and e drift along their fit degeneracy, so this
+    /// only asserts on the stable elements.
+    #[test]
+    #[ignore]
+    fn test_diff_against_live_sedna() {
+        let snapshots = vec![ElementSnapshot {
+            name: "Sedna".to_string(),
+            designation: "Sedna".to_string(),
+            // a and e omitted on purpose: they drift along the a-e
+            // degeneracy between JPL solutions (506 -> 544 AU already
+            // observed) and would make this test rot.
+            a: None,
+            e: None,
+            i_deg: Some(11.9),
+            omega_deg: Some(311.5),
+            omega_big_deg: Some(144.5),
+            h_mag: Some(1.6),
+        }];
+        let client = SbdbClient::new().unwrap();
+        let diffs = diff_against_live(&client, &snapshots, &Tolerances::published_table()).unwrap();
+        // omega can move a few tenths of a degree between solutions; the
+        // others should hold. Print rather than fail on omega-only drift.
+        for d in &diffs {
+            println!("{d}");
+            assert!(
+                d.element == Element::ArgPerihelion || d.element == Element::AbsoluteMagnitude,
+                "unexpected drift: {d}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Two additions extracted from OrbitalCommons/planet9:

- catalogs::synthetic::orbits — builder-style SyntheticOrbitPopulation generating seeded orbital-element records (uniform-wedge (a,q) with deterministic-N resampling, planar/half-normal/Rayleigh inclination models, SBDB element conventions, to_kepler_orbit bridge via mpcorb_orbit). Adds a validate() guard against non-terminating resampling configs that the original lacked.
- sbdb::snapshot — offline element-diff core (wrap-aware angle deltas, per-element tolerances, structured ElementDiff) plus a diff_against_live convenience over SbdbClient. Module docs codify the frozen-snapshot + drift-allowlist pattern from planet9's live-validation experience (a-e degeneracy drift vs stable q/i/Omega/H).

18 new unit tests + doc-examples; clippy -D warnings clean; zero new dependencies.

Closes OrbitalCommons/planet9#35