### PR TITLE
Add secularlib: secular and resonance dynamics toolkit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod pybridge;
 pub mod relativity;
 pub mod sbdb;
 pub mod searchlib;
+pub mod secularlib;
 pub mod sgp4lib;
 pub mod starlib;
 pub mod statslib;

--- a/src/secularlib/hamiltonian.rs
+++ b/src/secularlib/hamiltonian.rs
@@ -1,0 +1,356 @@
+//! Doubly-averaged secular Hamiltonians.
+//!
+//! Two levels of fidelity:
+//!
+//! 1. **Analytic quadrupole** ([`quadrupole_hamiltonian`]): the doubly-averaged
+//!    quadrupole for an inner test particle and an outer eccentric perturber.
+//!    This is *axisymmetric in the apsidal angle*: it depends on (e, i, ω)
+//!    only — at quadrupole order there is no Δϖ dependence and therefore no
+//!    aligned/anti-aligned structure. Valid only for α = a/a_p ≪ 1.
+//!
+//! 2. **Numerical Gauss-ring double averaging**
+//!    ([`numerical_secular_hamiltonian`]): the exact 1/Δ averaged over both
+//!    mean anomalies. The multipole expansion diverges for α ≈ 0.3–0.9
+//!    (the regime relevant to distant-perturber problems such as Planet Nine);
+//!    Batygin & Brown (2016) used numerical ring averaging for exactly this
+//!    reason. This captures the octupole-and-higher Δϖ dependence (the
+//!    anti-aligned libration islands) automatically. For orbit-crossing
+//!    geometries the doubly averaged integral is singular and a softening
+//!    length must be supplied.
+//!
+//! Units: AU, radians, GM in AU³/day² (see the [`crate::secularlib`] docs).
+//!
+//! Reference: Kozai (1962); Naoz (2016) §3; Batygin & Brown (2016)
+
+use std::f64::consts::PI;
+
+/// Quadrupole coupling constant C = gm_p α² / (4 a_p (1 − e_p²)^{3/2}).
+fn coupling(a: f64, a_p: f64, e_p: f64, gm_p: f64) -> f64 {
+    let alpha = a / a_p;
+    gm_p * alpha * alpha / (4.0 * a_p * (1.0 - e_p * e_p).powf(1.5))
+}
+
+/// Doubly-averaged quadrupole Hamiltonian for an inner test particle
+/// perturbed by an outer body (Kozai-Lidov form):
+///
+///   H_quad = −(C/4) · \[ (2 + 3e²)(3cos²i − 1) + 15 e² sin²i cos 2ω \]
+///
+/// with C = gm_p α²/(4 a_p (1−e_p²)^{3/2}). Angles are measured in the
+/// perturber's orbital plane: `i` is the mutual inclination and `omega` the
+/// particle's argument of perihelion from the common node.
+///
+/// Note the Hamiltonian is independent of the nodal and apsidal longitudes —
+/// at quadrupole order the averaged perturber is an axisymmetric ring, so no
+/// Δϖ-dependent (aligned/anti-aligned) dynamics exists at this order. Use
+/// [`numerical_secular_hamiltonian`] for apsidal structure.
+///
+/// Reference: Kozai (1962); Naoz (2016) §3, eq. (20)
+///
+/// * `a`: test particle semi-major axis (AU)
+/// * `e`: test particle eccentricity
+/// * `i`: mutual inclination (radians)
+/// * `omega`: argument of perihelion from the common node (radians)
+/// * `a_p`: perturber semi-major axis (AU)
+/// * `e_p`: perturber eccentricity
+/// * `gm_p`: perturber GM (AU³/day²)
+///
+/// # Example
+///
+/// ```
+/// use starfield::secularlib::{quadrupole_hamiltonian, GM_NEPTUNE_AU3_DAY2};
+///
+/// // A test particle well inside a Neptune-mass ring perturber.
+/// let h = quadrupole_hamiltonian(5.0, 0.3, 0.5, 1.0, 30.07, 0.01, GM_NEPTUNE_AU3_DAY2);
+/// assert!(h.is_finite());
+/// ```
+pub fn quadrupole_hamiltonian(
+    a: f64,
+    e: f64,
+    i: f64,
+    omega: f64,
+    a_p: f64,
+    e_p: f64,
+    gm_p: f64,
+) -> f64 {
+    let c = coupling(a, a_p, e_p, gm_p);
+    let e2 = e * e;
+    let cos_i2 = i.cos().powi(2);
+    let sin_i2 = 1.0 - cos_i2;
+
+    -(c / 4.0)
+        * ((2.0 + 3.0 * e2) * (3.0 * cos_i2 - 1.0) + 15.0 * e2 * sin_i2 * (2.0 * omega).cos())
+}
+
+/// Coplanar quadrupole Hamiltonian (i = 0):
+///   H = −C (2 + 3e²) / 2.
+///
+/// A function of e alone — the coplanar quadrupole has *no* libration islands;
+/// those appear only at octupole order (∝ e e_p α³) and beyond, which the
+/// numerical averaging includes.
+///
+/// # Example
+///
+/// ```
+/// use starfield::secularlib::{coplanar_quadrupole, GM_NEPTUNE_AU3_DAY2};
+///
+/// // The coplanar quadrupole energy decreases (more negative) with e.
+/// let h1 = coplanar_quadrupole(100.0, 0.1, 700.0, 0.6, GM_NEPTUNE_AU3_DAY2);
+/// let h2 = coplanar_quadrupole(100.0, 0.7, 700.0, 0.6, GM_NEPTUNE_AU3_DAY2);
+/// assert!(h2 < h1);
+/// ```
+pub fn coplanar_quadrupole(a: f64, e: f64, a_p: f64, e_p: f64, gm_p: f64) -> f64 {
+    quadrupole_hamiltonian(a, e, 0.0, 0.0, a_p, e_p, gm_p)
+}
+
+/// Position on an orbit at eccentric anomaly `ea`, rotated into the reference
+/// frame by (omega, i, omega_big). Returns the 3D position (units of `a`).
+fn orbit_position(a: f64, e: f64, i: f64, omega: f64, omega_big: f64, ea: f64) -> [f64; 3] {
+    let x_orb = a * (ea.cos() - e);
+    let y_orb = a * (1.0 - e * e).sqrt() * ea.sin();
+
+    let (sw, cw) = omega.sin_cos();
+    let (si, ci) = i.sin_cos();
+    let (so, co) = omega_big.sin_cos();
+
+    let x = (co * cw - so * sw * ci) * x_orb + (-co * sw - so * cw * ci) * y_orb;
+    let y = (so * cw + co * sw * ci) * x_orb + (-so * sw + co * cw * ci) * y_orb;
+    let z = sw * si * x_orb + cw * si * y_orb;
+
+    [x, y, z]
+}
+
+/// Doubly-averaged secular Hamiltonian from numerical Gauss-ring averaging of
+/// the exact interaction:
+///
+///   H = −gm_p ⟨⟨ 1/Δ ⟩⟩
+///     = −gm_p/(4π²) ∮∮ dM dM_p / sqrt(Δ² + b²)
+///
+/// (The indirect term −gm_p r·r_p/r_p³ double-averages to zero because the
+/// orbit average of the Keplerian acceleration vanishes.)
+///
+/// The integral is evaluated on uniform eccentric-anomaly grids with the
+/// Jacobians dM = (1 − e cos E) dE, which is spectrally accurate for smooth
+/// (non-crossing) geometries. For crossing orbits the unsoftened average
+/// diverges; pass a softening length `softening_au` > 0 (a fraction of a_p)
+/// to regularize — the resulting portraits follow Batygin & Brown (2016).
+///
+/// The perturber's apsidal line defines the x-axis and its orbit plane the
+/// reference plane, so the particle's `omega`/`omega_big` are relative to the
+/// perturber (coplanar: Δϖ = omega + omega_big).
+///
+/// `n_quad` is the number of quadrature nodes per anomaly (n_quad² total
+/// evaluations); 64–128 suffices for portrait work.
+///
+/// Reference: Batygin & Brown (2016), AJ 151, 22
+///
+/// # Example
+///
+/// ```
+/// use starfield::secularlib::{numerical_secular_hamiltonian, GM_NEPTUNE_AU3_DAY2};
+///
+/// // Non-crossing coplanar geometry: the averaged energy is finite and < 0.
+/// let h = numerical_secular_hamiltonian(
+///     250.0, 0.3, 0.0, 0.0, 0.0, 700.0, 0.6, GM_NEPTUNE_AU3_DAY2, 64, 0.0,
+/// );
+/// assert!(h.is_finite() && h < 0.0);
+/// ```
+#[allow(clippy::too_many_arguments)]
+pub fn numerical_secular_hamiltonian(
+    a: f64,
+    e: f64,
+    i: f64,
+    omega: f64,
+    omega_big: f64,
+    a_p: f64,
+    e_p: f64,
+    gm_p: f64,
+    n_quad: usize,
+    softening_au: f64,
+) -> f64 {
+    let b2 = softening_au * softening_au;
+    let de = 2.0 * PI / n_quad as f64;
+
+    // Precompute perturber ring samples (perturber defines the frame:
+    // i_p = 0, omega_p = 0, Omega_p = 0).
+    let mut p_pos = Vec::with_capacity(n_quad);
+    let mut p_weight = Vec::with_capacity(n_quad);
+    for kp in 0..n_quad {
+        let ea_p = (kp as f64 + 0.5) * de;
+        p_pos.push(orbit_position(a_p, e_p, 0.0, 0.0, 0.0, ea_p));
+        p_weight.push(1.0 - e_p * ea_p.cos());
+    }
+
+    let mut sum = 0.0;
+    for k in 0..n_quad {
+        let ea = (k as f64 + 0.5) * de;
+        let w = 1.0 - e * ea.cos();
+        let r = orbit_position(a, e, i, omega, omega_big, ea);
+
+        for (rp, wp) in p_pos.iter().zip(&p_weight) {
+            let dx = r[0] - rp[0];
+            let dy = r[1] - rp[1];
+            let dz = r[2] - rp[2];
+            let delta = (dx * dx + dy * dy + dz * dz + b2).sqrt();
+            sum += w * wp / delta;
+        }
+    }
+
+    // (1/2π)² ∮∮ ... dE dE_p with the dM Jacobians folded into the weights.
+    -gm_p * sum * (de * de) / (4.0 * PI * PI)
+}
+
+/// Generate a phase-space portrait grid: evaluate the numerically averaged
+/// Hamiltonian at a grid of (e, Δϖ) values for a fixed semi-major axis,
+/// coplanar with the perturber.
+///
+/// Uses Gauss-ring averaging of the exact 1/Δ (the multipole expansion does
+/// not converge for the relevant α), with a softening of 0.01·a_p to
+/// regularize crossing geometries.
+///
+/// Returns (e_vals, dvarpi_vals, portrait) where portrait\[i\]\[j\] = H(e_i, Δϖ_j).
+///
+/// # Example
+///
+/// ```
+/// use starfield::secularlib::{phase_portrait, GM_NEPTUNE_AU3_DAY2};
+///
+/// let (e_vals, dv_vals, portrait) =
+///     phase_portrait(400.0, 700.0, 0.6, GM_NEPTUNE_AU3_DAY2, 4, 6);
+/// assert_eq!((e_vals.len(), dv_vals.len()), (4, 6));
+/// assert_eq!((portrait.len(), portrait[0].len()), (4, 6));
+/// ```
+pub fn phase_portrait(
+    a: f64,
+    a_p: f64,
+    e_p: f64,
+    gm_p: f64,
+    n_e: usize,
+    n_dvarpi: usize,
+) -> (Vec<f64>, Vec<f64>, Vec<Vec<f64>>) {
+    let softening = 0.01 * a_p;
+    let n_quad = 64;
+
+    let e_vals: Vec<f64> = (0..n_e)
+        .map(|i| (i as f64 + 0.5) / n_e as f64 * 0.95)
+        .collect();
+
+    let dvarpi_vals: Vec<f64> = (0..n_dvarpi)
+        .map(|j| (j as f64) / n_dvarpi as f64 * 2.0 * PI - PI)
+        .collect();
+
+    let mut portrait = vec![vec![0.0; n_dvarpi]; n_e];
+
+    for (i, &e) in e_vals.iter().enumerate() {
+        for (j, &dv) in dvarpi_vals.iter().enumerate() {
+            portrait[i][j] = numerical_secular_hamiltonian(
+                a, e, 0.0, dv, 0.0, a_p, e_p, gm_p, n_quad, softening,
+            );
+        }
+    }
+
+    (e_vals, dvarpi_vals, portrait)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::secularlib::GM_SUN_AU3_DAY2;
+
+    const GM_P: f64 = 10.0 * 3.003489e-6 * GM_SUN_AU3_DAY2; // 10 Earth masses
+
+    #[test]
+    fn test_quadrupole_has_no_apsidal_dependence() {
+        // The coplanar quadrupole must be a function of e only.
+        let h1 = coplanar_quadrupole(100.0, 0.5, 700.0, 0.6, GM_P);
+        let h2 = coplanar_quadrupole(100.0, 0.5, 700.0, 0.6, GM_P);
+        assert_eq!(h1, h2);
+        // And independent of omega at i = 0:
+        let ha = quadrupole_hamiltonian(100.0, 0.5, 0.0, 0.3, 700.0, 0.6, GM_P);
+        let hb = quadrupole_hamiltonian(100.0, 0.5, 0.0, 2.1, 700.0, 0.6, GM_P);
+        assert!((ha - hb).abs() < 1e-30);
+    }
+
+    #[test]
+    fn test_numerical_matches_quadrupole_at_small_alpha() {
+        // Small α, circular perturber (octupole vanishes): the e-dependence
+        // of the numerical average must match the quadrupole formula. The
+        // constant monopole term −gm_p/a_p·(...) cancels in the difference.
+        let a = 30.0;
+        let a_p = 700.0;
+        let e_p = 0.0;
+        let n = 128;
+
+        let num =
+            |e: f64| numerical_secular_hamiltonian(a, e, 0.0, 0.0, 0.0, a_p, e_p, GM_P, n, 0.0);
+        let quad = |e: f64| coplanar_quadrupole(a, e, a_p, e_p, GM_P);
+
+        let d_num = num(0.6) - num(0.1);
+        let d_quad = quad(0.6) - quad(0.1);
+        let rel = ((d_num - d_quad) / d_quad).abs();
+        // Hexadecapole correction is O(α²) ≈ 0.2%
+        assert!(rel < 0.02, "numerical vs quadrupole ΔH mismatch: {rel:.3e}");
+    }
+
+    #[test]
+    fn test_numerical_axisymmetric_for_circular_perturber() {
+        // e_p = 0: the averaged perturber is an axisymmetric ring, so H must
+        // not depend on Δϖ even at large α.
+        let h0 =
+            numerical_secular_hamiltonian(300.0, 0.4, 0.0, 0.0, 0.0, 700.0, 0.0, GM_P, 96, 0.0);
+        let h1 = numerical_secular_hamiltonian(
+            300.0,
+            0.4,
+            0.0,
+            PI / 2.0,
+            0.0,
+            700.0,
+            0.0,
+            GM_P,
+            96,
+            0.0,
+        );
+        let rel = ((h0 - h1) / h0).abs();
+        assert!(
+            rel < 1e-10,
+            "circular perturber should be axisymmetric: {rel:.3e}"
+        );
+    }
+
+    #[test]
+    fn test_numerical_apsidal_structure_with_eccentric_perturber() {
+        // Eccentric perturber at moderate α: the exact average distinguishes
+        // aligned from anti-aligned apsides (octupole+), which the quadrupole
+        // cannot.
+        let h_aligned =
+            numerical_secular_hamiltonian(250.0, 0.3, 0.0, 0.0, 0.0, 700.0, 0.6, GM_P, 128, 0.0);
+        let h_anti =
+            numerical_secular_hamiltonian(250.0, 0.3, 0.0, PI, 0.0, 700.0, 0.6, GM_P, 128, 0.0);
+        let rel = ((h_aligned - h_anti) / h_aligned).abs();
+        assert!(rel > 1e-6, "expected Δϖ asymmetry, got {rel:.3e}");
+    }
+
+    #[test]
+    fn test_numerical_quadrature_converged() {
+        // n vs 2n agreement on a non-crossing geometry.
+        let h64 =
+            numerical_secular_hamiltonian(200.0, 0.5, 0.2, 1.0, 0.4, 700.0, 0.5, GM_P, 64, 0.0);
+        let h128 =
+            numerical_secular_hamiltonian(200.0, 0.5, 0.2, 1.0, 0.4, 700.0, 0.5, GM_P, 128, 0.0);
+        let rel = ((h64 - h128) / h128).abs();
+        assert!(rel < 1e-8, "quadrature not converged: {rel:.3e}");
+    }
+
+    #[test]
+    fn test_phase_portrait_shape_and_finite() {
+        let (e_vals, dv_vals, portrait) = phase_portrait(400.0, 700.0, 0.6, GM_P, 8, 12);
+        assert_eq!(e_vals.len(), 8);
+        assert_eq!(dv_vals.len(), 12);
+        assert_eq!(portrait.len(), 8);
+        assert_eq!(portrait[0].len(), 12);
+        for row in &portrait {
+            for &h in row {
+                assert!(h.is_finite() && h < 0.0);
+            }
+        }
+    }
+}

--- a/src/secularlib/hansen.rs
+++ b/src/secularlib/hansen.rs
@@ -1,0 +1,291 @@
+//! Hansen coefficients X_j^{n,m}(e) for the disturbing function.
+//!
+//! The numerical evaluator integrates in *eccentric* anomaly with the
+//! Jacobian dM = (1 − e cos E) dE — the integrand is smooth and periodic in E,
+//! so the uniform midpoint rule converges spectrally — and doubles the node
+//! count until the requested tolerance is met (the required resolution grows
+//! like j (1 − e)^{−3/2}).
+//!
+//! Units: AU, radians (see the [`crate::secularlib`] docs).
+//!
+//! Reference: Hughes (1981); Mardling (2013) Appendix B
+
+use crate::constants::TAU;
+use crate::secularlib::A_NEPTUNE_AU;
+use std::f64::consts::PI;
+
+/// Largest node count attempted before giving up on the tolerance.
+const MAX_POINTS: usize = 1 << 18;
+
+/// Numerical Hansen coefficient
+///
+///   X_j^{n,m}(e) = (1/2π) ∮ (r/a)^n cos(m f − j M) dM
+///
+/// evaluated with automatic convergence control: the quadrature node count
+/// doubles from 64 until successive estimates agree to `tol` (relative, with
+/// an absolute floor of 1e-13 so that coefficients that are exactly zero
+/// converge), panicking in debug builds if 2^18 nodes do not suffice.
+///
+/// Reference: Hughes (1981), Celestial Mechanics 25, 101
+///
+/// # Example
+///
+/// ```
+/// use starfield::secularlib::hansen_coefficient;
+///
+/// // X_0^{-2,0}(e) = (1 - e²)^{-1/2} in closed form.
+/// let num = hansen_coefficient(0, -2, 0, 0.4, 1e-10);
+/// let exact = (1.0_f64 - 0.4 * 0.4).powf(-0.5);
+/// assert!((num - exact).abs() < 1e-8);
+/// ```
+pub fn hansen_coefficient(j: i64, n: i32, m: i32, e: f64, tol: f64) -> f64 {
+    assert!((0.0..1.0).contains(&e), "eccentricity out of range: {e}");
+
+    let mut n_points = 64usize;
+    let mut prev = hansen_fixed(j, n, m, e, n_points);
+    while n_points < MAX_POINTS {
+        n_points *= 2;
+        let next = hansen_fixed(j, n, m, e, n_points);
+        if (next - prev).abs() <= tol * next.abs() + 1e-13 {
+            return next;
+        }
+        prev = next;
+    }
+    debug_assert!(
+        false,
+        "Hansen quadrature did not converge: j={j}, n={n}, m={m}, e={e}"
+    );
+    prev
+}
+
+/// Fixed-node evaluation on a uniform eccentric-anomaly midpoint grid.
+fn hansen_fixed(j: i64, n: i32, m: i32, e: f64, n_points: usize) -> f64 {
+    let de = TAU / n_points as f64;
+    let mut sum = 0.0;
+    for k in 0..n_points {
+        let ea = (k as f64 + 0.5) * de;
+        let r_over_a = 1.0 - e * ea.cos();
+        let mean_anom = ea - e * ea.sin();
+        // True anomaly from eccentric anomaly
+        let true_anom = 2.0 * (((1.0 + e) / (1.0 - e)).sqrt() * (ea / 2.0).tan()).atan();
+        let integrand =
+            r_over_a.powi(n) * (m as f64 * true_anom - j as f64 * mean_anom).cos() * r_over_a;
+        sum += integrand;
+    }
+    sum * de / TAU
+}
+
+/// Closed form X_0^{-3,0}(e) = (1 − e²)^{−3/2} (the secular orbit average of
+/// (a/r)³).
+///
+/// # Example
+///
+/// ```
+/// use starfield::secularlib::{hansen_coefficient, hansen_x0_neg3_0};
+///
+/// let e = 0.6;
+/// assert!((hansen_coefficient(0, -3, 0, e, 1e-10) - hansen_x0_neg3_0(e)).abs() < 1e-8);
+/// ```
+pub fn hansen_x0_neg3_0(e: f64) -> f64 {
+    (1.0 - e * e).powf(-1.5)
+}
+
+/// Asymptotic X_j^{-3,2} for a particle exterior to a planet at
+/// `a_planet_au` (AU) in the j:2 mean-motion resonance chain:
+///
+///   X_j^{-3,2} ≈ (2j/5) · exp(−(q/a_planet)²)
+///
+/// where q = a(1 − e) is the particle's perihelion distance in AU. The length
+/// scale in the exponent is the *planet's* semi-major axis, not the
+/// particle's (using q/a, i.e. 1 − e, is dimensionally inconsistent and off
+/// ~4x at e = 0.9 with the opposite e-trend).
+///
+/// Calibration regime: the fit was made for the Neptune 2:j chain, i.e.
+/// j ≳ 10 and q/a_planet ∈ (1.0, 1.7) (30–50 AU at Neptune); for other
+/// perturbers it assumes the same *scaled* regime. See
+/// [`hansen_x_neg3_2_neptune_chain`] for the Neptune-specific form.
+///
+/// Reference: Mardling (2013) Appendix B; Batygin & Brown (2021)
+pub fn hansen_x_neg3_2_chain(j: i64, q_au: f64, a_planet_au: f64) -> f64 {
+    let jf = j.abs() as f64;
+    (2.0 * jf / 5.0) * (-(q_au / a_planet_au).powi(2)).exp()
+}
+
+/// Asymptotic X_j^{-3,2} for a particle in the j:2 mean-motion resonance with
+/// Neptune (a_N = 30.07 AU). Valid for j ≳ 10 and q ∈ (30, 50) AU.
+///
+/// Convenience wrapper over [`hansen_x_neg3_2_chain`].
+///
+/// # Example
+///
+/// ```
+/// use starfield::secularlib::hansen_x_neg3_2_neptune_chain;
+///
+/// // Decreasing in perihelion distance q.
+/// assert!(hansen_x_neg3_2_neptune_chain(20, 30.0) > hansen_x_neg3_2_neptune_chain(20, 40.0));
+/// ```
+pub fn hansen_x_neg3_2_neptune_chain(j: i64, q_au: f64) -> f64 {
+    hansen_x_neg3_2_chain(j, q_au, A_NEPTUNE_AU)
+}
+
+/// Mean anomaly → true anomaly for an elliptic orbit (e < 1), via a
+/// safeguarded Newton/bisection Kepler solve.
+///
+/// # Example
+///
+/// ```
+/// use starfield::secularlib::mean_to_true_anomaly;
+///
+/// // Circular orbit: f = M. Perihelion: f = 0 for any e.
+/// assert!((mean_to_true_anomaly(1.0, 0.0) - 1.0).abs() < 1e-12);
+/// assert!(mean_to_true_anomaly(0.0, 0.7).abs() < 1e-12);
+/// ```
+pub fn mean_to_true_anomaly(mean_anomaly: f64, e: f64) -> f64 {
+    let ea = solve_kepler_elliptic(e, mean_anomaly);
+    2.0 * (((1.0 + e) / (1.0 - e)).sqrt() * (ea / 2.0).tan()).atan()
+}
+
+/// Solve Kepler's equation M = E − e sin E for the eccentric anomaly E
+/// (elliptic case, 0 ≤ e < 1) with a bisection-safeguarded Newton iteration.
+///
+/// (`keplerlib`'s internal solver targets the e > 0 elliptic/hyperbolic cases
+/// and divides by e in its starting guess; this one is well-defined down to
+/// e = 0.)
+fn solve_kepler_elliptic(e: f64, mean_anomaly: f64) -> f64 {
+    debug_assert!((0.0..1.0).contains(&e), "eccentricity out of range: {e}");
+
+    // Reduce M to (−π, π] and exploit the odd symmetry E(−M) = −E(M).
+    let mut m = mean_anomaly % TAU;
+    if m > PI {
+        m -= TAU;
+    } else if m < -PI {
+        m += TAU;
+    }
+    let sign = if m < 0.0 { -1.0 } else { 1.0 };
+    let m = m.abs();
+
+    // For M in [0, π] the root lies in [M, M + e] (since 0 ≤ e sin E ≤ e
+    // there: f(M) ≤ 0 and f(M + e) ≥ 0).
+    let mut lo = m;
+    let mut hi = m + e;
+    let mut ea = (if e > 0.8 { PI } else { m + 0.85 * e }).clamp(lo, hi);
+
+    for _ in 0..100 {
+        let f = ea - e * ea.sin() - m;
+        if f > 0.0 {
+            hi = ea;
+        } else {
+            lo = ea;
+        }
+        let fp = 1.0 - e * ea.cos();
+        let step = f / fp;
+        // A tiny Newton step means we are converged; take it even when it
+        // grazes the bracket boundary (the bisection fallback below would
+        // stop short at the bracket midpoint).
+        if step.abs() < 1e-14 * ea.abs().max(1.0) {
+            ea -= step;
+            break;
+        }
+        let next = ea - step;
+        // Fall back to bisection whenever Newton leaves the bracket.
+        ea = if next > lo && next < hi {
+            next
+        } else {
+            0.5 * (lo + hi)
+        };
+    }
+    sign * ea
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn test_hansen_matches_closed_form_x0() {
+        for &e in &[0.0, 0.3, 0.7, 0.9] {
+            let num = hansen_coefficient(0, -3, 0, e, 1e-10);
+            let exact = hansen_x0_neg3_0(e);
+            assert_relative_eq!(num, exact, max_relative = 1e-8);
+        }
+    }
+
+    #[test]
+    fn test_hansen_x0_neg2_0_closed_form() {
+        // X_0^{-2,0}(e) = (1 - e²)^{-1/2}
+        for &e in &[0.0, 0.4, 0.8] {
+            let num = hansen_coefficient(0, -2, 0, e, 1e-10);
+            let exact = (1.0 - e * e).powf(-0.5);
+            assert_relative_eq!(num, exact, max_relative = 1e-8);
+        }
+    }
+
+    #[test]
+    fn test_hansen_x0_1_0_closed_form() {
+        // X_0^{1,0}(e) = 1 + e²/2 (orbit average of r/a)
+        let num = hansen_coefficient(0, 1, 0, 0.6, 1e-10);
+        assert_relative_eq!(num, 1.0 + 0.18, max_relative = 1e-8);
+    }
+
+    #[test]
+    fn test_hansen_circular_kronecker() {
+        // At e = 0, X_j^{n,m} = δ_{jm}.
+        assert_relative_eq!(
+            hansen_coefficient(2, -3, 2, 0.0, 1e-10),
+            1.0,
+            epsilon = 1e-10
+        );
+        assert!(hansen_coefficient(3, -3, 2, 0.0, 1e-10).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_hansen_high_e_converges() {
+        // High-e, large-j case that aliases on a fixed 256-point grid.
+        let v = hansen_coefficient(40, -3, 2, 0.95, 1e-8);
+        assert!(v.is_finite());
+    }
+
+    #[test]
+    fn test_neptune_chain_asymptotic_trends() {
+        // Decreasing in q, increasing in j, positive.
+        let x = hansen_x_neg3_2_neptune_chain(20, 35.0);
+        assert!(x > 0.0);
+        assert!(hansen_x_neg3_2_neptune_chain(20, 30.0) > hansen_x_neg3_2_neptune_chain(20, 40.0));
+        assert!(hansen_x_neg3_2_neptune_chain(30, 35.0) > x);
+    }
+
+    #[test]
+    fn test_neptune_chain_matches_generic_form() {
+        // The Neptune wrapper is exactly the generic form at a_N = 30.07 AU.
+        for &(j, q) in &[(10, 30.0), (20, 35.0), (40, 50.0)] {
+            assert_eq!(
+                hansen_x_neg3_2_neptune_chain(j, q),
+                hansen_x_neg3_2_chain(j, q, A_NEPTUNE_AU)
+            );
+        }
+    }
+
+    #[test]
+    fn test_mean_to_true_anomaly() {
+        // Circular: f = M. Perihelion: f = 0 for any e.
+        assert_relative_eq!(mean_to_true_anomaly(1.0, 0.0), 1.0, epsilon = 1e-10);
+        assert!(mean_to_true_anomaly(0.0, 0.7).abs() < 1e-10);
+        // High-e quarter orbit stays finite and ahead of M.
+        let f = mean_to_true_anomaly(0.5, 0.9);
+        assert!(f > 0.5 && f < PI);
+    }
+
+    #[test]
+    fn test_kepler_solver_residual() {
+        // E − e sin E must reproduce M across e and M.
+        for &e in &[0.0, 0.1, 0.5, 0.9, 0.99] {
+            for k in 0..20 {
+                let m = -PI + (k as f64 + 0.5) * (TAU / 20.0);
+                let ea = solve_kepler_elliptic(e, m);
+                let residual = (ea - e * ea.sin() - m).abs();
+                assert!(residual < 1e-12, "e={e}, M={m}: residual {residual:.3e}");
+            }
+        }
+    }
+}

--- a/src/secularlib/mod.rs
+++ b/src/secularlib/mod.rs
@@ -1,0 +1,93 @@
+//! Secular and resonance dynamics for long-term small-body evolution.
+//!
+//! Three submodules:
+//!
+//! * [`hamiltonian`] — doubly-averaged secular Hamiltonians: the analytic
+//!   Kozai–Lidov quadrupole (valid in the hierarchical limit α = a/a_p ≪ 1)
+//!   and numerical Gauss-ring double averaging of the exact interaction,
+//!   which remains valid in the non-hierarchical regime (α ≳ 0.3) where the
+//!   multipole series diverges and which captures the octupole-and-higher
+//!   apsidal (Δϖ) structure automatically.
+//! * [`hansen`] — Hansen coefficients X_j^{n,m}(e) of the disturbing
+//!   function, via convergence-controlled quadrature plus standard closed
+//!   forms and asymptotics.
+//! * [`resonance`] — mean-motion resonance machinery: resonance locations,
+//!   the canonical resonant angle, libration detection on time series, and
+//!   the Chirikov resonance-overlap (chaos) criterion with its critical
+//!   perihelion.
+//!
+//! The most common items are re-exported at this level.
+//!
+//! # Units
+//!
+//! This module uses the conventions of the dynamics literature throughout:
+//! lengths in **AU**, angles in **radians**, time in **days**, and
+//! gravitational parameters (GM) in **AU³/day²**. This matches starfield's
+//! `keplerlib` internals; `elementslib` and `constants::GM_SUN` use km³/s²
+//! instead — convert with
+//!
+//! ```
+//! use starfield::constants::{AU_KM, DAY_S, GM_SUN};
+//! use starfield::secularlib::GM_SUN_AU3_DAY2;
+//!
+//! let gm_sun_au3_day2 = GM_SUN * DAY_S * DAY_S / (AU_KM * AU_KM * AU_KM);
+//! assert!((gm_sun_au3_day2 - GM_SUN_AU3_DAY2).abs() / GM_SUN_AU3_DAY2 < 1e-9);
+//! ```
+
+pub mod hamiltonian;
+pub mod hansen;
+pub mod resonance;
+
+pub use hamiltonian::{
+    coplanar_quadrupole, numerical_secular_hamiltonian, phase_portrait, quadrupole_hamiltonian,
+};
+pub use hansen::{
+    hansen_coefficient, hansen_x0_neg3_0, hansen_x_neg3_2_chain, hansen_x_neg3_2_neptune_chain,
+    mean_to_true_anomaly,
+};
+pub use resonance::{
+    chirikov_overlap_parameter, chirikov_overlap_parameter_neptune, critical_perihelion,
+    critical_perihelion_neptune, is_chaotic, is_chaotic_neptune, is_librating, libration_amplitude,
+    resonance_semi_major_axis, resonant_angle,
+};
+
+/// GM of the Sun in AU³/day² (the square of the Gaussian gravitational
+/// constant, k²).
+///
+/// Derived from the DE440 GM_SUN = 1.32712440041279419e+20 m³/s²
+/// (Park et al. 2021) with AU = 1.495978707e+11 m and day = 86 400 s.
+/// Agrees with `starfield::constants::GM_SUN` (km³/s², from a slightly older
+/// determination) to ~5e-12 relative; the agreement is pinned by a test.
+pub const GM_SUN_AU3_DAY2: f64 = 2.959122082855911e-4;
+
+/// GM of Neptune in AU³/day². Source: JPL DE440 / Park et al. (2021).
+pub const GM_NEPTUNE_AU3_DAY2: f64 = 1.524_358_9e-8;
+
+/// Neptune's semi-major axis in AU.
+pub const A_NEPTUNE_AU: f64 = 30.07;
+
+/// Neptune/Sun mass ratio. Source: JPL DE440 / Park et al. (2021).
+pub const MASS_NEPTUNE_SOLAR: f64 = 5.151_389_0e-5;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::{AU_KM, DAY_S, GM_SUN};
+
+    #[test]
+    fn test_gm_sun_conventions_agree() {
+        // starfield's GM_SUN (km³/s²) converted to AU³/day² must match the
+        // DE440-derived constant used here.
+        let converted = GM_SUN * DAY_S * DAY_S / (AU_KM * AU_KM * AU_KM);
+        let rel = ((converted - GM_SUN_AU3_DAY2) / GM_SUN_AU3_DAY2).abs();
+        assert!(rel < 1e-9, "GM_SUN conventions disagree: rel = {rel:.3e}");
+    }
+
+    #[test]
+    fn test_neptune_gm_consistent_with_mass_ratio() {
+        let rel = ((GM_NEPTUNE_AU3_DAY2 / GM_SUN_AU3_DAY2 - MASS_NEPTUNE_SOLAR)
+            / MASS_NEPTUNE_SOLAR)
+            .abs();
+        assert!(rel < 1e-6, "GM_NEPTUNE vs mass ratio: rel = {rel:.3e}");
+    }
+}

--- a/src/secularlib/resonance.rs
+++ b/src/secularlib/resonance.rs
@@ -1,0 +1,319 @@
+//! Mean-motion resonance machinery: resonant angles, libration detection,
+//! and the Chirikov resonance-overlap (chaos) criterion for the 2:j chain of
+//! an arbitrary planet (with Neptune-flavored convenience wrappers).
+//!
+//! Conventions: a particle *exterior* to the planet in the p:q resonance
+//! (p > q, both positive, p orbits of the planet per q orbits of the
+//! particle) sits at a_res = a_planet (p/q)^{2/3} and has the stationary
+//! angle
+//!
+//!   φ = p λ − q λ_planet − (p − q) ϖ
+//!
+//! which satisfies the d'Alembert rule (coefficients sum to zero) and is
+//! stationary when n/n_planet = q/p. (A p/q-swapped convention circulates
+//! even for an exactly resonant orbit; the overlap exponent carries
+//! q²/(2 a_pl²), the form consistent with the pendulum half-width of the
+//! resonance potential and with [`critical_perihelion`] — a q²/(4 a_pl²)
+//! variant is off by ≈ 1.4 at q = 35 AU for Neptune.)
+//!
+//! Units: AU, radians (see the [`crate::secularlib`] docs).
+//!
+//! Reference: Murray & Dermott (1999) Ch. 8; Batygin & Brown (2021)
+
+use crate::constants::TAU;
+use crate::secularlib::{A_NEPTUNE_AU, MASS_NEPTUNE_SOLAR};
+
+/// Semi-major axis of the exterior p:q resonance with a planet at
+/// `a_planet` (AU): a_res = a_planet (p/q)^{2/3}.
+///
+/// # Example
+///
+/// ```
+/// use starfield::secularlib::{resonance_semi_major_axis, A_NEPTUNE_AU};
+///
+/// // Neptune 3:2 (Plutinos): a ≈ 39.4 AU
+/// let a = resonance_semi_major_axis(3, 2, A_NEPTUNE_AU);
+/// assert!((a - 39.4).abs() < 0.1);
+/// ```
+pub fn resonance_semi_major_axis(p: u32, q: u32, a_planet: f64) -> f64 {
+    a_planet * (p as f64 / q as f64).powf(2.0 / 3.0)
+}
+
+/// Resonant angle φ = p λ − q λ_planet − (p − q) ϖ for the exterior p:q
+/// resonance, wrapped to [0, 2π).
+///
+/// `lambda`/`varpi` are the particle's mean longitude and longitude of
+/// perihelion; `lambda_planet` the planet's mean longitude (all radians).
+///
+/// # Example
+///
+/// ```
+/// use starfield::secularlib::resonant_angle;
+///
+/// // At t = 0 with λ = ϖ the 5:2 angle is (5 − 2) ϖ − (5 − 2) ϖ + ... = 2ϖ.
+/// let phi = resonant_angle(5, 2, 1.3, 0.0, 1.3);
+/// assert!((phi - 2.0 * 1.3).abs() < 1e-12);
+/// ```
+pub fn resonant_angle(p: u32, q: u32, lambda: f64, lambda_planet: f64, varpi: f64) -> f64 {
+    let (pf, qf) = (p as f64, q as f64);
+    (pf * lambda - qf * lambda_planet - (pf - qf) * varpi).rem_euclid(TAU)
+}
+
+/// Libration amplitude of a resonant-angle time series, or `None` if the
+/// angle circulates.
+///
+/// Detection: sort the angles on the circle and find the largest angular gap.
+/// A librating angle occupies an arc, leaving an empty gap > `min_gap`; a
+/// circulating angle covers the circle (max gap → 2π·ln N/N for N uniform
+/// samples). The returned amplitude is the half-width of the occupied arc.
+///
+/// `min_gap` of ~1 rad is a robust default for ≳ 50 samples spanning several
+/// libration periods.
+///
+/// # Example
+///
+/// ```
+/// use starfield::secularlib::libration_amplitude;
+///
+/// // φ oscillating about π with amplitude 0.8 librates.
+/// let angles: Vec<f64> = (0..200)
+///     .map(|k| std::f64::consts::PI + 0.8 * (0.1 * k as f64).sin())
+///     .collect();
+/// let amp = libration_amplitude(&angles, 1.0).unwrap();
+/// assert!((amp - 0.8).abs() < 0.05);
+/// ```
+pub fn libration_amplitude(angles: &[f64], min_gap: f64) -> Option<f64> {
+    if angles.len() < 2 {
+        return None;
+    }
+    let mut sorted: Vec<f64> = angles.iter().map(|a| a.rem_euclid(TAU)).collect();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+    let mut max_gap = TAU - (sorted[sorted.len() - 1] - sorted[0]);
+    for w in sorted.windows(2) {
+        max_gap = max_gap.max(w[1] - w[0]);
+    }
+
+    if max_gap > min_gap {
+        Some(0.5 * (TAU - max_gap))
+    } else {
+        None
+    }
+}
+
+/// Whether a resonant-angle time series librates (see [`libration_amplitude`]).
+pub fn is_librating(angles: &[f64], min_gap: f64) -> bool {
+    libration_amplitude(angles, min_gap).is_some()
+}
+
+/// Chirikov overlap parameter for the 2:j resonance chain of a planet at
+/// `a_planet_au` (AU) with planet/star mass ratio `mass_ratio`:
+///
+///   K = Δa/δa = (24/√5) (a/a_pl)^{5/4} √(m_pl/M*) · exp(−q²/(2 a_pl²))
+///
+/// Adjacent resonances overlap (K > 1) ⇒ chaotic transport. The exponent
+/// carries q²/(2 a_pl²) — this is the form consistent with the pendulum
+/// half-width of the resonance potential and with [`critical_perihelion`].
+/// The exponential inherits the calibration regime of the
+/// [`crate::secularlib::hansen::hansen_x_neg3_2_chain`] asymptotic
+/// (q/a_pl ∈ ~(1.0, 1.7), fitted on the Neptune chain).
+///
+/// Reference: Batygin & Brown (2021); Murray & Dermott (1999) Ch. 9
+///
+/// # Example
+///
+/// ```
+/// use starfield::secularlib::{
+///     chirikov_overlap_parameter, A_NEPTUNE_AU, MASS_NEPTUNE_SOLAR,
+/// };
+///
+/// // Overlap strengthens with semi-major axis at fixed perihelion.
+/// let k1 = chirikov_overlap_parameter(100.0, 35.0, A_NEPTUNE_AU, MASS_NEPTUNE_SOLAR);
+/// let k2 = chirikov_overlap_parameter(500.0, 35.0, A_NEPTUNE_AU, MASS_NEPTUNE_SOLAR);
+/// assert!(k2 > k1);
+/// ```
+pub fn chirikov_overlap_parameter(a_au: f64, q_au: f64, a_planet_au: f64, mass_ratio: f64) -> f64 {
+    let alpha = a_au / a_planet_au;
+    (24.0 / 5.0_f64.sqrt())
+        * alpha.powf(1.25)
+        * mass_ratio.sqrt()
+        * (-q_au * q_au / (2.0 * a_planet_au * a_planet_au)).exp()
+}
+
+/// Chirikov overlap parameter for the Neptune 2:j chain (convenience wrapper
+/// over [`chirikov_overlap_parameter`] with a_N = 30.07 AU and the Neptune/Sun
+/// mass ratio).
+pub fn chirikov_overlap_parameter_neptune(a_au: f64, q_au: f64) -> f64 {
+    chirikov_overlap_parameter(a_au, q_au, A_NEPTUNE_AU, MASS_NEPTUNE_SOLAR)
+}
+
+/// Whether orbits at (a, q) are in the chaotic resonance-overlap regime of
+/// the planet's 2:j chain (K > 1; see [`chirikov_overlap_parameter`]).
+pub fn is_chaotic(a_au: f64, q_au: f64, a_planet_au: f64, mass_ratio: f64) -> bool {
+    chirikov_overlap_parameter(a_au, q_au, a_planet_au, mass_ratio) > 1.0
+}
+
+/// Whether orbits at (a, q) are in Neptune's chaotic resonance-overlap regime.
+pub fn is_chaotic_neptune(a_au: f64, q_au: f64) -> bool {
+    is_chaotic(a_au, q_au, A_NEPTUNE_AU, MASS_NEPTUNE_SOLAR)
+}
+
+/// Critical perihelion below which the planet's 2:j chain overlaps (the
+/// K = 1 root of [`chirikov_overlap_parameter`]):
+///
+///   q_crit = a_pl √( ln\[ (576/5) (m_pl/M*) (a/a_pl)^{5/2} \] )
+///
+/// Returns 0 when the argument of the log is ≤ 1 (no chaos at any q).
+///
+/// # Example
+///
+/// ```
+/// use starfield::secularlib::{
+///     chirikov_overlap_parameter, critical_perihelion, A_NEPTUNE_AU, MASS_NEPTUNE_SOLAR,
+/// };
+///
+/// // K(a, q_crit(a)) = 1 by construction.
+/// let q = critical_perihelion(500.0, A_NEPTUNE_AU, MASS_NEPTUNE_SOLAR);
+/// let k = chirikov_overlap_parameter(500.0, q, A_NEPTUNE_AU, MASS_NEPTUNE_SOLAR);
+/// assert!((k - 1.0).abs() < 1e-10);
+/// ```
+pub fn critical_perihelion(a_au: f64, a_planet_au: f64, mass_ratio: f64) -> f64 {
+    let alpha = a_au / a_planet_au;
+    let argument = (576.0 / 5.0) * mass_ratio * alpha.powf(2.5);
+    if argument <= 1.0 {
+        return 0.0;
+    }
+    a_planet_au * argument.ln().sqrt()
+}
+
+/// Critical perihelion of the Neptune 2:j chain (convenience wrapper over
+/// [`critical_perihelion`]).
+///
+/// # Example
+///
+/// ```
+/// use starfield::secularlib::critical_perihelion_neptune;
+///
+/// // q_crit(500 AU) ≈ 41.4 AU for Neptune.
+/// let q = critical_perihelion_neptune(500.0);
+/// assert!((q - 41.4).abs() < 0.1);
+/// ```
+pub fn critical_perihelion_neptune(a_au: f64) -> f64 {
+    critical_perihelion(a_au, A_NEPTUNE_AU, MASS_NEPTUNE_SOLAR)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn test_resonant_angle_stationary_at_exact_resonance() {
+        // A perfectly resonant orbit: n/n_N = q/p. The angle must be
+        // constant in time — the p/q-swapped convention circulates at
+        // n_N (p² − q²)/q and fails this test.
+        let (p, q) = (5u32, 2u32);
+        let n_planet = 1.0e-2; // rad/day
+        let n = n_planet * (q as f64) / (p as f64);
+        let varpi = 1.3;
+
+        let phi0 = resonant_angle(p, q, varpi, 0.0, varpi);
+        for step in 1..200 {
+            let t = step as f64 * 50.0;
+            let phi = resonant_angle(p, q, varpi + n * t, n_planet * t, varpi);
+            assert_relative_eq!(phi, phi0, epsilon = 1e-9);
+        }
+    }
+
+    #[test]
+    fn test_resonant_angle_circulates_off_resonance() {
+        let (p, q) = (3u32, 1u32);
+        let n_planet = 1.0e-2;
+        let n = n_planet * (q as f64) / (p as f64) * 1.05; // 5% off
+        let angles: Vec<f64> = (0..500)
+            .map(|s| {
+                let t = s as f64 * 200.0;
+                resonant_angle(p, q, n * t, n_planet * t, 0.0)
+            })
+            .collect();
+        assert!(!is_librating(&angles, 1.0));
+    }
+
+    #[test]
+    fn test_libration_detection() {
+        // Librating: φ oscillates about π with amplitude 0.8.
+        let librating: Vec<f64> = (0..200)
+            .map(|k| std::f64::consts::PI + 0.8 * (0.1 * k as f64).sin())
+            .collect();
+        let amp = libration_amplitude(&librating, 1.0).expect("should librate");
+        assert!((amp - 0.8).abs() < 0.05, "amplitude {amp}");
+
+        // Circulating: uniform coverage.
+        let circulating: Vec<f64> = (0..200).map(|k| k as f64 * TAU / 200.0).collect();
+        assert!(libration_amplitude(&circulating, 1.0).is_none());
+    }
+
+    #[test]
+    fn test_resonance_location() {
+        // Neptune 3:2 (Plutinos): a ≈ 39.4 AU
+        let a = resonance_semi_major_axis(3, 2, A_NEPTUNE_AU);
+        assert!((a - 39.4).abs() < 0.1, "a = {a}");
+    }
+
+    #[test]
+    fn test_chirikov_critical_perihelion_consistent_with_overlap() {
+        // The two public APIs must agree: K(a, q_crit(a)) = 1 exactly —
+        // for Neptune and for a heavier, more distant perturber alike.
+        for &(a_pl, mu) in &[(A_NEPTUNE_AU, MASS_NEPTUNE_SOLAR), (19.19, 4.366_244_0e-5)] {
+            for &a in &[300.0, 500.0, 1000.0] {
+                let q_crit = critical_perihelion(a, a_pl, mu);
+                assert!(q_crit > 0.0);
+                let k = chirikov_overlap_parameter(a, q_crit, a_pl, mu);
+                assert_relative_eq!(k, 1.0, epsilon = 1e-10);
+                // And the classification flips across the boundary.
+                assert!(is_chaotic(a, q_crit - 1.0, a_pl, mu));
+                assert!(!is_chaotic(a, q_crit + 1.0, a_pl, mu));
+            }
+        }
+    }
+
+    #[test]
+    fn test_chirikov_trends() {
+        assert!(
+            chirikov_overlap_parameter_neptune(500.0, 35.0)
+                > chirikov_overlap_parameter_neptune(100.0, 35.0)
+        );
+        assert!(
+            chirikov_overlap_parameter_neptune(200.0, 30.0)
+                > chirikov_overlap_parameter_neptune(200.0, 45.0)
+        );
+        // q_crit at a = 500 AU is in the trans-Neptunian range
+        let q = critical_perihelion_neptune(500.0);
+        assert!(q > 25.0 && q < 60.0, "q_crit = {q}");
+    }
+
+    #[test]
+    fn test_neptune_critical_perihelion_pin() {
+        // Pin against the planet9 reference value: q_crit(500 AU) = 41.4 AU.
+        let q = critical_perihelion_neptune(500.0);
+        assert!((q - 41.4).abs() < 0.1, "q_crit(500) = {q}");
+    }
+
+    #[test]
+    fn test_neptune_wrappers_match_generic_form() {
+        for &(a, q) in &[(300.0, 35.0), (500.0, 41.0), (1000.0, 50.0)] {
+            assert_eq!(
+                chirikov_overlap_parameter_neptune(a, q),
+                chirikov_overlap_parameter(a, q, A_NEPTUNE_AU, MASS_NEPTUNE_SOLAR)
+            );
+            assert_eq!(
+                is_chaotic_neptune(a, q),
+                is_chaotic(a, q, A_NEPTUNE_AU, MASS_NEPTUNE_SOLAR)
+            );
+        }
+        assert_eq!(
+            critical_perihelion_neptune(500.0),
+            critical_perihelion(500.0, A_NEPTUNE_AU, MASS_NEPTUNE_SOLAR)
+        );
+    }
+}


### PR DESCRIPTION
Adds starfield::secularlib, extracted from OrbitalCommons/planet9 and genericized over the perturber:

- hamiltonian — quadrupole/octupole secular Hamiltonians with documented validity regimes, plus numerical Gauss-ring double averaging of the exact interaction for the non-hierarchical regime (alpha > ~0.3) where multipole series diverge; phase-portrait helper
- hansen — convergence-controlled numerical Hansen coefficients + asymptotics (calibration regime documented)
- resonance — resonance locations, canonical resonant angle, libration detection, Chirikov overlap parameter and critical perihelion, all taking (a_planet, mass_ratio) with Neptune convenience wrappers

Units convention documented at module root (AU, radians, days, GM in AU^3/day^2) with a doc-tested conversion from constants::GM_SUN. All source citations travel with the code, including the bug-history notes from planet9's review (these exact formulas were once wrong in three mutually inconsistent ways). Internal-consistency identity overlap(a, q_crit(a)) = 1 tested for Neptune and a Uranus-like perturber; Neptune q_crit(500 AU) = 41.4 AU pinned. 25 unit + 15 doc tests; clippy -D warnings clean; zero new dependencies.

Closes OrbitalCommons/planet9#31