### PR TITLE
Add nbodylib: symplectic N-body integrator stack

### DIFF
--- a/examples/nbody_giants.rs
+++ b/examples/nbody_giants.rs
@@ -1,0 +1,89 @@
+//! Integrate the four giant planets for 1000 years with the Wisdom-Holman
+//! symplectic integrator, starting from real DE421 ephemeris states.
+//!
+//! Demonstrates the planetlib → nbodylib bridge: kernel states in,
+//! long-term dynamics out, with energy and angular momentum diagnostics.
+//!
+//! Usage: cargo run --example nbody_giants
+
+use starfield::constants::J2000;
+use starfield::jplephem::SpiceKernel;
+use starfield::nbodylib::{
+    barycentric_energy, cartesian_to_elements, giant_planets_from_ephemeris,
+    total_angular_momentum, validate_timestep, SimConfig, StateVector, WhmIntegrator, GM_SUN,
+};
+use starfield::planetlib::Ephemeris;
+use starfield::Timescale;
+
+fn main() -> starfield::Result<()> {
+    let ts = Timescale::default();
+    let bsp_path = "test_data/de421.bsp";
+
+    println!("Wisdom-Holman integration of the giant planets");
+    println!("==============================================\n");
+
+    // Initial conditions: heliocentric ecliptic-J2000 barycenter states from
+    // DE421 at J2000, paired with DE440 system GMs.
+    let mut ephemeris = Ephemeris::from_kernel(SpiceKernel::open(bsp_path)?);
+    let t0 = ts.tdb_jd(J2000);
+    let mut bodies = giant_planets_from_ephemeris(&mut ephemeris, &t0)
+        .map_err(|e| starfield::StarfieldError::DataError(e.to_string()))?;
+
+    println!("Initial states (J2000, from {bsp_path}):");
+    for body in &bodies {
+        let elem = cartesian_to_elements(&body.state, GM_SUN);
+        println!(
+            "  {:<8} r = {:6.3} AU   a = {:6.3} AU   e = {:.4}",
+            body.name,
+            body.state.distance(),
+            elem.a,
+            elem.e
+        );
+    }
+
+    // 1000 years at dt = 150 d (P_Jupiter / 20 ≈ 217 d, so Jupiter is
+    // resolved; validate_timestep enforces this).
+    let dt = 150.0;
+    validate_timestep(&bodies, dt).expect("timestep under-resolves a planet");
+    let years = 1000.0;
+    let n_steps = (years * 365.25 / dt).round() as usize;
+
+    let mut particles: Vec<StateVector> = Vec::new();
+    let mut active: Vec<bool> = Vec::new();
+    let config = SimConfig {
+        dt,
+        ..SimConfig::default()
+    };
+    let integrator = WhmIntegrator::new();
+
+    let e0 = barycentric_energy(&bodies);
+    let l0 = total_angular_momentum(&bodies);
+
+    let mut max_de: f64 = 0.0;
+    for step in 0..n_steps {
+        integrator.step(&mut bodies, &mut particles, &mut active, dt, &config);
+        if step % 100 == 99 {
+            let e1 = barycentric_energy(&bodies);
+            max_de = max_de.max(((e1 - e0) / e0).abs());
+        }
+    }
+
+    let dl = (total_angular_momentum(&bodies) - l0).norm() / l0.norm();
+
+    println!("\nAfter {years:.0} years ({n_steps} steps of {dt} d):");
+    for body in &bodies {
+        let elem = cartesian_to_elements(&body.state, GM_SUN);
+        println!(
+            "  {:<8} r = {:6.3} AU   a = {:6.3} AU   e = {:.4}",
+            body.name,
+            body.state.distance(),
+            elem.a,
+            elem.e
+        );
+    }
+    println!("\nDiagnostics (symplectic: bounded, not growing):");
+    println!("  max |dE/E| = {max_de:.3e}");
+    println!("  |dL|/|L|   = {dl:.3e}");
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod jplephem;
 pub mod jplephem_ext;
 pub mod keplerlib;
 pub mod magnitudelib;
+pub mod nbodylib;
 pub mod nutationlib;
 pub mod planetlib;
 pub mod positions;

--- a/src/nbodylib/bulirsch_stoer.rs
+++ b/src/nbodylib/bulirsch_stoer.rs
@@ -1,0 +1,400 @@
+//! Bulirsch-Stoer integrator for high-accuracy integration during close
+//! encounters.
+//!
+//! Uses the modified midpoint method with Richardson extrapolation to achieve
+//! arbitrary accuracy. This is the fallback integrator when a particle enters
+//! a planet's Hill sphere and the symplectic integrator would fail.
+//!
+//! Two fixes relative to a naive implementation (bug history preserved from
+//! the original port):
+//!
+//! 1. **Planets move during the step.** Each acceleration evaluation
+//!    Kepler-drifts every massive body from its step-start state to the
+//!    substep epoch, instead of holding planets frozen over the full dt
+//!    (Jupiter moves ~25 deg in 300 d).
+//! 2. **Adaptive step reduction.** When the extrapolation tableau fails to
+//!    converge, the step is recursively halved rather than silently
+//!    returning the unconverged full-step estimate.
+//!
+//! The force model supports the Chambers (1999) hybrid changeover: each body
+//! carries a critical radius `r_crit`, and the BS force takes the fraction
+//! `1 - K(d)` of the direct planet force (the kick stage applies the
+//! complementary `K(d)` fraction plus the indirect term). Pass `r_crit = 0`
+//! for full direct force (pure BS integration, no kick sharing).
+//!
+//! Reference: Press et al., Numerical Recipes; Stoer & Bulirsch (1980);
+//! Chambers (1999)
+
+use nalgebra::Vector3;
+
+use super::kepler::kepler_drift;
+use super::types::{MassiveBody, StateVector};
+use super::GM_SUN;
+
+/// Maximum subdivision sequence for Bulirsch-Stoer extrapolation.
+/// Bulirsch-Stoer sequence: 2, 4, 6, 8, 12, 16, 24, 32, ...
+const BS_SEQUENCE: [usize; 12] = [2, 4, 6, 8, 12, 16, 24, 32, 48, 64, 96, 128];
+
+/// Maximum number of columns in the extrapolation tableau.
+const MAX_COLUMNS: usize = 12;
+
+/// Maximum recursive halvings before giving up (dt reduction of 2^8 = 256x).
+const MAX_HALVINGS: u32 = 8;
+
+/// Chambers (1999) changeover function K(d).
+///
+/// Returns the fraction of the direct planet force handled by the *kick*
+/// stage: K = 1 far from the planet (d >= r_crit, pure symplectic kick),
+/// K = 0 deep inside the encounter region (d <= 0.1 r_crit, pure BS), with
+/// the smooth rational bridge K = y^2 / (2y^2 - 2y + 1) in between.
+/// The BS force uses the complement (1 - K).
+pub fn changeover_k(d: f64, r_crit: f64) -> f64 {
+    if r_crit <= 0.0 {
+        return 1.0;
+    }
+    let y = (d - 0.1 * r_crit) / (0.9 * r_crit);
+    if y <= 0.0 {
+        0.0
+    } else if y >= 1.0 {
+        1.0
+    } else {
+        y * y / (2.0 * y * y - 2.0 * y + 1.0)
+    }
+}
+
+/// Gravitational acceleration on a test particle at time `t` after the step
+/// start: Sun plus the BS share `(1 - K)` of the direct force from each body,
+/// with bodies Kepler-drifted from their step-start states to time `t`.
+///
+/// The indirect (heliocentric-frame) term is *not* included here: in the
+/// hybrid scheme it is applied at full weight by the kick stage. For
+/// standalone BS use (empty `r_crit` handling via `r_crit[i] = 0`) the
+/// indirect term is negligible only if the bodies are massless or the caller
+/// accounts for it separately.
+fn acceleration(
+    pos: &Vector3<f64>,
+    t: f64,
+    bodies: &[MassiveBody],
+    r_crit: &[f64],
+) -> Vector3<f64> {
+    let r = pos.norm();
+    let mut accel = if r > 1e-30 {
+        -GM_SUN * pos / (r * r * r)
+    } else {
+        Vector3::zeros()
+    };
+
+    for (j, body) in bodies.iter().enumerate() {
+        // Drift the planet to the substep epoch (frozen planets give O(1)
+        // errors over a 300 d step).
+        let body_pos = if t != 0.0 {
+            kepler_drift(&body.state, t, GM_SUN + body.gm).pos
+        } else {
+            body.state.pos
+        };
+        let dr = pos - body_pos;
+        let dr_mag = dr.norm();
+        if dr_mag > 1e-30 {
+            let bs_weight = 1.0 - changeover_k(dr_mag, r_crit.get(j).copied().unwrap_or(0.0));
+            accel -= bs_weight * body.gm * dr / (dr_mag * dr_mag * dr_mag);
+        }
+    }
+
+    accel
+}
+
+/// Modified midpoint method: integrate from t0 to t0+H using n substeps.
+/// Returns the final state vector.
+fn modified_midpoint(
+    state: &StateVector,
+    bodies: &[MassiveBody],
+    r_crit: &[f64],
+    t0: f64,
+    h_total: f64,
+    n_steps: usize,
+) -> StateVector {
+    let h = h_total / n_steps as f64;
+
+    // First step: Euler
+    let a0 = acceleration(&state.pos, t0, bodies, r_crit);
+    let mut z_prev = state.pos;
+    let mut z_curr = state.pos + h * state.vel;
+    let mut v_prev = state.vel;
+    let mut v_curr = state.vel + h * a0;
+
+    // General steps: leapfrog
+    for k in 1..n_steps {
+        let a = acceleration(&z_curr, t0 + k as f64 * h, bodies, r_crit);
+        let z_next = z_prev + 2.0 * h * v_curr;
+        let v_next = v_prev + 2.0 * h * a;
+
+        z_prev = z_curr;
+        z_curr = z_next;
+        v_prev = v_curr;
+        v_curr = v_next;
+    }
+
+    // Final smoothing step
+    let a_final = acceleration(&z_curr, t0 + h_total, bodies, r_crit);
+    let pos = 0.5 * (z_prev + z_curr + h * v_curr);
+    let vel = 0.5 * (v_prev + v_curr + h * a_final);
+
+    StateVector::new(pos, vel)
+}
+
+/// One Bulirsch-Stoer extrapolation attempt over [t0, t0+dt].
+///
+/// Returns `(state, converged)`: the extrapolated state and whether the
+/// tableau met the tolerance `epsilon`.
+fn bs_attempt(
+    state: &StateVector,
+    bodies: &[MassiveBody],
+    r_crit: &[f64],
+    t0: f64,
+    dt: f64,
+    epsilon: f64,
+) -> (StateVector, bool) {
+    let mut pos_tableau = [[Vector3::<f64>::zeros(); MAX_COLUMNS]; MAX_COLUMNS];
+    let mut vel_tableau = [[Vector3::<f64>::zeros(); MAX_COLUMNS]; MAX_COLUMNS];
+
+    for k in 0..MAX_COLUMNS {
+        let n = BS_SEQUENCE[k];
+        let result = modified_midpoint(state, bodies, r_crit, t0, dt, n);
+
+        pos_tableau[k][0] = result.pos;
+        vel_tableau[k][0] = result.vel;
+
+        if k > 0 {
+            // Richardson extrapolation (must go forward: each j depends on j-1)
+            for j in 1..=k {
+                let ratio = (BS_SEQUENCE[k] as f64 / BS_SEQUENCE[k - j] as f64).powi(2);
+                let factor = 1.0 / (ratio - 1.0);
+
+                pos_tableau[k][j] = pos_tableau[k][j - 1]
+                    + factor * (pos_tableau[k][j - 1] - pos_tableau[k - 1][j - 1]);
+                vel_tableau[k][j] = vel_tableau[k][j - 1]
+                    + factor * (vel_tableau[k][j - 1] - vel_tableau[k - 1][j - 1]);
+            }
+
+            // Check convergence
+            let pos_err = (pos_tableau[k][k] - pos_tableau[k][k - 1]).norm();
+            let vel_err = (vel_tableau[k][k] - vel_tableau[k][k - 1]).norm();
+
+            let pos_scale = pos_tableau[k][k].norm().max(1.0);
+            let vel_scale = vel_tableau[k][k].norm().max(1e-6);
+
+            if pos_err / pos_scale < epsilon && vel_err / vel_scale < epsilon {
+                return (StateVector::new(pos_tableau[k][k], vel_tableau[k][k]), true);
+            }
+        }
+    }
+
+    let k = MAX_COLUMNS - 1;
+    (
+        StateVector::new(pos_tableau[k][k], vel_tableau[k][k]),
+        false,
+    )
+}
+
+/// Recursive halving driver around `bs_attempt`.
+fn bs_recurse(
+    state: &StateVector,
+    bodies: &[MassiveBody],
+    r_crit: &[f64],
+    t0: f64,
+    dt: f64,
+    epsilon: f64,
+    depth: u32,
+) -> (StateVector, bool) {
+    let (result, converged) = bs_attempt(state, bodies, r_crit, t0, dt, epsilon);
+    if converged {
+        return (result, true);
+    }
+    if depth >= MAX_HALVINGS {
+        return (result, false);
+    }
+    let half = 0.5 * dt;
+    let (mid, ok1) = bs_recurse(state, bodies, r_crit, t0, half, epsilon, depth + 1);
+    let (end, ok2) = bs_recurse(&mid, bodies, r_crit, t0 + half, half, epsilon, depth + 1);
+    (end, ok1 && ok2)
+}
+
+/// Perform one Bulirsch-Stoer step on a single test particle over [0, dt].
+///
+/// `bodies` hold their step-start states and are Kepler-drifted internally to
+/// each substep epoch. `r_crit` gives the Chambers changeover radius per body
+/// (use 0.0, or an empty slice, for full direct force).
+///
+/// On convergence failure the step is recursively halved up to 2^8 times;
+/// the returned flag is `false` only if even the smallest substep failed.
+///
+/// Returns `(new_state, converged)`.
+pub fn bs_step(
+    state: &StateVector,
+    bodies: &[MassiveBody],
+    r_crit: &[f64],
+    dt: f64,
+    epsilon: f64,
+) -> (StateVector, bool) {
+    bs_recurse(state, bodies, r_crit, 0.0, dt, epsilon, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn test_bs_circular_orbit() {
+        let a = 1.0;
+        let v = (GM_SUN / a).sqrt();
+        let state = StateVector::new(Vector3::new(a, 0.0, 0.0), Vector3::new(0.0, v, 0.0));
+
+        let period = 2.0 * std::f64::consts::PI * (a * a * a / GM_SUN).sqrt();
+        let n_steps = 100;
+        let dt = period / n_steps as f64;
+
+        let mut s = state;
+        for _ in 0..n_steps {
+            let (new_s, converged) = bs_step(&s, &[], &[], dt, 1e-12);
+            assert!(converged);
+            s = new_s;
+        }
+
+        // Should return to start within high accuracy
+        assert_relative_eq!(s.pos.x, a, epsilon = 1e-8);
+        assert_relative_eq!(s.pos.y, 0.0, epsilon = 1e-8);
+    }
+
+    #[test]
+    fn test_bs_energy_conservation() {
+        let state = StateVector::new(Vector3::new(1.0, 0.0, 0.0), Vector3::new(0.0, 0.02, 0.002));
+
+        let energy = |s: &StateVector| 0.5 * s.vel.norm_squared() - GM_SUN / s.pos.norm();
+
+        let e0 = energy(&state);
+        let mut s = state;
+        for _ in 0..100 {
+            let (new_s, converged) = bs_step(&s, &[], &[], 50.0, 1e-12);
+            assert!(converged);
+            s = new_s;
+        }
+        let e1 = energy(&s);
+
+        let de = ((e1 - e0) / e0).abs();
+        assert!(de < 1e-10, "BS energy error: {:.2e}", de);
+    }
+
+    #[test]
+    fn test_bs_adaptive_halving_high_eccentricity() {
+        // e = 0.99 orbit at perihelion with a step that spans the whole
+        // perihelion passage: a single tableau cannot converge, the adaptive
+        // halving must.
+        let a = 1.0;
+        let e = 0.99;
+        let q = a * (1.0 - e);
+        let v_peri = (GM_SUN * (2.0 / q - 1.0 / a)).sqrt();
+        let state = StateVector::new(Vector3::new(q, 0.0, 0.0), Vector3::new(0.0, v_peri, 0.0));
+
+        let energy = |s: &StateVector| 0.5 * s.vel.norm_squared() - GM_SUN / s.pos.norm();
+        let e0 = energy(&state);
+
+        // ~1/6 of the orbital period in one BS call
+        let period = 2.0 * std::f64::consts::PI * (a * a * a / GM_SUN).sqrt();
+        let (s1, converged) = bs_step(&state, &[], &[], period / 6.0, 1e-12);
+        assert!(converged, "adaptive BS should converge via halving");
+
+        let de = ((energy(&s1) - e0) / e0).abs();
+        assert!(de < 1e-8, "energy error through perihelion: {:.2e}", de);
+    }
+
+    #[test]
+    fn test_bs_matches_kepler_drift_hyperbolic_flyby() {
+        // A solar flyby on a hyperbolic orbit, no planets: the numerical BS
+        // trajectory must agree with the analytic universal-variable drift.
+        let e = 1.5;
+        let q = 2.0;
+        let v_peri = (GM_SUN * (1.0 + e) / q).sqrt();
+        let state = StateVector::new(Vector3::new(q, 0.0, 0.0), Vector3::new(0.0, v_peri, 0.0));
+
+        let total_dt = 2000.0;
+        let mut s = state;
+        for _ in 0..40 {
+            let (new_s, converged) = bs_step(&s, &[], &[], total_dt / 40.0, 1e-13);
+            assert!(converged);
+            s = new_s;
+        }
+
+        let exact = kepler_drift(&state, total_dt, GM_SUN);
+        let dr = (s.pos - exact.pos).norm() / exact.pos.norm();
+        let dv = (s.vel - exact.vel).norm() / exact.vel.norm();
+        assert!(dr < 1e-9, "BS vs drift flyby position mismatch: {dr:.2e}");
+        assert!(dv < 1e-9, "BS vs drift flyby velocity mismatch: {dv:.2e}");
+    }
+
+    #[test]
+    fn test_bs_planets_drift_during_step() {
+        // A particle co-orbiting far from a Jupiter-mass planet: the
+        // acceleration evaluated at the end of the step must use the drifted
+        // planet position. We verify by comparing one big BS step against
+        // many small ones — frozen planets would produce a secular offset.
+        let gm_jup = 1e-3 * GM_SUN;
+        let a_jup = 5.2;
+        let v_jup = (GM_SUN / a_jup).sqrt();
+        let jupiter = MassiveBody::new(
+            "Jupiter",
+            gm_jup,
+            StateVector::new(Vector3::new(a_jup, 0.0, 0.0), Vector3::new(0.0, v_jup, 0.0)),
+        );
+
+        let a_p = 8.0;
+        let v_p = (GM_SUN / a_p).sqrt();
+        let particle = StateVector::new(Vector3::new(0.0, a_p, 0.0), Vector3::new(-v_p, 0.0, 0.0));
+
+        // One 600 d step vs 60 x 10 d steps (re-drifting Jupiter between calls)
+        let (coarse, ok) = bs_step(
+            &particle,
+            std::slice::from_ref(&jupiter),
+            &[0.0],
+            600.0,
+            1e-13,
+        );
+        assert!(ok);
+
+        let mut fine = particle;
+        let mut jup = jupiter;
+        for _ in 0..60 {
+            let (s, ok) = bs_step(&fine, &[jup.clone()], &[0.0], 10.0, 1e-13);
+            assert!(ok);
+            fine = s;
+            jup.state = kepler_drift(&jup.state, 10.0, GM_SUN + jup.gm);
+        }
+
+        let dr = (coarse.pos - fine.pos).norm();
+        assert!(
+            dr < 1e-6,
+            "coarse vs fine BS positions differ by {dr:.2e} AU"
+        );
+    }
+
+    #[test]
+    fn test_changeover_limits_and_monotone() {
+        let rc = 1.0;
+        assert_eq!(changeover_k(0.0, rc), 0.0);
+        assert_eq!(changeover_k(0.05, rc), 0.0);
+        assert_eq!(changeover_k(1.0, rc), 1.0);
+        assert_eq!(changeover_k(5.0, rc), 1.0);
+        // r_crit = 0 disables the changeover (full kick share)
+        assert_eq!(changeover_k(0.5, 0.0), 1.0);
+
+        let mut prev = 0.0;
+        for k in 0..=100 {
+            let d = k as f64 * 0.01;
+            let val = changeover_k(d, rc);
+            assert!(val >= prev, "K not monotone at d = {d}");
+            prev = val;
+        }
+        // Continuity at the midpoint: K(0.55) = y^2/(2y^2-2y+1) at y = 0.5 -> 0.5
+        assert_relative_eq!(changeover_k(0.55, rc), 0.5, epsilon = 1e-12);
+    }
+}

--- a/src/nbodylib/democratic.rs
+++ b/src/nbodylib/democratic.rs
@@ -1,0 +1,126 @@
+//! Democratic heliocentric coordinate system for the Wisdom-Holman integrator.
+//!
+//! In this splitting, the Hamiltonian is decomposed as:
+//!   H = H_Kepler + H_interaction + H_sun
+//!
+//! H_Kepler: each body (planet or test particle) orbits the Sun in a
+//!           Keplerian ellipse
+//! H_interaction: planet-planet and planet-particle gravitational
+//!           perturbations
+//! H_sun:    |Σpᵢ|²/(2 m_sun), the solar-drift substep
+//!
+//! Coordinates are heliocentric positions with barycentric momenta
+//! (velocities). This is the coordinate system used by mercury6
+//! (Chambers 1999); see Duncan, Levison & Lee (1998).
+//!
+//! Masses are in solar units throughout (`m_sun = 1.0` for a solar-mass
+//! central body).
+
+use nalgebra::Vector3;
+
+use super::types::{MassiveBody, StateVector};
+
+/// Convert from heliocentric positions + velocities to democratic heliocentric.
+/// In DH coords:
+///   - Positions remain heliocentric
+///   - Momenta (velocities) become barycentric:
+///     v_DH_i = v_helio_i - v_bary
+///
+/// where v_bary = sum(m_i * v_i) / M_total (including the Sun at rest in the
+/// heliocentric frame).
+///
+/// Returns the barycentric velocity of the system.
+pub fn helio_to_democratic(
+    bodies: &mut [MassiveBody],
+    particles: &mut [StateVector],
+    m_sun: f64,
+) -> Vector3<f64> {
+    // Compute total momentum in heliocentric frame
+    let mut total_momentum = Vector3::zeros();
+    let mut total_mass = m_sun; // Sun is at rest in heliocentric frame
+
+    for b in bodies.iter() {
+        total_momentum += b.mass * b.state.vel;
+        total_mass += b.mass;
+    }
+    // Test particles are massless, don't contribute to momentum
+
+    let v_bary = total_momentum / total_mass;
+
+    // Transform velocities
+    for b in bodies.iter_mut() {
+        b.state.vel -= v_bary;
+    }
+    for p in particles.iter_mut() {
+        p.vel -= v_bary;
+    }
+
+    v_bary
+}
+
+/// Convert from democratic heliocentric back to heliocentric.
+pub fn democratic_to_helio(
+    bodies: &mut [MassiveBody],
+    particles: &mut [StateVector],
+    v_bary: &Vector3<f64>,
+) {
+    for b in bodies.iter_mut() {
+        b.state.vel += v_bary;
+    }
+    for p in particles.iter_mut() {
+        p.vel += v_bary;
+    }
+}
+
+/// Compute the barycentric correction velocity from current body states.
+pub fn compute_v_bary(bodies: &[MassiveBody], m_sun: f64) -> Vector3<f64> {
+    let mut total_momentum = Vector3::zeros();
+    let mut total_mass = m_sun;
+
+    for b in bodies {
+        total_momentum += b.mass * b.state.vel;
+        total_mass += b.mass;
+    }
+
+    total_momentum / total_mass
+}
+
+/// Inverse-transform correction for states currently in DH coordinates.
+///
+/// With barycentric (DH) velocities, momentum conservation fixes the Sun's
+/// barycentric velocity to −Σmᵢvᵢ/m_sun, so heliocentric velocities are
+/// recovered as v_helio = v_DH + Σmᵢvᵢ/m_sun. (At the instant of the forward
+/// transform this equals `compute_v_bary` of the heliocentric velocities, but
+/// it must be re-evaluated after the velocities have evolved.)
+pub fn dh_velocity_correction(bodies: &[MassiveBody], m_sun: f64) -> Vector3<f64> {
+    let mut total_momentum = Vector3::zeros();
+    for b in bodies {
+        total_momentum += b.mass * b.state.vel;
+    }
+    total_momentum / m_sun
+}
+
+/// Solar-drift substep of the democratic heliocentric scheme (DLL98).
+///
+/// H_sun = |Σpᵢ|²/(2 m_sun) advances every heliocentric position (bodies and
+/// test particles alike) by dt·Σmᵢvᵢ/m_sun, with vᵢ the DH (barycentric)
+/// velocities. Omitting this substep is what makes a naive heliocentric
+/// "WHM" non-symplectic.
+pub fn solar_drift(
+    bodies: &mut [MassiveBody],
+    particles: &mut [StateVector],
+    active: &[bool],
+    dt: f64,
+    m_sun: f64,
+) {
+    let shift = dt * dh_velocity_correction(bodies, m_sun);
+    for b in bodies.iter_mut() {
+        b.state.pos += shift;
+    }
+    for (i, p) in particles.iter_mut().enumerate() {
+        if !active[i] {
+            continue;
+        }
+        p.pos += shift;
+    }
+}

--- a/src/nbodylib/forces.rs
+++ b/src/nbodylib/forces.rs
@@ -1,0 +1,574 @@
+//! Accelerations for the kick stage of the integrators.
+//!
+//! Two layers live here:
+//!
+//! 1. The Newtonian building blocks used by the Wisdom-Holman and hybrid
+//!    drivers: direct and direct+indirect point-mass kicks, and the J2/J4
+//!    oblateness field.
+//! 2. [`ExtraForce`] — composable, position-dependent extra accelerations
+//!    (potential kicks, so they preserve the symplectic structure of the
+//!    Wisdom-Holman splitting): an orbit-averaged giant-planet quadrupole,
+//!    the Milky Way vertical disk tide, and user closures.
+
+use std::sync::Arc;
+
+use nalgebra::{Matrix3, Vector3};
+use once_cell::sync::Lazy;
+
+use crate::constants::{AU_KM, J2000};
+use crate::framelib::{Frame, ECLIPJ2000_MATRIX_INV, GALACTIC};
+use crate::time::Timescale;
+
+use super::types::{MassiveBody, StateVector};
+use super::{
+    GM_JUPITER, GM_SATURN, GM_SUN, GM_URANUS, MASS_JUPITER_SOLAR, MASS_SATURN_SOLAR,
+    MASS_URANUS_SOLAR,
+};
+
+// ===================================================================
+// Point-mass kicks
+// ===================================================================
+
+/// Compute the gravitational acceleration on a body at position `r` due to
+/// a perturbing body with GM `gm_pert` at position `r_pert`.
+///
+/// This is the direct + indirect term:
+///   a = -gm_pert * [ (r - r_pert)/|r - r_pert|^3 + r_pert/|r_pert|^3 ]
+///
+/// The second term is the indirect (Sun-centered frame) acceleration.
+#[inline]
+pub fn perturbation_acceleration(
+    r: &Vector3<f64>,
+    r_pert: &Vector3<f64>,
+    gm_pert: f64,
+) -> Vector3<f64> {
+    let dr = r - r_pert;
+    let dr_mag = dr.norm();
+    let r_pert_mag = r_pert.norm();
+
+    if dr_mag < 1e-30 || r_pert_mag < 1e-30 {
+        return Vector3::zeros();
+    }
+
+    let dr3 = dr_mag.powi(3);
+    let rp3 = r_pert_mag.powi(3);
+
+    // Direct term + indirect (Sun recoil) term
+    -gm_pert * (dr / dr3 + r_pert / rp3)
+}
+
+/// Direct gravitational acceleration only (no indirect term).
+///
+/// In the democratic heliocentric splitting (Duncan, Levison & Lee 1998) the
+/// Sun-recoil physics is carried by the separate solar-drift substep, so the
+/// kick must apply only the direct term.
+#[inline]
+pub fn direct_acceleration(r: &Vector3<f64>, r_pert: &Vector3<f64>, gm_pert: f64) -> Vector3<f64> {
+    let dr = r - r_pert;
+    let dr_mag = dr.norm();
+    if dr_mag < 1e-30 {
+        return Vector3::zeros();
+    }
+    -gm_pert * dr / dr_mag.powi(3)
+}
+
+/// Direct-only mutual kick for massive bodies (democratic heliocentric scheme).
+pub fn kick_bodies_direct(bodies: &mut [MassiveBody], dt: f64) {
+    let n = bodies.len();
+    if n < 2 {
+        return;
+    }
+
+    let mut accels = vec![Vector3::<f64>::zeros(); n];
+    for i in 0..n {
+        for j in 0..n {
+            if i == j {
+                continue;
+            }
+            accels[i] +=
+                direct_acceleration(&bodies[i].state.pos, &bodies[j].state.pos, bodies[j].gm);
+        }
+    }
+
+    for (body, accel) in bodies.iter_mut().zip(accels.iter()) {
+        body.state.vel += dt * accel;
+    }
+}
+
+/// Direct-only kick on test particles from massive bodies (democratic
+/// heliocentric).
+pub fn kick_particles_direct(
+    particles: &mut [StateVector],
+    active: &[bool],
+    bodies: &[MassiveBody],
+    dt: f64,
+) {
+    for (i, particle) in particles.iter_mut().enumerate() {
+        if !active[i] {
+            continue;
+        }
+        let mut accel = Vector3::zeros();
+        for body in bodies {
+            accel += direct_acceleration(&particle.pos, &body.state.pos, body.gm);
+        }
+        particle.vel += dt * accel;
+    }
+}
+
+/// Apply a kick (velocity impulse) to all massive bodies due to mutual
+/// interactions. Each body receives acceleration from all other bodies.
+///
+/// Direct + indirect form, for heliocentric-velocity schemes. The
+/// democratic-heliocentric integrator uses `kick_bodies_direct` instead.
+pub fn kick_bodies(bodies: &mut [MassiveBody], dt: f64) {
+    let n = bodies.len();
+    if n < 2 {
+        return;
+    }
+
+    // Compute accelerations first, then apply (to avoid order dependence)
+    let mut accels = vec![Vector3::<f64>::zeros(); n];
+
+    for i in 0..n {
+        for j in 0..n {
+            if i == j {
+                continue;
+            }
+            accels[i] +=
+                perturbation_acceleration(&bodies[i].state.pos, &bodies[j].state.pos, bodies[j].gm);
+        }
+    }
+
+    for (body, accel) in bodies.iter_mut().zip(accels.iter()) {
+        body.state.vel += dt * accel;
+    }
+}
+
+/// Apply a direct + indirect kick to all test particles due to massive
+/// bodies. Test particles do not affect each other or the massive bodies.
+pub fn kick_particles(
+    particles: &mut [StateVector],
+    active: &[bool],
+    bodies: &[MassiveBody],
+    dt: f64,
+) {
+    for (i, particle) in particles.iter_mut().enumerate() {
+        if !active[i] {
+            continue;
+        }
+
+        let mut accel = Vector3::zeros();
+        for body in bodies {
+            accel += perturbation_acceleration(&particle.pos, &body.state.pos, body.gm);
+        }
+
+        particle.vel += dt * accel;
+    }
+}
+
+// ===================================================================
+// J2/J4 oblateness
+// ===================================================================
+
+/// J2 (and optionally J4) oblateness acceleration of a body centered at the
+/// origin with equatorial radius `radius` (AU), symmetry axis along z.
+///
+/// The J2 potential is:
+///   Φ_J2 = -GM/r * (R/r)^2 * J2 * P2(sin(φ))
+/// where φ is the latitude.
+pub fn j2_acceleration(
+    r: &Vector3<f64>,
+    gm: f64,
+    radius: f64,
+    j2: f64,
+    j4: Option<f64>,
+) -> Vector3<f64> {
+    let r_mag = r.norm();
+    if r_mag < 1e-30 {
+        return Vector3::zeros();
+    }
+
+    let r2 = r_mag * r_mag;
+    let r5 = r2 * r2 * r_mag;
+    let r7 = r5 * r2;
+    let rr = radius * radius;
+
+    let z2 = r.z * r.z;
+    let z2_r2 = z2 / r2;
+
+    // J2 acceleration components
+    let factor_j2 = 1.5 * gm * j2 * rr;
+    let ax_j2 = -factor_j2 * r.x / r5 * (1.0 - 5.0 * z2_r2);
+    let ay_j2 = -factor_j2 * r.y / r5 * (1.0 - 5.0 * z2_r2);
+    let az_j2 = -factor_j2 * r.z / r5 * (3.0 - 5.0 * z2_r2);
+
+    let mut accel = Vector3::new(ax_j2, ay_j2, az_j2);
+
+    // J4 acceleration if provided
+    if let Some(j4_val) = j4 {
+        let r4 = rr * rr;
+        let r9 = r7 * r2;
+        let z4_r4 = z2_r2 * z2_r2;
+
+        let factor_j4 = 0.625 * gm * j4_val * r4;
+        let bracket = 3.0 - 42.0 * z2_r2 + 63.0 * z4_r4;
+        let bracket_z = 15.0 - 70.0 * z2_r2 + 63.0 * z4_r4;
+
+        accel.x += factor_j4 * r.x / r9 * bracket;
+        accel.y += factor_j4 * r.y / r9 * bracket;
+        accel.z += factor_j4 * r.z / r9 * bracket_z;
+    }
+
+    accel
+}
+
+// ===================================================================
+// Orbit-averaged giant-planet quadrupole (secular J2)
+// ===================================================================
+
+/// Orbit-averaged J2 coefficient from a planet.
+///
+/// When a giant planet is not integrated directly (to save CPU), its
+/// gravitational effect can be approximated as an enhanced J2 moment on the
+/// central body, valid for particles with perihelia well outside the
+/// planet's orbit:
+///   J2_eff = (1/2) * (m_planet / M_sun) * (a_planet / R_ref)^2
+///
+/// `mass_ratio`: m_planet / M_sun;
+/// `a_planet_au`: semi-major axis of the planet (AU);
+/// `r_ref_au`: reference radius for the J2 expansion (typically 1 AU).
+///
+/// Reference: Murray & Dermott (1999), Section 6.11; Batygin & Brown (2016)
+pub fn effective_j2(mass_ratio: f64, a_planet_au: f64, r_ref_au: f64) -> f64 {
+    0.5 * mass_ratio * (a_planet_au / r_ref_au).powi(2)
+}
+
+/// Combined effective field from orbit-averaging Jupiter, Saturn, and
+/// Uranus. Uses a reference radius of 1 AU.
+///
+/// Returns `(j2_eff, j4_eff, gm_boost)` where `gm_boost = Σ GM_JSU`
+/// (AU³/day²) is the monopole that must be added to the central GM.
+/// Absorbing a planet into the central body requires this monopole boost;
+/// without it mean motions and secular frequencies are systematically off
+/// by ~6e-4.
+///
+/// Validity: the J2+J4 ring expansion is in powers of (a_planet/r)². With
+/// a_Uranus = 19.2 AU it converges slowly for perihelia q ≲ 30 AU — at
+/// q ≈ 30 AU the J6 term is still at the percent level of J4. Do not use
+/// this approximation for Neptune-crossing perihelia; integrate Neptune
+/// directly instead.
+pub fn combined_j2_giants() -> (f64, f64, f64) {
+    let r_ref = 1.0; // AU
+
+    let j2_jup = effective_j2(MASS_JUPITER_SOLAR, 5.2026, r_ref);
+    let j2_sat = effective_j2(MASS_SATURN_SOLAR, 9.5549, r_ref);
+    let j2_ura = effective_j2(MASS_URANUS_SOLAR, 19.2184, r_ref);
+
+    let j2_total = j2_jup + j2_sat + j2_ura;
+
+    // Effective J4 from the same averaging (second order)
+    // J4_eff = -(3/8) * (m/M) * (a/R)^4
+    let j4_jup = -0.375 * MASS_JUPITER_SOLAR * (5.2026 / r_ref).powi(4);
+    let j4_sat = -0.375 * MASS_SATURN_SOLAR * (9.5549 / r_ref).powi(4);
+    let j4_ura = -0.375 * MASS_URANUS_SOLAR * (19.2184 / r_ref).powi(4);
+
+    let j4_total = j4_jup + j4_sat + j4_ura;
+
+    // Monopole: the averaged planets' mass joins the central body.
+    let gm_boost = GM_JUPITER + GM_SATURN + GM_URANUS;
+
+    (j2_total, j4_total, gm_boost)
+}
+
+/// Perturbation acceleration of the J2/J4-averaged planets, relative to bare
+/// Keplerian motion about `gm_central`.
+///
+/// Includes both the ring field (J2/J4 of the boosted central mass) and the
+/// extra monopole `-gm_boost * r / r³`. Apply this in the kick stage of an
+/// integrator whose Kepler drift uses `gm_central` alone.
+pub fn secular_j2_acceleration(
+    pos: &Vector3<f64>,
+    gm_central: f64,
+    j2: f64,
+    j4: f64,
+    gm_boost: f64,
+    r_ref: f64,
+) -> Vector3<f64> {
+    let r_mag = pos.norm();
+    if r_mag < 1e-30 {
+        return Vector3::zeros();
+    }
+
+    let gm_eff = gm_central + gm_boost;
+    let mut accel = j2_acceleration(pos, gm_eff, r_ref, j2, Some(j4));
+    accel -= gm_boost * pos / r_mag.powi(3);
+    accel
+}
+
+// ===================================================================
+// Galactic tide
+// ===================================================================
+
+/// Local Milky Way disk density in M_sun/AU³ (0.1 M_sun/pc³ converted).
+pub const RHO_MW_MSUN_AU3: f64 = 0.1 / {
+    let pc_km = 3.085_677_6e13_f64;
+    let ratio = pc_km / AU_KM;
+    ratio * ratio * ratio
+};
+
+/// Ecliptic-J2000 → galactic rotation, assembled from framelib's SPICE
+/// frame table: (ICRF → GALACTIC) · (ecliptic → ICRF). Both factors are
+/// static (the GALACTIC frame ignores the epoch argument).
+static ECL_TO_GAL: Lazy<Matrix3<f64>> = Lazy::new(|| {
+    let eq_to_gal = GALACTIC.rotation_at(&Timescale::default().tt_jd(J2000, None));
+    eq_to_gal * *ECLIPJ2000_MATRIX_INV
+});
+
+/// Unit vector toward the north galactic pole in ecliptic J2000 coordinates
+/// (the galactic z-axis row of the ecliptic→galactic rotation).
+///
+/// λ ≈ 180.023°, β ≈ +29.812°; the complement of β gives the ≈60.19°
+/// ecliptic–galactic obliquity.
+pub fn galactic_pole_ecliptic() -> Vector3<f64> {
+    ECL_TO_GAL.row(2).transpose()
+}
+
+/// Galactic tidal acceleration on a particle at position `pos`
+/// (AU, heliocentric ecliptic J2000), for local disk density `rho_msun_au3`.
+///
+/// The dominant component is the vertical tide from the Milky Way disk,
+///   a_z̃ = -4π G ρ z̃,
+/// where z̃ is the height above the *galactic* mid-plane. The galactic plane
+/// is inclined ~60.2° to the ecliptic, so the position is rotated into the
+/// galactic frame (via framelib's SPICE `GALACTIC` frame), the vertical disk
+/// tide is applied along galactic z, and the result is rotated back —
+/// applying it along ecliptic z would misdirect the torque by the full
+/// obliquity.
+///
+/// The radial tide terms (Heisler & Tremaine's G1, G2, from the galactic
+/// rotation curve) are ~10x weaker than the disk term at the Sun's location
+/// and are omitted; only the G3 (vertical) term is applied. The tide is
+/// important for a ≳ 1000 AU (inner Oort cloud) and dominant beyond
+/// ~10,000 AU.
+///
+/// Reference: Heisler & Tremaine (1986), Nesvorny et al. (2017)
+pub fn galactic_tide_acceleration(pos: &Vector3<f64>, rho_msun_au3: f64) -> Vector3<f64> {
+    // 4*pi*G*rho in day^-2:
+    // G = GM_SUN / M_sun (AU^3/(M_sun*day^2)), rho in M_sun/AU^3.
+    let four_pi_g_rho = 4.0 * std::f64::consts::PI * GM_SUN * rho_msun_au3;
+
+    let pos_gal = *ECL_TO_GAL * pos;
+    let acc_gal = Vector3::new(0.0, 0.0, -four_pi_g_rho * pos_gal.z);
+
+    ECL_TO_GAL.transpose() * acc_gal
+}
+
+// ===================================================================
+// ExtraForce
+// ===================================================================
+
+/// A user-supplied acceleration field a(r) in AU/day², heliocentric.
+pub type CustomForce = Arc<dyn Fn(&Vector3<f64>) -> Vector3<f64> + Send + Sync>;
+
+/// Extra acceleration applied during the kick stage of an integrator.
+///
+/// These are position-dependent perturbations (potential kicks), so they
+/// preserve the symplectic structure of the Wisdom-Holman splitting. They
+/// are applied to massive bodies and test particles alike, in heliocentric
+/// ecliptic-J2000 coordinates.
+#[derive(Clone)]
+pub enum ExtraForce {
+    /// Orbit-averaged planets as an effective J2/J4 ring field plus the
+    /// monopole boost `gm_boost` on the central body (see
+    /// [`secular_j2_acceleration`]). Use [`ExtraForce::j2_giants`] for the
+    /// standard Jupiter+Saturn+Uranus field.
+    J2Averaged {
+        /// Effective J2 at the reference radius.
+        j2: f64,
+        /// Effective J4 at the reference radius.
+        j4: f64,
+        /// Monopole added to the central GM (AU³/day²).
+        gm_boost: f64,
+        /// Reference radius of the J2/J4 expansion (AU).
+        r_ref_au: f64,
+    },
+    /// Milky Way vertical disk tide ([`galactic_tide_acceleration`] with the
+    /// local density [`RHO_MW_MSUN_AU3`]), evaluated in the galactic frame.
+    GalacticTide,
+    /// User-supplied acceleration field a(r) in AU/day², heliocentric.
+    Custom(CustomForce),
+}
+
+impl ExtraForce {
+    /// Orbit-averaged Jupiter+Saturn+Uranus quadrupole with the ΣGM_JSU
+    /// monopole boost ([`combined_j2_giants`]). Valid for perihelia
+    /// q ≳ 30 AU; integrate Neptune directly.
+    pub fn j2_giants() -> Self {
+        let (j2, j4, gm_boost) = combined_j2_giants();
+        ExtraForce::J2Averaged {
+            j2,
+            j4,
+            gm_boost,
+            r_ref_au: 1.0,
+        }
+    }
+
+    /// Acceleration at heliocentric position `pos` (AU), in AU/day².
+    pub fn acceleration(&self, pos: &Vector3<f64>) -> Vector3<f64> {
+        match self {
+            ExtraForce::J2Averaged {
+                j2,
+                j4,
+                gm_boost,
+                r_ref_au,
+            } => secular_j2_acceleration(pos, GM_SUN, *j2, *j4, *gm_boost, *r_ref_au),
+            ExtraForce::GalacticTide => galactic_tide_acceleration(pos, RHO_MW_MSUN_AU3),
+            ExtraForce::Custom(f) => f(pos),
+        }
+    }
+}
+
+impl std::fmt::Debug for ExtraForce {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExtraForce::J2Averaged {
+                j2,
+                j4,
+                gm_boost,
+                r_ref_au,
+            } => write!(
+                f,
+                "ExtraForce::J2Averaged {{ j2: {j2:e}, j4: {j4:e}, gm_boost: {gm_boost:e}, \
+                 r_ref_au: {r_ref_au} }}"
+            ),
+            ExtraForce::GalacticTide => write!(f, "ExtraForce::GalacticTide"),
+            ExtraForce::Custom(_) => write!(f, "ExtraForce::Custom(..)"),
+        }
+    }
+}
+
+/// Total extra acceleration from a list of extra forces.
+pub fn total_extra_acceleration(forces: &[ExtraForce], pos: &Vector3<f64>) -> Vector3<f64> {
+    let mut accel = Vector3::zeros();
+    for force in forces {
+        accel += force.acceleration(pos);
+    }
+    accel
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::RAD2DEG;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn test_perturbation_self_consistency() {
+        // Two bodies on opposite sides of the Sun.
+        let r = Vector3::new(5.0, 0.0, 0.0);
+        let r_pert = Vector3::new(-5.0, 0.0, 0.0);
+        let gm = 1e-4;
+
+        let accel = perturbation_acceleration(&r, &r_pert, gm);
+
+        // direct: -gm * (r-r_pert)/|r-r_pert|^3 = -gm * (10,0,0)/1000
+        // indirect: -gm * r_pert/|r_pert|^3 = -gm * (-5,0,0)/125
+        // ax = -gm*(10/1000 - 5/125) = -gm*(0.01 - 0.04) = +0.03*gm
+        // Positive x (away from the perturber): the indirect term dominates
+        // here, accounting for the Sun being accelerated toward the
+        // perturber.
+        assert!(accel.x > 0.0);
+        assert_relative_eq!(accel.x, gm * 0.03, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_j2_equatorial_vs_polar() {
+        // J2 acceleration should differ at the pole vs the equator.
+        let gm = GM_SUN;
+        let r_eq = Vector3::new(1.0, 0.0, 0.0);
+        let r_pole = Vector3::new(0.0, 0.0, 1.0);
+
+        let a_eq = j2_acceleration(&r_eq, gm, 0.00465, 0.01, None);
+        let a_pole = j2_acceleration(&r_pole, gm, 0.00465, 0.01, None);
+
+        // At the equator (z=0), J2 makes gravity stronger (pulls inward);
+        // at the pole (z=r), J2 makes gravity weaker (pushes outward).
+        assert!(a_eq.x < 0.0);
+        assert!(a_pole.z > 0.0);
+    }
+
+    #[test]
+    fn test_gm_boost_magnitude() {
+        // ΣGM_JSU ≈ 1.28e-3 GM_sun
+        let (_, _, gm_boost) = combined_j2_giants();
+        let ratio = gm_boost / GM_SUN;
+        assert!(
+            (ratio - 1.28e-3).abs() < 5e-5,
+            "GM boost ratio {ratio:.3e} should be ~1.28e-3"
+        );
+    }
+
+    #[test]
+    fn test_secular_acceleration_dominated_by_monopole_at_large_r() {
+        // Far from the rings the perturbation tends to the extra monopole.
+        let (j2, j4, gm_boost) = combined_j2_giants();
+        let pos = Vector3::new(500.0, 0.0, 0.0);
+        let a = secular_j2_acceleration(&pos, GM_SUN, j2, j4, gm_boost, 1.0);
+        let monopole = gm_boost / (500.0_f64 * 500.0);
+        assert!((a.norm() - monopole).abs() / monopole < 1e-3);
+        // Pointing inward (extra attraction).
+        assert!(a.x < 0.0);
+    }
+
+    #[test]
+    fn test_galactic_pole_is_unit_and_inclined_60deg() {
+        let n = galactic_pole_ecliptic();
+        assert_relative_eq!(n.norm(), 1.0, epsilon = 1e-12);
+        // Obliquity between galactic plane and ecliptic: acos(n.z) ~ 60.2 deg
+        let obliquity = n.z.acos() * RAD2DEG;
+        assert!((obliquity - 60.19).abs() < 0.1, "obliquity {obliquity}");
+    }
+
+    #[test]
+    fn test_tide_restoring_toward_galactic_plane() {
+        // A point displaced along the galactic pole feels a pure restoring
+        // force.
+        let n = galactic_pole_ecliptic();
+        let pos = 10_000.0 * n;
+        let a = galactic_tide_acceleration(&pos, RHO_MW_MSUN_AU3);
+        // Anti-parallel to displacement
+        assert!(a.dot(&pos) < 0.0);
+        assert_relative_eq!(a.cross(&pos).norm(), 0.0, epsilon = 1e-20);
+    }
+
+    #[test]
+    fn test_tide_vanishes_in_galactic_plane() {
+        // Any vector orthogonal to the pole sits in the galactic mid-plane.
+        let n = galactic_pole_ecliptic();
+        let in_plane = n.cross(&Vector3::new(0.0, 0.0, 1.0)).normalize() * 10_000.0;
+        let a = galactic_tide_acceleration(&in_plane, RHO_MW_MSUN_AU3);
+        assert!(a.norm() < 1e-25);
+    }
+
+    #[test]
+    fn test_tide_matches_pole_projection_form() {
+        // The rotate-apply-rotate-back implementation must equal the
+        // algebraically collapsed form a = -4πGρ (r·n̂) n̂.
+        let four_pi_g_rho = 4.0 * std::f64::consts::PI * GM_SUN * RHO_MW_MSUN_AU3;
+        let n = galactic_pole_ecliptic();
+        let pos = Vector3::new(3_000.0, -7_000.0, 5_000.0);
+        let expected = -four_pi_g_rho * pos.dot(&n) * n;
+        let a = galactic_tide_acceleration(&pos, RHO_MW_MSUN_AU3);
+        assert_relative_eq!((a - expected).norm(), 0.0, epsilon = 1e-30);
+    }
+
+    #[test]
+    fn test_custom_force_composes() {
+        let drag = ExtraForce::Custom(Arc::new(|pos: &Vector3<f64>| -1e-12 * pos));
+        let forces = vec![drag, ExtraForce::GalacticTide];
+        let pos = Vector3::new(100.0, 0.0, 0.0);
+        let total = total_extra_acceleration(&forces, &pos);
+        let parts = forces[0].acceleration(&pos) + forces[1].acceleration(&pos);
+        assert_relative_eq!((total - parts).norm(), 0.0, epsilon = 1e-30);
+    }
+}

--- a/src/nbodylib/hybrid.rs
+++ b/src/nbodylib/hybrid.rs
@@ -1,0 +1,306 @@
+//! Mercury6-style hybrid integrator (Chambers 1999).
+//!
+//! Uses the Wisdom-Holman splitting for the majority of particles, switching
+//! to Bulirsch-Stoer for any particle predicted to pass near a planet during
+//! the step.
+//!
+//! The planet force on each particle is partitioned with the Chambers
+//! changeover function K(d) so that no force is double-counted:
+//!
+//! - the **kick** stage applies `K(d) * F_direct` plus the full indirect
+//!   (heliocentric-frame) term,
+//! - the **drift** stage of an encountering particle integrates
+//!   Sun + `(1 - K(d)) * F_direct` with Bulirsch-Stoer, Kepler-drifting the
+//!   planets to each substep epoch.
+//!
+//! Far from planets K = 1 and the scheme reduces to plain WHM; deep inside an
+//! encounter K = 0 and the BS step carries the full planet force.
+//!
+//! Encounter detection uses the predicted minimum separation over the whole
+//! step [t, t+dt] (linear relative motion), not just the step start, so a
+//! particle cannot cross a Hill sphere entirely between checks.
+//!
+//! The changeover radius is `changeover * r_Hill` with
+//! r_Hill = r_planet * (m_planet / 3 M_sun)^(1/3), changeover typically 3.0.
+//!
+//! Note: this driver uses the heliocentric-velocity splitting (kick includes
+//! the indirect term), not the democratic-heliocentric scheme of
+//! [`super::whm::WhmIntegrator`]; for encounter work the BS accuracy
+//! dominates the error budget.
+//!
+//! Reference: Chambers (1999), "A hybrid symplectic integrator that permits
+//! close encounters between massive bodies"
+
+use nalgebra::Vector3;
+
+use super::bulirsch_stoer::{bs_step, changeover_k};
+use super::forces::kick_bodies;
+use super::kepler::kepler_drift;
+use super::types::{MassiveBody, SimConfig, StateVector};
+use super::GM_SUN;
+
+/// Changeover radius (AU) for each body: `changeover * r_Hill`.
+pub fn changeover_radii(bodies: &[MassiveBody], changeover_hill: f64) -> Vec<f64> {
+    bodies
+        .iter()
+        .map(|body| {
+            let r_planet = body.state.pos.norm();
+            changeover_hill * r_planet * (body.mass / 3.0).cbrt()
+        })
+        .collect()
+}
+
+/// Predicted minimum particle-body separation over [0, dt] assuming linear
+/// relative motion: min over s of |dr0 + s*dv0|, s clamped to [0, dt].
+fn min_separation(particle: &StateVector, body: &MassiveBody, dt: f64) -> f64 {
+    let dr = particle.pos - body.state.pos;
+    let dv = particle.vel - body.state.vel;
+    let dv2 = dv.norm_squared();
+    let s = if dv2 > 1e-30 {
+        (-dr.dot(&dv) / dv2).clamp(0.0, dt)
+    } else {
+        0.0
+    };
+    (dr + s * dv).norm()
+}
+
+/// Determine which particles need Bulirsch-Stoer integration this step.
+///
+/// A particle is flagged when its predicted minimum separation from any body
+/// over [t, t+dt] (linear relative motion) falls inside that body's
+/// changeover radius. Sampling only the step start would let particles cross
+/// the encounter sphere entirely between checks.
+///
+/// Returns a boolean mask (true = needs BS).
+pub fn find_close_encounters(
+    particles: &[StateVector],
+    active: &[bool],
+    bodies: &[MassiveBody],
+    r_crit: &[f64],
+    dt: f64,
+) -> Vec<bool> {
+    let mut needs_bs = vec![false; particles.len()];
+
+    for (i, particle) in particles.iter().enumerate() {
+        if !active[i] {
+            continue;
+        }
+        for (body, &rc) in bodies.iter().zip(r_crit) {
+            if min_separation(particle, body, dt) < rc {
+                needs_bs[i] = true;
+                break;
+            }
+        }
+    }
+
+    needs_bs
+}
+
+/// Kick stage for particles with the Chambers force partition: each body
+/// contributes `K(d) * direct + indirect`. Far from every body this is the
+/// standard full perturbation kick.
+fn kick_particles_changeover(
+    particles: &mut [StateVector],
+    active: &[bool],
+    bodies: &[MassiveBody],
+    r_crit: &[f64],
+    dt: f64,
+) {
+    for (i, particle) in particles.iter_mut().enumerate() {
+        if !active[i] {
+            continue;
+        }
+        let mut accel = Vector3::zeros();
+        for (body, &rc) in bodies.iter().zip(r_crit) {
+            let dr = particle.pos - body.state.pos;
+            let dr_mag = dr.norm();
+            let rp = body.state.pos.norm();
+            if dr_mag > 1e-30 {
+                accel -= changeover_k(dr_mag, rc) * body.gm * dr / dr_mag.powi(3);
+            }
+            if rp > 1e-30 {
+                // Indirect term: always full weight (frame correction, not a
+                // particle-planet interaction).
+                accel -= body.gm * body.state.pos / rp.powi(3);
+            }
+        }
+        particle.vel += dt * accel;
+    }
+}
+
+/// Perform one hybrid step: WHM for most particles, BS for close encounters.
+///
+/// Returns the number of particles whose Bulirsch-Stoer step failed to
+/// converge even after the maximum number of halvings (0 = all clean).
+pub fn hybrid_step(
+    bodies: &mut [MassiveBody],
+    particles: &mut [StateVector],
+    active: &mut [bool],
+    dt: f64,
+    config: &SimConfig,
+) -> usize {
+    let half_dt = 0.5 * dt;
+
+    // Changeover radii and encounter mask, evaluated at the step start with
+    // predicted minimum separations over [t, t+dt].
+    let r_crit = changeover_radii(bodies, config.hybrid_changeover_hill);
+    let needs_bs = find_close_encounters(particles, active, bodies, &r_crit, dt);
+
+    // === KICK dt/2 ===
+    kick_bodies(bodies, half_dt);
+    kick_particles_changeover(particles, active, bodies, &r_crit, half_dt);
+
+    // Snapshot body states for the BS force evaluation (BS drifts them to the
+    // substep epochs internally).
+    let bodies_at_start: Vec<MassiveBody> = bodies.to_vec();
+
+    // === DRIFT dt ===
+    // Bodies always use Kepler drift
+    for body in bodies.iter_mut() {
+        let gm_total = GM_SUN + body.gm;
+        body.state = kepler_drift(&body.state, dt, gm_total);
+    }
+
+    // Particles: Kepler for most, BS (with the complementary force share and
+    // moving planets) for close encounters.
+    let mut failed = 0;
+    for (i, particle) in particles.iter_mut().enumerate() {
+        if !active[i] {
+            continue;
+        }
+
+        if needs_bs[i] {
+            let (new_state, converged) =
+                bs_step(particle, &bodies_at_start, &r_crit, dt, config.bs_epsilon);
+            if !converged {
+                failed += 1;
+            }
+            *particle = new_state;
+        } else {
+            *particle = kepler_drift(particle, dt, GM_SUN);
+        }
+    }
+
+    // === KICK dt/2 ===
+    kick_bodies(bodies, half_dt);
+    kick_particles_changeover(particles, active, bodies, &r_crit, half_dt);
+
+    // === BOUNDARY CHECK ===
+    for (i, particle) in particles.iter().enumerate() {
+        if !active[i] {
+            continue;
+        }
+        let r = particle.pos.norm();
+        if r < config.removal_inner_au || r > config.removal_outer_au {
+            active[i] = false;
+        }
+    }
+
+    failed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    fn test_config(dt: f64) -> SimConfig {
+        SimConfig {
+            dt,
+            removal_inner_au: 0.01,
+            removal_outer_au: 1e6,
+            hybrid_changeover_hill: 3.0,
+            bs_epsilon: 1e-12,
+        }
+    }
+
+    fn jupiter() -> MassiveBody {
+        let gm = 1e-3 * GM_SUN;
+        let a = 5.2;
+        let v = (GM_SUN / a).sqrt();
+        MassiveBody::new(
+            "Jupiter",
+            gm,
+            StateVector::new(Vector3::new(a, 0.0, 0.0), Vector3::new(0.0, v, 0.0)),
+        )
+    }
+
+    #[test]
+    fn test_encounter_detected_mid_step() {
+        // Particle currently outside the changeover sphere but crossing it
+        // during the step: the start-only check would miss this.
+        let jup = jupiter();
+        let r_crit = changeover_radii(std::slice::from_ref(&jup), 3.0);
+        assert!(r_crit[0] > 1.0 && r_crit[0] < 1.2, "r_crit = {}", r_crit[0]);
+
+        let dt = 300.0;
+        // 3 AU "below" Jupiter, closing at 0.02 AU/day relative: passes
+        // within ~0 AU mid-step.
+        let particle = StateVector::new(
+            Vector3::new(5.2, -3.0, 0.0),
+            jup.state.vel + Vector3::new(0.0, 0.02, 0.0),
+        );
+
+        let flagged = find_close_encounters(
+            &[particle],
+            &[true],
+            std::slice::from_ref(&jup),
+            &r_crit,
+            dt,
+        );
+        assert!(flagged[0], "mid-step crossing must be flagged");
+
+        // Start-distance check alone would say "no encounter":
+        let d_start = (particle.pos - jup.state.pos).norm();
+        assert!(d_start > r_crit[0]);
+    }
+
+    #[test]
+    fn test_hybrid_matches_kepler_far_from_planets() {
+        // A distant particle (no encounter) must follow its Kepler orbit.
+        let mut bodies = vec![jupiter()];
+        let a = 60.0;
+        let v = (GM_SUN / a).sqrt();
+        let p0 = StateVector::new(Vector3::new(a, 0.0, 0.0), Vector3::new(0.0, v, 0.0));
+        let mut particles = vec![p0];
+        let mut active = vec![true];
+        let config = test_config(100.0);
+
+        for _ in 0..100 {
+            let failed = hybrid_step(&mut bodies, &mut particles, &mut active, config.dt, &config);
+            assert_eq!(failed, 0);
+        }
+
+        // Compare against pure Kepler + Jupiter perturbation: at 60 AU the
+        // perturbation is tiny, so the orbit radius is preserved well.
+        let r = particles[0].pos.norm();
+        assert_relative_eq!(r, a, epsilon = 0.05);
+    }
+
+    #[test]
+    fn test_hybrid_energy_through_encounter() {
+        // Particle on an orbit crossing Jupiter's: total (Sun + Jupiter)
+        // specific energy in the rotating-free frame is not conserved, but
+        // the sanity check is that the integration neither blows up nor
+        // silently fails.
+        let mut bodies = vec![jupiter()];
+        // Eccentric orbit with perihelion near Jupiter's orbit
+        let q = 5.0;
+        let a = 20.0;
+        let v_peri = (GM_SUN * (2.0 / q - 1.0 / a)).sqrt();
+        let p0 = StateVector::new(Vector3::new(q, 0.0, 0.0), Vector3::new(0.0, v_peri, 0.0));
+        let mut particles = vec![p0];
+        let mut active = vec![true];
+        let config = test_config(150.0);
+
+        let mut total_failed = 0;
+        for _ in 0..500 {
+            total_failed +=
+                hybrid_step(&mut bodies, &mut particles, &mut active, config.dt, &config);
+        }
+        assert_eq!(total_failed, 0, "BS should converge through encounters");
+        assert!(active[0], "particle should survive");
+        let r = particles[0].pos.norm();
+        assert!(r.is_finite() && r > 0.1 && r < 1e4, "r = {r}");
+    }
+}

--- a/src/nbodylib/kepler.rs
+++ b/src/nbodylib/kepler.rs
@@ -1,0 +1,489 @@
+//! Kepler drift step: advance each body along its two-body Keplerian orbit.
+//!
+//! Uses the universal variable formulation (Battin 1999) for robust
+//! propagation of elliptic, parabolic, and hyperbolic orbits.
+
+use crate::constants::TAU as TWO_PI;
+
+use super::types::StateVector;
+
+/// Advance a state vector along its Keplerian orbit for time dt.
+/// Uses Stumpff function formulation with bisection-safeguarded
+/// Newton-Raphson iteration on the universal variable s. Bound orbits are
+/// reduced modulo the orbital period so the root is bracketed within one
+/// revolution of the universal anomaly; hyperbolic brackets expand outward
+/// but never past the Stumpff overflow cap. Cross-validated against
+/// `crate::keplerlib` (the SPICE prop2b port) by the oracle tests below.
+///
+/// `gm` is the central body GM in AU^3/day^2.
+pub fn kepler_drift(state: &StateVector, dt: f64, gm: f64) -> StateVector {
+    let r0 = state.pos;
+    let v0 = state.vel;
+    let r0_mag = r0.norm();
+    let v0_mag2 = v0.norm_squared();
+
+    if r0_mag < 1e-30 {
+        return *state;
+    }
+
+    // Specific orbital energy -> semi-major axis
+    let energy = 0.5 * v0_mag2 - gm / r0_mag;
+    let alpha = -2.0 * energy / gm; // = 1/a (positive for elliptic)
+
+    let r0_dot_v0 = r0.dot(&v0);
+
+    // Bound orbits are periodic: reduce dt by whole orbital periods so the
+    // universal anomaly stays within one revolution. Without this, multi-orbit
+    // dt makes every term of the universal Kepler equation ~ sqrt(gm)*|dt|;
+    // the rounding noise of the residual, divided by f' = r (small near
+    // perihelion at high e), then exceeds the 1e-15*s step tolerance and
+    // safeguarded Newton dithers inside a noise-width bracket forever
+    // ("convergence plateau"). Within one period every term is O(one orbit)
+    // and the noise floor sits below the tolerance.
+    let mut elliptic_period = None;
+    let dt = if alpha > 0.0 {
+        let period = TWO_PI / (gm * alpha.powi(3)).sqrt();
+        if period.is_finite() {
+            elliptic_period = Some(period);
+            dt.rem_euclid(period)
+        } else {
+            dt
+        }
+    } else {
+        dt
+    };
+    if dt == 0.0 {
+        return *state;
+    }
+
+    // Initial guess for universal variable s
+    let mut s = if alpha > 0.0 {
+        // Elliptic: s ~ n*dt where n = sqrt(gm * alpha^3)
+        let n = (gm * alpha.powi(3)).sqrt();
+        dt * n / (1.0 + 0.85 * (r0_dot_v0 / r0_mag).abs() * dt * n)
+    } else if alpha < -1e-15 {
+        // Hyperbolic
+        let a = 1.0 / alpha;
+        let sign_dt = dt.signum();
+        sign_dt
+            * (-a).sqrt()
+            * ((-2.0 * gm * alpha * dt)
+                / (r0_dot_v0 + sign_dt * (-gm / alpha).sqrt() * (1.0 - r0_mag * alpha)))
+                .abs()
+                .ln()
+    } else {
+        // Near-parabolic
+        dt / r0_mag
+    };
+
+    // Newton-Raphson iteration on the universal Kepler equation
+    // f(s) = r0*s + r0_dot_v0/sqrt(gm) * s^2 * c2(alpha*s^2)
+    //        + (1 - r0*alpha) * s^3 * c3(alpha*s^2) - sqrt(gm)*dt = 0
+    //
+    // f is strictly monotone in s (f' = r > 0), so a sign-changing bracket
+    // always exists and bisection-safeguarded Newton cannot diverge.
+    let sqrt_gm = gm.sqrt();
+
+    let kepler_f = |s: f64| -> f64 {
+        let psi = alpha * s * s;
+        let (c2, c3) = stumpff_c2c3(psi);
+        let s2 = s * s;
+        r0_mag * s + r0_dot_v0 / sqrt_gm * s2 * c2 + (1.0 - r0_mag * alpha) * s2 * s * c3
+            - sqrt_gm * dt
+    };
+
+    // Hyperbolic cap: |psi| = -alpha*s^2 beyond ~580^2 overflows cosh in the
+    // Stumpff terms, turning f into inf/NaN and corrupting the bracket.
+    // Physical roots sit exponentially far inside the cap (H = 580 means
+    // r ~ e^580 * |a|), so clamping loses nothing.
+    let s_cap = if alpha < 0.0 {
+        580.0 / (-alpha).sqrt()
+    } else {
+        f64::INFINITY
+    };
+
+    // Bracket the root: f(0) = -sqrt(gm)*dt has the opposite sign of dt.
+    // Elliptic: dt was reduced to [0, period), so the root lies within one
+    // revolution of the universal anomaly, s in [0, 2*pi/sqrt(alpha)]
+    // (expand only to absorb rounding at the endpoint). Hyperbolic /
+    // near-parabolic: expand outward from the starter until the sign
+    // changes, never past the overflow cap.
+    let (mut lo, mut hi) = if elliptic_period.is_some() {
+        let mut hi = TWO_PI / alpha.sqrt();
+        while kepler_f(hi) < 0.0 {
+            hi *= 1.5;
+        }
+        (0.0, hi)
+    } else if dt >= 0.0 {
+        let mut hi = s.abs().max(dt / r0_mag).max(1e-8).min(s_cap);
+        while kepler_f(hi) < 0.0 && hi < s_cap {
+            hi = (hi * 2.0).min(s_cap);
+        }
+        (0.0, hi)
+    } else {
+        let mut lo = (-s.abs().max(-dt / r0_mag).max(1e-8)).max(-s_cap);
+        while kepler_f(lo) > 0.0 && lo > -s_cap {
+            lo = (lo * 2.0).max(-s_cap);
+        }
+        (lo, 0.0)
+    };
+    s = s.clamp(lo, hi);
+
+    // Residual scale at the root (the constant term of the universal Kepler
+    // equation). When |f| dwarfs this, the iterate is deep in the Stumpff
+    // exponential tail where Newton only creeps additively (~1/sqrt(-alpha)
+    // per step without leaving the bracket); bisection gets there in
+    // O(log) steps instead.
+    let f_scale = sqrt_gm * dt.abs();
+
+    let mut converged = false;
+    let mut s_prev = f64::NAN;
+    for _ in 0..100 {
+        let psi = alpha * s * s;
+        let (c2, c3) = stumpff_c2c3(psi);
+
+        let s2 = s * s;
+        let s3 = s2 * s;
+
+        let t1 = r0_mag * s;
+        let t2 = r0_dot_v0 / sqrt_gm * s2 * c2;
+        let t3 = (1.0 - r0_mag * alpha) * s3 * c3;
+        let f_val = t1 + t2 + t3 - sqrt_gm * dt;
+
+        // The residual cannot be resolved below the rounding noise of its
+        // constituent terms; reaching that floor is convergence.
+        let f_floor = 4.0 * f64::EPSILON * (t1.abs() + t2.abs() + t3.abs() + sqrt_gm * dt.abs());
+        if f_val.abs() <= f_floor {
+            converged = true;
+            break;
+        }
+
+        if f_val > 0.0 {
+            hi = s;
+        } else {
+            lo = s;
+        }
+
+        // F'(χ) = r(χ) — the distance at the current iterate
+        let df =
+            r0_mag + r0_dot_v0 / sqrt_gm * s * (1.0 - psi * c3) + (1.0 - r0_mag * alpha) * s2 * c2;
+
+        let mut next = s - f_val / df;
+        if !(lo..=hi).contains(&next) || f_val.abs() > 1e8 * f_scale {
+            next = 0.5 * (lo + hi);
+        }
+        let ds = (next - s).abs();
+        // A bit-exact period-2 cycle means the iterate is alternating
+        // between the two adjacent representable values that straddle the
+        // root: the residual is pure rounding noise and the answer is as
+        // accurate as f64 permits.
+        let cycled = next == s_prev;
+        s_prev = s;
+        s = next;
+
+        // Converged when the step or the remaining bracket is at relative
+        // machine precision (the bracket collapses onto the root even when
+        // residual noise makes the Newton step dither).
+        let tol = 1e-15 * s.abs().max(1.0);
+        if ds < tol || (hi - lo) < tol || cycled {
+            converged = true;
+            break;
+        }
+    }
+    debug_assert!(
+        converged,
+        "universal Kepler solver failed to converge: dt = {dt}, gm = {gm}"
+    );
+
+    // Compute f, g, fdot, gdot Lagrange coefficients
+    let psi = alpha * s * s;
+    let (c2, c3) = stumpff_c2c3(psi);
+
+    let s2 = s * s;
+    let s3 = s2 * s;
+
+    let r_mag =
+        r0_mag + r0_dot_v0 / sqrt_gm * s * (1.0 - psi * c3) + (1.0 - r0_mag * alpha) * s2 * c2;
+
+    let f = 1.0 - s2 * c2 / r0_mag;
+    let g = dt - s3 * c3 / sqrt_gm;
+
+    let pos = f * r0 + g * v0;
+
+    let f_dot = sqrt_gm / (r_mag * r0_mag) * s * (alpha * s2 * c3 - 1.0);
+    let g_dot = 1.0 - s2 * c2 / r_mag;
+
+    let vel = f_dot * r0 + g_dot * v0;
+
+    StateVector::new(pos, vel)
+}
+
+/// Stumpff functions c2(psi) and c3(psi).
+/// c2(psi) = (1 - cos(sqrt(psi))) / psi     for psi > 0
+/// c3(psi) = (sqrt(psi) - sin(sqrt(psi))) / psi^(3/2)  for psi > 0
+///
+/// Uses 4-fold argument reduction: psi is divided by 4 until |psi| <= 0.1,
+/// the series is evaluated there, and the quadruple-angle recurrences
+///   c2(4x) = c1(x)^2 / 2,  c3(4x) = (c2(x) + c0(x) c3(x)) / 4
+/// (with c0 = 1 - x c2, c1 = 1 - x c3) recover the original argument.
+/// This avoids the catastrophic cosh overflow / cancellation the direct
+/// formulas suffer for large hyperbolic |psi|.
+fn stumpff_c2c3(psi: f64) -> (f64, f64) {
+    let mut x = psi;
+    let mut depth = 0u32;
+    while x.abs() > 0.1 {
+        x *= 0.25;
+        depth += 1;
+    }
+
+    // Maclaurin series, |x| <= 0.1: truncation error < 1e-16.
+    let mut c2 = (1.0 / 2.0) + x * (-1.0 / 24.0 + x * (1.0 / 720.0 + x * (-1.0 / 40_320.0)));
+    let mut c3 = (1.0 / 6.0) + x * (-1.0 / 120.0 + x * (1.0 / 5_040.0 + x * (-1.0 / 362_880.0)));
+
+    let mut c0 = 1.0 - x * c2;
+    let mut c1 = 1.0 - x * c3;
+
+    for _ in 0..depth {
+        c3 = (c2 + c0 * c3) * 0.25;
+        c2 = c1 * c1 * 0.5;
+        c1 *= c0;
+        c0 = 2.0 * c0 * c0 - 1.0;
+    }
+
+    (c2, c3)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::J2000;
+    use crate::keplerlib::KeplerOrbit;
+    use crate::nbodylib::types::{elements_to_cartesian, OrbitalElements};
+    use crate::nbodylib::GM_SUN;
+    use crate::time::Timescale;
+    use approx::assert_relative_eq;
+    use nalgebra::Vector3;
+
+    #[test]
+    fn test_circular_orbit() {
+        // Circular orbit at 1 AU: v = sqrt(GM/r)
+        let v_circ = (GM_SUN / 1.0_f64).sqrt();
+        let state = StateVector::new(Vector3::new(1.0, 0.0, 0.0), Vector3::new(0.0, v_circ, 0.0));
+
+        // One full period
+        let period = 2.0 * std::f64::consts::PI / (GM_SUN).sqrt();
+        let final_state = kepler_drift(&state, period, GM_SUN);
+
+        assert_relative_eq!(final_state.pos.x, 1.0, epsilon = 1e-10);
+        assert_relative_eq!(final_state.pos.y, 0.0, epsilon = 1e-10);
+        assert_relative_eq!(final_state.pos.z, 0.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_energy_conservation() {
+        // Eccentric orbit
+        let state = StateVector::new(
+            Vector3::new(1.0, 0.0, 0.0),
+            Vector3::new(0.0, 0.02, 0.002), // AU/day
+        );
+
+        let energy =
+            |s: &StateVector| -> f64 { 0.5 * s.vel.norm_squared() - GM_SUN / s.pos.norm() };
+
+        let e0 = energy(&state);
+        let mut s = state;
+        for _ in 0..10_000 {
+            s = kepler_drift(&s, 10.0, GM_SUN);
+        }
+        let e1 = energy(&s);
+
+        assert_relative_eq!(e0, e1, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn test_half_orbit() {
+        // Start at perihelion of e=0.5 orbit at 1 AU perihelion
+        // a = q/(1-e) = 2 AU
+        let a: f64 = 2.0;
+        let e = 0.5;
+        let v_peri = (GM_SUN * (1.0 + e) / (a * (1.0 - e))).sqrt();
+        let state = StateVector::new(Vector3::new(1.0, 0.0, 0.0), Vector3::new(0.0, v_peri, 0.0));
+
+        let period = 2.0 * std::f64::consts::PI * (a.powi(3) / GM_SUN).sqrt();
+        let half = kepler_drift(&state, period / 2.0, GM_SUN);
+
+        // At aphelion: x should be -Q = -a(1+e) = -3
+        assert_relative_eq!(half.pos.x, -3.0, epsilon = 1e-8);
+        assert_relative_eq!(half.pos.y, 0.0, epsilon = 1e-8);
+    }
+
+    #[test]
+    fn test_hyperbolic_round_trip() {
+        // Drift out and back along hyperbolic orbits: must return to the
+        // starting state to relative rounding.
+        for &e in &[1.0 + 1e-6, 1.5, 3.0] {
+            for &q in &[5.0, 800.0] {
+                let v_peri = (GM_SUN * (1.0 + e) / q).sqrt();
+                let s0 =
+                    StateVector::new(Vector3::new(q, 0.0, 0.0), Vector3::new(0.0, v_peri, 0.0));
+                for &dt in &[1.0e3, 2.0e5] {
+                    let out = kepler_drift(&s0, dt, GM_SUN);
+                    let back = kepler_drift(&out, -dt, GM_SUN);
+                    // Rounding error scales with the largest distance the
+                    // trajectory reaches, not the perihelion distance, and
+                    // the return leg loses a couple of digits to
+                    // cancellation in the f,g reconstruction near
+                    // perihelion (~2.5e-9 relative for e = 1.5, q = 5 AU).
+                    let scale = out.pos.norm().max(q);
+                    assert!(
+                        (back.pos - s0.pos).norm() <= 1e-8 * scale,
+                        "round-trip position drift: e = {e}, q = {q}, dt = {dt}"
+                    );
+                    // The perihelion velocity is the most sensitive quantity
+                    // (the v-field gradient is steepest there), so its error
+                    // also grows with the length of the round trip.
+                    assert!(
+                        (back.vel - s0.vel).norm() <= 1e-8 * v_peri * (scale / q),
+                        "round-trip velocity drift: e = {e}, q = {q}, dt = {dt}"
+                    );
+                }
+            }
+        }
+    }
+
+    // ===================================================================
+    // Oracle tests: kepler_drift vs keplerlib (SPICE prop2b port)
+    // ===================================================================
+
+    /// Propagate a state with keplerlib's prop2b port (universal variables +
+    /// Stumpff functions, SPICE parity) and return (pos AU, vel AU/day).
+    fn keplerlib_propagate(state: &StateVector, dt: f64) -> (Vector3<f64>, Vector3<f64>) {
+        let ts = Timescale::default();
+        let epoch = ts.tt_jd(J2000, None);
+        let target = ts.tt_jd(J2000 + dt, None);
+        let orbit = KeplerOrbit::new(state.pos, state.vel, &epoch, GM_SUN, None, None);
+        let p = orbit.at(&target);
+        (p.position, p.velocity)
+    }
+
+    /// Compare kepler_drift to keplerlib over one (state, dt) case.
+    /// `tol` is a relative tolerance scaled by the orbit size (AU) and by
+    /// the number of orbits covered: the two independent universal-variable
+    /// formulations accumulate along-track phase differences of a few ulps
+    /// per revolution, so multi-orbit dt amplifies an irreducible rounding
+    /// disagreement linearly.
+    fn check_drift_against_keplerlib(elem: &OrbitalElements, dt: f64, tol: f64) {
+        let state = elements_to_cartesian(elem, GM_SUN);
+        let ours = kepler_drift(&state, dt, GM_SUN);
+        let (sf_pos, sf_vel) = keplerlib_propagate(&state, dt);
+
+        let period = TWO_PI * (elem.a.abs().powi(3) / GM_SUN).sqrt();
+        let tol = tol * (1.0 + (dt / period).abs());
+
+        let scale_r = state.pos.norm().max(sf_pos.norm());
+        let scale_v = state.vel.norm().max(sf_vel.norm());
+
+        let dpos = (ours.pos - sf_pos).norm();
+        let dvel = (ours.vel - sf_vel).norm();
+        assert!(
+            dpos <= tol * scale_r,
+            "position mismatch vs keplerlib: |dr| = {dpos:.3e} AU (scale {scale_r:.3e}), \
+             a = {}, e = {}, M = {}, dt = {dt}",
+            elem.a,
+            elem.e,
+            elem.mean_anomaly
+        );
+        assert!(
+            dvel <= tol * scale_v,
+            "velocity mismatch vs keplerlib: |dv| = {dvel:.3e} AU/d (scale {scale_v:.3e}), \
+             a = {}, e = {}, M = {}, dt = {dt}",
+            elem.a,
+            elem.e,
+            elem.mean_anomaly
+        );
+    }
+
+    /// The documented failing corner of an earlier universal-variable
+    /// iteration: a = 800 AU, e = 0.95, M ≈ 5.97 (just before perihelion),
+    /// dt = 4e5 days. In debug builds the unhardened solver hit a
+    /// convergence-plateau debug_assert; the hardened solver must converge
+    /// AND agree with keplerlib.
+    #[test]
+    fn test_kepler_drift_known_failing_corner() {
+        let elem = OrbitalElements {
+            a: 800.0,
+            e: 0.95,
+            i: 0.3,
+            omega_big: 1.0,
+            omega: 2.0,
+            mean_anomaly: 5.97,
+        };
+        check_drift_against_keplerlib(&elem, 4.0e5, 1e-8);
+    }
+
+    /// Property grid: (a, e, M, dt) sweep spanning the integrators'
+    /// operating envelope (Kuiper belt through inner Oort cloud, fractions
+    /// of an orbit through many orbits, both time directions). Tolerance
+    /// 1e-8 relative: both solvers are independent universal-variable
+    /// formulations, and near-perihelion high-e states lose a few digits to
+    /// cancellation in either implementation.
+    #[test]
+    fn test_kepler_drift_grid_vs_keplerlib() {
+        let a_grid = [5.0, 40.0, 250.0, 800.0, 3000.0];
+        let e_grid = [0.0, 0.3, 0.7, 0.95, 0.99];
+        let m_grid = [0.0, 1.0, 3.1, 5.97];
+        // dt as a fraction of the orbital period, plus fixed offsets that
+        // put long-period orbits in the "fraction of an orbit across
+        // perihelion" regime where the plateau was observed.
+        let dt_fracs = [0.05, 0.5, 1.0, 3.7, -0.5];
+
+        for &a in &a_grid {
+            let period = TWO_PI * (a * a * a / GM_SUN).sqrt();
+            for &e in &e_grid {
+                for &m in &m_grid {
+                    let elem = OrbitalElements {
+                        a,
+                        e,
+                        i: 0.4,
+                        omega_big: 0.7,
+                        omega: 2.1,
+                        mean_anomaly: m,
+                    };
+                    for &frac in &dt_fracs {
+                        check_drift_against_keplerlib(&elem, frac * period, 1e-8);
+                    }
+                    // Fixed dt = 4e5 d (a typical Oort-cloud step size).
+                    check_drift_against_keplerlib(&elem, 4.0e5, 1e-8);
+                }
+            }
+        }
+    }
+
+    /// Hyperbolic states: kepler_drift vs keplerlib for e > 1.
+    #[test]
+    fn test_kepler_drift_hyperbolic_vs_keplerlib() {
+        for &e in &[1.0 + 1e-6, 1.1, 1.5, 3.0] {
+            for &q in &[5.0, 100.0, 800.0] {
+                // Build a perihelion state directly: r = q x̂, v = v_peri ŷ.
+                let v_peri = (GM_SUN * (1.0 + e) / q).sqrt();
+                let state =
+                    StateVector::new(Vector3::new(q, 0.0, 0.0), Vector3::new(0.0, v_peri, 0.0));
+                for &dt in &[-2.0e5, -1.0e3, 1.0e3, 2.0e5] {
+                    let ours = kepler_drift(&state, dt, GM_SUN);
+                    let (sf_pos, sf_vel) = keplerlib_propagate(&state, dt);
+                    let scale_r = sf_pos.norm();
+                    assert!(
+                        (ours.pos - sf_pos).norm() <= 1e-9 * scale_r,
+                        "hyperbolic position mismatch: e = {e}, q = {q}, dt = {dt}, \
+                         |dr| = {:.3e} (scale {scale_r:.3e})",
+                        (ours.pos - sf_pos).norm()
+                    );
+                    assert!(
+                        (ours.vel - sf_vel).norm() <= 1e-9 * sf_vel.norm(),
+                        "hyperbolic velocity mismatch: e = {e}, q = {q}, dt = {dt}"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/nbodylib/mod.rs
+++ b/src/nbodylib/mod.rs
@@ -1,0 +1,143 @@
+//! N-body integrators for solar-system dynamics.
+//!
+//! This module provides perturbed, multi-body orbit propagation on top of
+//! starfield's two-body machinery:
+//!
+//! - [`whm`] — symplectic Wisdom-Holman mapping in democratic-heliocentric
+//!   coordinates (Wisdom & Holman 1991; Duncan, Levison & Lee 1998), with
+//!   bounded energy error over arbitrarily long integrations.
+//! - [`bulirsch_stoer`] — Bulirsch-Stoer with recursive step-size control,
+//!   for high-accuracy work and close encounters.
+//! - [`hybrid`] — Mercury6-style hybrid switching (Chambers 1999): WHM far
+//!   from planets, Bulirsch-Stoer through encounters, with the smooth
+//!   changeover K(r) partitioning the planet force so nothing is
+//!   double-counted.
+//! - [`kepler`] — the universal-variable Kepler drift shared by all of the
+//!   above (bisection-safeguarded Newton, robust for elliptic, parabolic,
+//!   and hyperbolic states).
+//! - [`forces`] — composable extra accelerations applied in the kick stage
+//!   (orbit-averaged giant-planet quadrupole, galactic disk tide, custom
+//!   closures).
+//! - [`types`] — state vectors, orbital elements, massive bodies, and the
+//!   bridges to starfield's `planetlib` (ephemeris initial conditions) and
+//!   `keplerlib` (test particles from `KeplerOrbit`).
+//! - [`democratic`] — heliocentric/barycentric coordinate transforms used by
+//!   the WHM splitting.
+//!
+//! # Units and frame
+//!
+//! Everything in this module uses **AU** for length, **days** for time, and
+//! **AU³/day²** for gravitational parameters (GM). State vectors are
+//! heliocentric ecliptic-J2000 Cartesian coordinates, matching
+//! `positions::ecliptic::EclipticStateVector`.
+//!
+//! # Example
+//!
+//! ```
+//! use nalgebra::Vector3;
+//! use starfield::nbodylib::{MassiveBody, SimConfig, StateVector, WhmIntegrator, GM_SUN};
+//!
+//! // A Jupiter-mass planet on a circular 5.2 AU orbit.
+//! let gm = 1e-3 * GM_SUN;
+//! let v = (GM_SUN / 5.2_f64).sqrt();
+//! let mut bodies = vec![MassiveBody::new(
+//!     "Jupiter",
+//!     gm,
+//!     StateVector::new(Vector3::new(5.2, 0.0, 0.0), Vector3::new(0.0, v, 0.0)),
+//! )];
+//! let mut particles: Vec<StateVector> = Vec::new();
+//! let mut active: Vec<bool> = Vec::new();
+//!
+//! let config = SimConfig::default();
+//! let integrator = WhmIntegrator::new();
+//! for _ in 0..100 {
+//!     integrator.step(&mut bodies, &mut particles, &mut active, 100.0, &config);
+//! }
+//!
+//! // Still on a circular orbit after ~27 years.
+//! assert!((bodies[0].state.distance() - 5.2).abs() < 0.01);
+//! ```
+
+pub mod bulirsch_stoer;
+pub mod democratic;
+pub mod forces;
+pub mod hybrid;
+pub mod kepler;
+pub mod types;
+pub mod whm;
+
+pub use bulirsch_stoer::{bs_step, changeover_k};
+pub use forces::{total_extra_acceleration, ExtraForce};
+pub use hybrid::{changeover_radii, find_close_encounters, hybrid_step};
+pub use kepler::kepler_drift;
+pub use types::{
+    cartesian_to_elements, elements_to_cartesian, giant_planets_from_ephemeris, solve_kepler,
+    MassiveBody, OrbitalElements, SimConfig, StateVector,
+};
+pub use whm::{
+    barycentric_energy, total_angular_momentum, validate_timestep, WhmIntegrator,
+    MIN_STEPS_PER_ORBIT,
+};
+
+/// Heliocentric gravitational parameter in AU³/day².
+///
+/// JPL DE440 (Park et al. 2021): GM☉ = 1.32712440041279419e20 m³/s².
+/// Note this differs from `crate::constants::GM_SUN` (km³/s², Pitjeva 2005,
+/// 1.32712440042e20 m³/s²) by ~5.4e-12 relative — beyond every tolerance in
+/// this module, but pinned by a test below so the two can never silently
+/// diverge. The crate-level constant is left untouched.
+pub const GM_SUN: f64 = 2.959122082855911e-4;
+
+/// Giant-planet *system* gravitational parameters in AU³/day² (planet plus
+/// satellites, JPL DE440). These pair with the planet-system *barycenter*
+/// states that `planetlib` resolves for the outer planets, so barycenter
+/// states and system masses describe the same dynamical body.
+pub const GM_JUPITER: f64 = 2.825_345_818e-7;
+/// Saturn system GM in AU³/day² (DE440).
+pub const GM_SATURN: f64 = 8.459_715_6e-8;
+/// Uranus system GM in AU³/day² (DE440).
+pub const GM_URANUS: f64 = 1.292_024_9e-8;
+/// Neptune system GM in AU³/day² (DE440).
+pub const GM_NEPTUNE: f64 = 1.524_358_9e-8;
+
+/// Giant-planet system masses as a fraction of the solar mass (DE440).
+pub const MASS_JUPITER_SOLAR: f64 = 9.547_919_384e-4;
+/// Saturn system mass in solar masses (DE440).
+pub const MASS_SATURN_SOLAR: f64 = 2.858_859_81e-4;
+/// Uranus system mass in solar masses (DE440).
+pub const MASS_URANUS_SOLAR: f64 = 4.366_244_0e-5;
+/// Neptune system mass in solar masses (DE440).
+pub const MASS_NEPTUNE_SOLAR: f64 = 5.151_389_0e-5;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::{AU_KM, DAY_S};
+
+    #[test]
+    fn test_gm_sun_matches_crate_constant() {
+        // crate::constants::GM_SUN (km³/s²) converted to AU³/day². The
+        // underlying determinations differ by ~5.4e-12 relative (DE440 vs
+        // Pitjeva 2005), so agreement is pinned at 1e-11 rather than full
+        // f64 precision.
+        let crate_au3_day2 = crate::constants::GM_SUN * DAY_S * DAY_S / (AU_KM * AU_KM * AU_KM);
+        let rel = ((crate_au3_day2 - GM_SUN) / GM_SUN).abs();
+        assert!(rel < 1e-11, "relative difference = {rel:e}");
+    }
+
+    #[test]
+    fn test_planet_gm_mass_consistency() {
+        // GM_planet / GM_sun must equal the tabulated mass ratios.
+        for (gm, mass) in [
+            (GM_JUPITER, MASS_JUPITER_SOLAR),
+            (GM_SATURN, MASS_SATURN_SOLAR),
+            (GM_URANUS, MASS_URANUS_SOLAR),
+            (GM_NEPTUNE, MASS_NEPTUNE_SOLAR),
+        ] {
+            // The GM and mass-ratio constants are independently rounded
+            // DE440 values, so they agree to ~1e-7, not full precision.
+            let rel = (gm / GM_SUN - mass).abs() / mass;
+            assert!(rel < 1e-6, "GM/mass inconsistency: {rel:e}");
+        }
+    }
+}

--- a/src/nbodylib/types.rs
+++ b/src/nbodylib/types.rs
@@ -1,0 +1,781 @@
+//! Core types for the N-body integrators: state vectors, orbital elements,
+//! massive bodies, and simulation configuration.
+//!
+//! Units throughout: AU, days, GM in AU³/day², heliocentric ecliptic-J2000
+//! frame (see the [module root](super)).
+//!
+//! The element conversions here are the integrators' fast internal path
+//! (Murray & Dermott 1999 formulation, bisection-safeguarded Kepler solver).
+//! They are cross-validated against `crate::elementslib` — an independent
+//! Skyfield/SPICE-parity implementation — by the oracle tests below.
+
+use nalgebra::Vector3;
+
+use crate::constants::TAU as TWO_PI;
+use crate::keplerlib::KeplerOrbit;
+use crate::planetlib::{Body, Ephemeris, PlanetError};
+use crate::time::Time;
+
+use super::{GM_JUPITER, GM_NEPTUNE, GM_SATURN, GM_SUN, GM_URANUS};
+
+/// 3D position + velocity state vector in heliocentric ecliptic J2000.
+/// Units: AU for position, AU/day for velocity.
+#[derive(Debug, Clone, Copy)]
+pub struct StateVector {
+    /// Heliocentric position in AU.
+    pub pos: Vector3<f64>,
+    /// Heliocentric velocity in AU/day.
+    pub vel: Vector3<f64>,
+}
+
+impl StateVector {
+    /// Build a state vector from position (AU) and velocity (AU/day).
+    pub fn new(pos: Vector3<f64>, vel: Vector3<f64>) -> Self {
+        Self { pos, vel }
+    }
+
+    /// The zero state (origin, at rest).
+    pub fn zero() -> Self {
+        Self {
+            pos: Vector3::zeros(),
+            vel: Vector3::zeros(),
+        }
+    }
+
+    /// Heliocentric distance in AU.
+    pub fn distance(&self) -> f64 {
+        self.pos.norm()
+    }
+
+    /// Speed in AU/day.
+    pub fn speed(&self) -> f64 {
+        self.vel.norm()
+    }
+
+    /// Test-particle initial conditions from a `keplerlib::KeplerOrbit`,
+    /// propagated to `time` with the two-body universal-variable propagator.
+    ///
+    /// The state is returned in the frame the orbit's epoch state was given
+    /// in; any rotation configured on the orbit (e.g. via
+    /// `set_ecliptic_rotation`) is applied by `KeplerOrbit::at` first. For
+    /// use with this module's integrators the orbit should describe
+    /// heliocentric ecliptic-J2000 motion with no equatorial rotation set.
+    pub fn from_kepler_orbit(orbit: &KeplerOrbit, time: &Time) -> Self {
+        let p = orbit.at(time);
+        Self {
+            pos: p.position,
+            vel: p.velocity,
+        }
+    }
+}
+
+/// Classical Keplerian orbital elements.
+/// Angles in radians, distances in AU.
+#[derive(Debug, Clone, Copy)]
+pub struct OrbitalElements {
+    /// Semi-major axis (AU). Negative for hyperbolic orbits.
+    pub a: f64,
+    /// Eccentricity (dimensionless)
+    pub e: f64,
+    /// Inclination (radians, [0, pi])
+    pub i: f64,
+    /// Longitude of ascending node (radians, [0, 2pi))
+    pub omega_big: f64,
+    /// Argument of perihelion (radians, [0, 2pi))
+    pub omega: f64,
+    /// Mean anomaly (radians, [0, 2pi))
+    pub mean_anomaly: f64,
+}
+
+impl OrbitalElements {
+    /// Perihelion distance q = a(1-e) in AU
+    pub fn perihelion(&self) -> f64 {
+        self.a * (1.0 - self.e)
+    }
+
+    /// Aphelion distance Q = a(1+e) in AU
+    pub fn aphelion(&self) -> f64 {
+        self.a * (1.0 + self.e)
+    }
+
+    /// Semi-latus rectum p = a(1-e^2)
+    pub fn semi_latus_rectum(&self) -> f64 {
+        self.a * (1.0 - self.e * self.e)
+    }
+
+    /// Orbital period in days (only meaningful for bound orbits)
+    pub fn period(&self, gm: f64) -> f64 {
+        TWO_PI * (self.a.powi(3) / gm).sqrt()
+    }
+
+    /// Longitude of perihelion (varpi = Omega + omega)
+    pub fn longitude_of_perihelion(&self) -> f64 {
+        (self.omega_big + self.omega) % TWO_PI
+    }
+
+    /// Mean motion (radians/day)
+    pub fn mean_motion(&self, gm: f64) -> f64 {
+        (gm / self.a.powi(3)).sqrt()
+    }
+
+    /// Convert to Cartesian state vector.
+    /// `gm` is the central body GM in AU^3/day^2.
+    pub fn to_state_vector(&self, gm: f64) -> StateVector {
+        elements_to_cartesian(self, gm)
+    }
+}
+
+/// A massive body (planet, dwarf planet, hypothetical perturber).
+#[derive(Debug, Clone)]
+pub struct MassiveBody {
+    /// Display name (diagnostics only).
+    pub name: String,
+    /// GM in AU^3/day^2
+    pub gm: f64,
+    /// Mass in solar masses
+    pub mass: f64,
+    /// Heliocentric ecliptic-J2000 state.
+    pub state: StateVector,
+}
+
+impl MassiveBody {
+    /// Build a massive body from its GM (AU³/day²) and heliocentric state.
+    /// The solar-mass `mass` field is derived as `gm / GM_SUN`.
+    pub fn new(name: impl Into<String>, gm: f64, state: StateVector) -> Self {
+        Self {
+            name: name.into(),
+            gm,
+            mass: gm / GM_SUN,
+            state,
+        }
+    }
+
+    /// Hill sphere radius: r_H = d * (m / 3 M_sun)^(1/3), with `d` the
+    /// body's distance from the central mass in AU.
+    pub fn hill_radius(&self, distance_from_central: f64) -> f64 {
+        distance_from_central * (self.mass / 3.0).cbrt()
+    }
+
+    /// Initial conditions from a SPICE kernel: the body's heliocentric
+    /// ecliptic-J2000 state at `time`, with the caller-supplied GM
+    /// (AU³/day²).
+    ///
+    /// The ephemeris provides *states only*; GM always comes from the caller
+    /// (e.g. [`super::GM_JUPITER`]) rather than the kernel header, so
+    /// hard-coded and ephemeris-seeded integrations share one mass model.
+    /// Note `planetlib` resolves the outer planets to their NAIF *system
+    /// barycenters* — the right object here, since the `GM_*` constants are
+    /// planetary-system GMs (planet + satellites).
+    pub fn from_ephemeris(
+        ephemeris: &mut Ephemeris,
+        body: Body,
+        time: &Time,
+        gm: f64,
+    ) -> Result<Self, PlanetError> {
+        let sv = ephemeris.ecliptic_state(body, time)?;
+        Ok(Self::new(
+            body.name(),
+            gm,
+            StateVector::new(sv.position.to_vector3(), sv.velocity.to_vector3()),
+        ))
+    }
+}
+
+/// The four giant planets (Jupiter, Saturn, Uranus, Neptune) at `time`,
+/// with kernel barycenter states and DE440 system GMs. The standard
+/// starting condition for outer-solar-system integrations.
+pub fn giant_planets_from_ephemeris(
+    ephemeris: &mut Ephemeris,
+    time: &Time,
+) -> Result<Vec<MassiveBody>, PlanetError> {
+    [
+        (Body::Jupiter, GM_JUPITER),
+        (Body::Saturn, GM_SATURN),
+        (Body::Uranus, GM_URANUS),
+        (Body::Neptune, GM_NEPTUNE),
+    ]
+    .into_iter()
+    .map(|(body, gm)| MassiveBody::from_ephemeris(ephemeris, body, time, gm))
+    .collect()
+}
+
+/// Configuration for an integration run.
+#[derive(Debug, Clone)]
+pub struct SimConfig {
+    /// Timestep in days (see `whm::validate_timestep`).
+    pub dt: f64,
+    /// Remove particles closer than this to the Sun (AU)
+    pub removal_inner_au: f64,
+    /// Remove particles farther than this from the Sun (AU)
+    pub removal_outer_au: f64,
+    /// Hill sphere multiplier for hybrid integrator switching
+    pub hybrid_changeover_hill: f64,
+    /// Bulirsch-Stoer relative accuracy parameter
+    pub bs_epsilon: f64,
+}
+
+impl Default for SimConfig {
+    fn default() -> Self {
+        Self {
+            dt: 100.0,
+            removal_inner_au: 0.1,
+            removal_outer_au: 1e6,
+            hybrid_changeover_hill: 3.0,
+            bs_epsilon: 1e-12,
+        }
+    }
+}
+
+// ============================================================
+// Orbital element <-> Cartesian conversion
+// ============================================================
+
+/// Convert Keplerian elements to Cartesian state vector.
+/// Standard Murray & Dermott (1999) formulation.
+pub fn elements_to_cartesian(elem: &OrbitalElements, gm: f64) -> StateVector {
+    let p = elem.semi_latus_rectum();
+
+    // Solve Kepler's equation for eccentric anomaly
+    let ea = solve_kepler(elem.e, elem.mean_anomaly);
+
+    // True anomaly from eccentric anomaly
+    let nu = if elem.e < 1.0 {
+        let sin_nu = (1.0 - elem.e * elem.e).sqrt() * ea.sin() / (1.0 - elem.e * ea.cos());
+        let cos_nu = (ea.cos() - elem.e) / (1.0 - elem.e * ea.cos());
+        sin_nu.atan2(cos_nu)
+    } else {
+        // Hyperbolic case: sin ν = +√(e²−1)·sinh H / (e·cosh H − 1), so that
+        // M > 0 (outbound, r·v > 0) maps to ν > 0. A negated sin ν mirrors the
+        // state about perihelion (inbound/outbound swapped).
+        let sin_nu = (elem.e * elem.e - 1.0).sqrt() * ea.sinh() / (elem.e * ea.cosh() - 1.0);
+        let cos_nu = (elem.e - ea.cosh()) / (elem.e * ea.cosh() - 1.0);
+        sin_nu.atan2(cos_nu)
+    };
+
+    // Distance
+    let r = p / (1.0 + elem.e * nu.cos());
+
+    // Position and velocity in orbital plane
+    let r_orb = Vector3::new(r * nu.cos(), r * nu.sin(), 0.0);
+    let mu_p = (gm / p).sqrt();
+    let v_orb = Vector3::new(-mu_p * nu.sin(), mu_p * (elem.e + nu.cos()), 0.0);
+
+    // Rotation from orbital plane to ecliptic
+    let cos_o = elem.omega.cos();
+    let sin_o = elem.omega.sin();
+    let cos_i = elem.i.cos();
+    let sin_i = elem.i.sin();
+    let cos_big_o = elem.omega_big.cos();
+    let sin_big_o = elem.omega_big.sin();
+
+    let px = cos_big_o * cos_o - sin_big_o * sin_o * cos_i;
+    let py = sin_big_o * cos_o + cos_big_o * sin_o * cos_i;
+    let pz = sin_o * sin_i;
+
+    let qx = -cos_big_o * sin_o - sin_big_o * cos_o * cos_i;
+    let qy = -sin_big_o * sin_o + cos_big_o * cos_o * cos_i;
+    let qz = cos_o * sin_i;
+
+    let pos = Vector3::new(
+        r_orb.x * px + r_orb.y * qx,
+        r_orb.x * py + r_orb.y * qy,
+        r_orb.x * pz + r_orb.y * qz,
+    );
+
+    let vel = Vector3::new(
+        v_orb.x * px + v_orb.y * qx,
+        v_orb.x * py + v_orb.y * qy,
+        v_orb.x * pz + v_orb.y * qz,
+    );
+
+    StateVector { pos, vel }
+}
+
+/// Convert Cartesian state vector to Keplerian elements.
+pub fn cartesian_to_elements(state: &StateVector, gm: f64) -> OrbitalElements {
+    let r = &state.pos;
+    let v = &state.vel;
+    let r_mag = r.norm();
+    let v_mag = v.norm();
+
+    // Specific angular momentum
+    let h = r.cross(v);
+    let h_mag = h.norm();
+
+    // Node vector (z cross h)
+    let n = Vector3::new(-h.y, h.x, 0.0);
+    let n_mag = n.norm();
+
+    // Eccentricity vector
+    let e_vec = ((v_mag * v_mag - gm / r_mag) * r - r.dot(v) * v) / gm;
+    let e = e_vec.norm();
+
+    // Semi-major axis
+    let energy = 0.5 * v_mag * v_mag - gm / r_mag;
+    let a = if energy.abs() < 1e-30 {
+        f64::INFINITY
+    } else {
+        -gm / (2.0 * energy)
+    };
+
+    // Inclination
+    let i = (h.z / h_mag).clamp(-1.0, 1.0).acos();
+
+    // Longitude of ascending node
+    let omega_big = if n_mag < 1e-30 {
+        0.0
+    } else {
+        let mut o = (n.x / n_mag).clamp(-1.0, 1.0).acos();
+        if n.y < 0.0 {
+            o = TWO_PI - o;
+        }
+        o
+    };
+
+    // Argument of perihelion
+    let omega = if n_mag < 1e-30 || e < 1e-15 {
+        if e >= 1e-15 {
+            // Equatorial (no node): perihelion longitude measured along the
+            // direction of motion; h.z's sign distinguishes prograde from
+            // retrograde (a v.x or e_vec.y test alone breaks for i = π).
+            let mut w = (e_vec.x / e).clamp(-1.0, 1.0).acos();
+            if e_vec.y * h.z.signum() < 0.0 {
+                w = TWO_PI - w;
+            }
+            w
+        } else {
+            0.0
+        }
+    } else {
+        let cos_w = (n.dot(&e_vec) / (n_mag * e)).clamp(-1.0, 1.0);
+        let mut w = cos_w.acos();
+        if e_vec.z < 0.0 {
+            w = TWO_PI - w;
+        }
+        w
+    };
+
+    // True anomaly
+    let nu = if e < 1e-15 {
+        if n_mag < 1e-30 {
+            // Circular equatorial: true longitude along the direction of
+            // motion, prograde/retrograde resolved by sign(h.z).
+            let mut nu = (r.x / r_mag).clamp(-1.0, 1.0).acos();
+            if r.y * h.z.signum() < 0.0 {
+                nu = TWO_PI - nu;
+            }
+            nu
+        } else {
+            let cos_nu = (n.dot(r) / (n_mag * r_mag)).clamp(-1.0, 1.0);
+            let mut nu = cos_nu.acos();
+            if r.z < 0.0 {
+                nu = TWO_PI - nu;
+            }
+            nu
+        }
+    } else {
+        let cos_nu = (e_vec.dot(r) / (e * r_mag)).clamp(-1.0, 1.0);
+        let mut nu = cos_nu.acos();
+        if r.dot(v) < 0.0 {
+            nu = TWO_PI - nu;
+        }
+        nu
+    };
+
+    // Mean anomaly from true anomaly
+    let mean_anomaly = if e < 1.0 {
+        let ea = ((1.0 - e) / (1.0 + e)).sqrt() * (nu / 2.0).tan();
+        let ea = 2.0 * ea.atan();
+        let ma = ea - e * ea.sin();
+        if ma < 0.0 {
+            ma + TWO_PI
+        } else {
+            ma
+        }
+    } else {
+        // Hyperbolic
+        let ha = ((e - 1.0) / (e + 1.0)).sqrt() * (nu / 2.0).tan();
+        let ha = 2.0 * ha.atanh();
+        e * ha.sinh() - ha
+    };
+
+    OrbitalElements {
+        a,
+        e,
+        i,
+        omega_big,
+        omega,
+        mean_anomaly,
+    }
+}
+
+/// Solve Kepler's equation for the eccentric (e < 1) or hyperbolic (e > 1) anomaly.
+///
+/// Elliptic: M = E − e·sin E. Hyperbolic: M = e·sinh H − H.
+///
+/// Newton-Raphson with a bisection safeguard: the Kepler function is strictly
+/// monotone in the anomaly, so the iterate is confined to a sign-changing
+/// bracket and cannot diverge, even for e → 1. Starters: E₀ = π for e > 0.8
+/// (elliptic, avoids the e·sin E ≈ M degeneracy near perihelion), Danby's
+/// H₀ = ln(2M/e + 1.8) (hyperbolic).
+pub fn solve_kepler(e: f64, mean_anomaly: f64) -> f64 {
+    if e < 1.0 {
+        // Reduce M to (-pi, pi] and exploit the odd symmetry E(-M) = -E(M).
+        let mut m = mean_anomaly % TWO_PI;
+        if m > std::f64::consts::PI {
+            m -= TWO_PI;
+        } else if m < -std::f64::consts::PI {
+            m += TWO_PI;
+        }
+        let sign = if m < 0.0 { -1.0 } else { 1.0 };
+        let m = m.abs();
+
+        // For m in [0, pi] the root lies in [m, m + e] (since 0 <= e sin E <= e).
+        let mut lo = m;
+        let mut hi = (m + e).min(std::f64::consts::PI + e);
+        let mut ea = if e > 0.8 {
+            std::f64::consts::PI
+        } else {
+            m + 0.85 * e
+        };
+        ea = ea.clamp(lo, hi);
+
+        let mut converged = false;
+        for _ in 0..100 {
+            let f = ea - e * ea.sin() - m;
+            if f > 0.0 {
+                hi = ea;
+            } else {
+                lo = ea;
+            }
+            let fp = 1.0 - e * ea.cos();
+            let delta = f / fp;
+            let mut next = ea - delta;
+            if !(lo..=hi).contains(&next) {
+                // Newton left the bracket: bisect instead.
+                next = 0.5 * (lo + hi);
+            }
+            let step = (next - ea).abs();
+            ea = next;
+            if step < 1e-15 * ea.abs().max(1.0) {
+                converged = true;
+                break;
+            }
+        }
+        debug_assert!(
+            converged || (ea - e * ea.sin() - m).abs() < 1e-12,
+            "Kepler solver failed to converge: e = {e}, M = {mean_anomaly}"
+        );
+        sign * ea
+    } else {
+        // Hyperbolic, odd symmetry H(-M) = -H(M).
+        let sign = if mean_anomaly < 0.0 { -1.0 } else { 1.0 };
+        let m = mean_anomaly.abs();
+
+        // Danby (1988) starter.
+        let mut ha = (2.0 * m / e + 1.8).ln().max(1e-12);
+
+        // Bracket: f(0) = -m <= 0; expand hi until f(hi) >= 0
+        // (f' = e cosh H - 1 > 0, so the root is unique).
+        let f = |h: f64| e * h.sinh() - h - m;
+        let mut lo = 0.0_f64;
+        let mut hi = ha.max(1.0);
+        while f(hi) < 0.0 {
+            hi *= 2.0;
+        }
+        ha = ha.clamp(lo, hi);
+
+        let mut converged = false;
+        for _ in 0..100 {
+            let fv = f(ha);
+            if fv > 0.0 {
+                hi = ha;
+            } else {
+                lo = ha;
+            }
+            let fp = e * ha.cosh() - 1.0;
+            let mut next = ha - fv / fp;
+            if !(lo..=hi).contains(&next) {
+                next = 0.5 * (lo + hi);
+            }
+            let step = (next - ha).abs();
+            ha = next;
+            if step < 1e-15 * ha.abs().max(1.0) {
+                converged = true;
+                break;
+            }
+        }
+        debug_assert!(
+            converged || f(ha).abs() < 1e-12 * m.max(1.0),
+            "hyperbolic Kepler solver failed to converge: e = {e}, M = {mean_anomaly}"
+        );
+        sign * ha
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::{AU_KM, DAY_S, J2000};
+    use crate::jplephem::kernel::SpiceKernel;
+    use crate::time::Timescale;
+
+    /// This module's GM_SUN (AU³/day²) expressed in km³/s² for
+    /// `elementslib`'s APIs, so both sides describe the identical two-body
+    /// problem.
+    fn gm_sun_km3_s2() -> f64 {
+        GM_SUN * AU_KM * AU_KM * AU_KM / (DAY_S * DAY_S)
+    }
+
+    /// Wrap an angle difference to (-pi, pi].
+    fn angle_diff(x: f64, y: f64) -> f64 {
+        let mut d = (x - y) % TWO_PI;
+        if d > std::f64::consts::PI {
+            d -= TWO_PI;
+        } else if d < -std::f64::consts::PI {
+            d += TWO_PI;
+        }
+        d
+    }
+
+    /// Compare `cartesian_to_elements` against `elementslib`'s
+    /// OsculatingElements for the same state vector.
+    ///
+    /// Tolerances by regime:
+    /// - a (or q for near-parabolic), e, i: 1e-9 relative — pure algebra on
+    ///   the state vector in both implementations.
+    /// - Ω, ω, M: 1e-8 rad away from degeneracies. Near-degenerate cases
+    ///   (e ≤ 1e-6 makes ω/M individually ill-defined; i ≤ 1e-6 or i ≥ π−1e-6
+    ///   makes Ω/ω individually ill-defined) are compared through the
+    ///   well-defined combinations instead, with 2e-5 rad slack since the
+    ///   two codes resolve the degenerate angle from differently-rounded
+    ///   tiny vectors.
+    fn check_elements_against_elementslib(state: &StateVector) {
+        let ours = cartesian_to_elements(state, GM_SUN);
+        let sf =
+            crate::elementslib::osculating_elements_of(&state.pos, &state.vel, gm_sun_km3_s2());
+
+        let e = sf.eccentricity();
+        let i = sf.inclination_rad();
+
+        // Shape: a for bound/hyperbolic, q always. Skip a near e = 1, where
+        // a = -gm/(2*energy) is ill-conditioned (the ~1e-16 relative noise of
+        // the energy is amplified by 1/|e-1|); q remains well-conditioned and
+        // is always compared.
+        if (e - 1.0).abs() > 1e-5 {
+            let a_sf = sf.semi_major_axis_au();
+            assert!(
+                (ours.a - a_sf).abs() <= 1e-9 * a_sf.abs(),
+                "a mismatch: {} vs {a_sf}",
+                ours.a
+            );
+        }
+        let q_sf = sf.periapsis_distance_au();
+        let q_ours = ours.a * (1.0 - ours.e);
+        assert!(
+            (q_ours - q_sf).abs() <= 1e-8 * q_sf,
+            "q mismatch: {q_ours} vs {q_sf} (e = {e})"
+        );
+        assert!(
+            (ours.e - e).abs() <= 1e-9 * e.max(1.0),
+            "e mismatch: {} vs {e}",
+            ours.e
+        );
+        assert!((ours.i - i).abs() <= 1e-9, "i mismatch: {} vs {i}", ours.i);
+
+        let near_circular = e <= 1e-6;
+        let near_equatorial = !(1e-6..=std::f64::consts::PI - 1e-6).contains(&i);
+
+        if !near_equatorial {
+            assert!(
+                angle_diff(ours.omega_big, sf.longitude_of_ascending_node_rad()).abs() <= 1e-8,
+                "Omega mismatch: {} vs {}",
+                ours.omega_big,
+                sf.longitude_of_ascending_node_rad()
+            );
+        }
+        if !near_circular && !near_equatorial {
+            assert!(
+                angle_diff(ours.omega, sf.argument_of_periapsis_rad()).abs() <= 1e-8,
+                "omega mismatch: {} vs {}",
+                ours.omega,
+                sf.argument_of_periapsis_rad()
+            );
+        }
+        if !near_circular && e < 1.0 {
+            assert!(
+                angle_diff(ours.mean_anomaly, sf.mean_anomaly_rad()).abs() <= 1e-8,
+                "M mismatch: {} vs {} (e = {e})",
+                ours.mean_anomaly,
+                sf.mean_anomaly_rad()
+            );
+        }
+
+        // Degenerate regimes: compare the non-degenerate combinations.
+        // ϖ-like sum Ω + ω + M is well-defined for prograde orbits whenever
+        // the state itself is (elementslib folds the same convention into its
+        // longitude accessors only for i < π/2, so restrict to prograde).
+        if (near_circular || near_equatorial) && e < 1.0 && i < std::f64::consts::FRAC_PI_2 {
+            let ours_l = ours.omega_big + ours.omega + ours.mean_anomaly;
+            let sf_l = sf.longitude_of_ascending_node_rad()
+                + sf.argument_of_periapsis_rad()
+                + sf.mean_anomaly_rad();
+            assert!(
+                angle_diff(ours_l, sf_l).abs() <= 2e-5,
+                "mean longitude mismatch in degenerate regime: {ours_l} vs {sf_l} \
+                 (e = {e}, i = {i})"
+            );
+        }
+    }
+
+    /// Round trip: elements -> cartesian -> elements must reproduce the
+    /// state vector (the conversions are mutual inverses), checked through
+    /// the state because angle representations differ in degenerate regimes.
+    fn check_round_trip(elem: &OrbitalElements) {
+        let state = elements_to_cartesian(elem, GM_SUN);
+        let back = cartesian_to_elements(&state, GM_SUN);
+        let state2 = elements_to_cartesian(&back, GM_SUN);
+
+        let scale_r = state.pos.norm();
+        let scale_v = state.vel.norm();
+        assert!(
+            (state.pos - state2.pos).norm() <= 1e-9 * scale_r,
+            "round-trip position drift: a = {}, e = {}, i = {}, O = {}, w = {}, M = {}: \
+             |dr| = {:.3e}",
+            elem.a,
+            elem.e,
+            elem.i,
+            elem.omega_big,
+            elem.omega,
+            elem.mean_anomaly,
+            (state.pos - state2.pos).norm()
+        );
+        assert!(
+            (state.vel - state2.vel).norm() <= 1e-9 * scale_v,
+            "round-trip velocity drift: a = {}, e = {}, i = {}, O = {}, w = {}, M = {}",
+            elem.a,
+            elem.e,
+            elem.i,
+            elem.omega_big,
+            elem.omega,
+            elem.mean_anomaly
+        );
+    }
+
+    #[test]
+    fn test_element_round_trips_vs_elementslib() {
+        let e_grid = [0.0, 1e-6, 0.3, 0.95, 0.999, 1.0 + 1e-6, 1.5];
+        let i_grid_deg = [0.0, 1e-6_f64.to_degrees(), 30.0, 90.0, 150.0, 180.0];
+        // All quadrants of Omega, omega, nu (via mean anomaly proxies).
+        let angles = [0.5, 2.0, 3.8, 5.5];
+
+        for &e in &e_grid {
+            for &i_deg in &i_grid_deg {
+                for &omega_big in &angles {
+                    for &omega in &angles {
+                        for &m in &angles {
+                            // Hyperbolic: a < 0 with q = 30 AU. Pick the
+                            // anomaly through the true anomaly as a fraction
+                            // of the asymptote angle so r stays O(q) — a raw
+                            // M grid puts near-parabolic states
+                            // (|a| = q/(e-1), huge) at absurd distances where
+                            // every element is ill-conditioned. The fractions
+                            // still cover inbound and outbound on both sides
+                            // of perihelion.
+                            let (a, mean_anomaly) = if e < 1.0 {
+                                (450.0, m)
+                            } else {
+                                let nu_inf = (-1.0_f64 / e).acos();
+                                let frac = 0.8 * (m - std::f64::consts::PI) / std::f64::consts::PI;
+                                let nu = frac * nu_inf;
+                                let h: f64 = 2.0
+                                    * (((e - 1.0) / (e + 1.0)).sqrt() * (nu / 2.0).tan()).atanh();
+                                (-30.0 / (e - 1.0), e * h.sinh() - h)
+                            };
+                            let elem = OrbitalElements {
+                                a,
+                                e,
+                                i: i_deg.to_radians(),
+                                omega_big,
+                                omega,
+                                mean_anomaly,
+                            };
+                            let state = elements_to_cartesian(&elem, GM_SUN);
+                            check_elements_against_elementslib(&state);
+                            check_round_trip(&elem);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_giant_planets_from_de421_at_j2000() {
+        let kernel = SpiceKernel::open("test_data/de421.bsp").expect("Failed to open DE421");
+        let mut eph = Ephemeris::from_kernel(kernel);
+        let ts = Timescale::default();
+        let t = ts.tdb_jd(J2000);
+
+        let giants = giant_planets_from_ephemeris(&mut eph, &t).expect("kernel lookup");
+        let expected = [
+            (5.2, "Jupiter"),
+            (9.5, "Saturn"),
+            (19.2, "Uranus"),
+            (30.1, "Neptune"),
+        ];
+        for (body, (a, name)) in giants.iter().zip(expected) {
+            assert_eq!(body.name, name);
+            let r = body.state.distance();
+            assert!(
+                (r - a).abs() / a < 0.06,
+                "{name} at r = {r:.2} AU, expected near {a} AU"
+            );
+            // Speed near the vis-viva value for that distance and a.
+            let vis_viva = (GM_SUN * (2.0 / r - 1.0 / a)).sqrt();
+            assert!((body.state.speed() - vis_viva).abs() / vis_viva < 0.05);
+            // Giants are within ~2.5 deg of the ecliptic.
+            let lat = (body.state.pos.z / r).asin().abs();
+            assert!(lat < 0.05, "{name} ecliptic latitude {lat:.3} rad");
+            // mass derived from gm
+            assert!((body.mass - body.gm / GM_SUN).abs() < 1e-18);
+        }
+    }
+
+    #[test]
+    fn test_state_from_kepler_orbit_matches_elements() {
+        // A KeplerOrbit built from an nbodylib state, propagated zero days,
+        // returns the same state; propagated half a period it matches
+        // elements_to_cartesian at M + pi.
+        let elem = OrbitalElements {
+            a: 40.0,
+            e: 0.2,
+            i: 0.3,
+            omega_big: 1.1,
+            omega: 0.7,
+            mean_anomaly: 0.4,
+        };
+        let state = elements_to_cartesian(&elem, GM_SUN);
+
+        let ts = Timescale::default();
+        let epoch = ts.tt_jd(J2000, None);
+        let orbit = KeplerOrbit::new(state.pos, state.vel, &epoch, GM_SUN, None, None);
+
+        let s0 = StateVector::from_kepler_orbit(&orbit, &epoch);
+        assert!((s0.pos - state.pos).norm() < 1e-12);
+        assert!((s0.vel - state.vel).norm() < 1e-12);
+
+        let period = elem.period(GM_SUN);
+        let t_half = ts.tt_jd(J2000 + 0.5 * period, None);
+        let s_half = StateVector::from_kepler_orbit(&orbit, &t_half);
+
+        let mut elem_half = elem;
+        elem_half.mean_anomaly = (elem.mean_anomaly + std::f64::consts::PI) % TWO_PI;
+        let expect = elements_to_cartesian(&elem_half, GM_SUN);
+        assert!(
+            (s_half.pos - expect.pos).norm() < 1e-8 * expect.pos.norm(),
+            "half-period mismatch: {:.3e}",
+            (s_half.pos - expect.pos).norm()
+        );
+    }
+}

--- a/src/nbodylib/whm.rs
+++ b/src/nbodylib/whm.rs
@@ -1,0 +1,631 @@
+//! Wisdom-Holman Mapping (WHM) symplectic integrator in democratic
+//! heliocentric coordinates (Duncan, Levison & Lee 1998).
+//!
+//! The Hamiltonian splits into three commuting-flow pieces:
+//!   H_Kepler: each body on a Keplerian orbit about GM_sun
+//!             (heliocentric positions, barycentric momenta)
+//!   H_int:    direct planet-planet / planet-particle interactions
+//!   H_sun:    |Σpᵢ|²/(2 m_sun) — the solar-drift substep
+//!
+//! and the second-order step is
+//!   kick(dt/2) · solar_drift(dt/2) · Kepler(dt) · solar_drift(dt/2) · kick(dt/2).
+//!
+//! Heliocentric positions with *barycentric* momenta are canonical, so this
+//! splitting preserves a shadow Hamiltonian and gives bounded energy error
+//! over arbitrarily long integrations. (Heliocentric positions with
+//! heliocentric velocities are not canonical and drift secularly at
+//! O((m/M)²) per step.)
+//!
+//! Public state remains heliocentric positions + heliocentric velocities; the
+//! barycentric transform is applied internally per step (it is exact, so this
+//! does not break symplecticity).
+//!
+//! Reference: Wisdom & Holman (1991), Duncan, Levison & Lee (1998),
+//! Chambers (1999)
+
+use nalgebra::Vector3;
+
+use crate::constants::TAU as TWO_PI;
+
+use super::democratic::{
+    democratic_to_helio, dh_velocity_correction, helio_to_democratic, solar_drift,
+};
+use super::forces::{kick_bodies_direct, kick_particles_direct, total_extra_acceleration};
+use super::kepler::kepler_drift;
+use super::types::{MassiveBody, SimConfig, StateVector};
+use super::{ExtraForce, GM_SUN};
+
+/// Minimum number of steps per orbit of the innermost massive body needed for
+/// the WHM kick to resolve the interaction Hamiltonian (Wisdom & Holman 1991).
+pub const MIN_STEPS_PER_ORBIT: f64 = 20.0;
+
+/// Validate the timestep against the innermost massive body's orbital period.
+///
+/// WHM requires dt ≲ P_inner / 20; e.g. with Jupiter integrated directly
+/// (P ≈ 4333 d) the timestep must be ≲ 215 d. Coarser steps (e.g. 300 d)
+/// are only valid when the inner giants are absorbed into the J2-averaged
+/// field ([`ExtraForce::j2_giants`]) and Neptune is the innermost direct
+/// body.
+///
+/// Returns Err with a description when the timestep is too coarse.
+pub fn validate_timestep(bodies: &[MassiveBody], dt: f64) -> Result<(), String> {
+    for body in bodies {
+        let r = body.state.pos.norm();
+        let v2 = body.state.vel.norm_squared();
+        let energy = 0.5 * v2 - GM_SUN / r.max(1e-30);
+        if energy >= 0.0 {
+            continue; // unbound body: no period to resolve
+        }
+        let a = -GM_SUN / (2.0 * energy);
+        let period = TWO_PI * (a.powi(3) / GM_SUN).sqrt();
+        let max_dt = period / MIN_STEPS_PER_ORBIT;
+        if dt > max_dt {
+            return Err(format!(
+                "dt = {:.1} d under-resolves {} (P = {:.1} d; need dt <= P/{} = {:.1} d)",
+                dt, body.name, period, MIN_STEPS_PER_ORBIT, max_dt
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// The WHM integrator. Stateless apart from its extra-force list; the system
+/// being integrated is passed to [`WhmIntegrator::step`].
+#[derive(Debug, Default, Clone)]
+pub struct WhmIntegrator {
+    /// Extra accelerations applied in the kick stage (J2-averaged giants,
+    /// galactic tide, custom fields). Empty by default.
+    pub extra_forces: Vec<ExtraForce>,
+}
+
+impl WhmIntegrator {
+    /// Plain WHM with no extra kick-stage forces.
+    pub fn new() -> Self {
+        Self {
+            extra_forces: Vec::new(),
+        }
+    }
+
+    /// Convenience constructor with extra kick-stage forces.
+    pub fn with_extra_forces(extra_forces: Vec<ExtraForce>) -> Self {
+        Self { extra_forces }
+    }
+
+    /// Interaction kick: direct-only gravity plus any extra forces, applied
+    /// to bodies and particles for time dt.
+    fn kick(
+        &self,
+        bodies: &mut [MassiveBody],
+        particles: &mut [StateVector],
+        active: &[bool],
+        dt: f64,
+    ) {
+        kick_bodies_direct(bodies, dt);
+        kick_particles_direct(particles, active, bodies, dt);
+
+        if !self.extra_forces.is_empty() {
+            for body in bodies.iter_mut() {
+                body.state.vel +=
+                    dt * total_extra_acceleration(&self.extra_forces, &body.state.pos);
+            }
+            for (i, particle) in particles.iter_mut().enumerate() {
+                if !active[i] {
+                    continue;
+                }
+                particle.vel += dt * total_extra_acceleration(&self.extra_forces, &particle.pos);
+            }
+        }
+    }
+
+    /// Perform a single WHM step (democratic heliocentric scheme).
+    ///
+    /// `bodies`: massive bodies (planets, hypothetical perturbers),
+    ///           heliocentric pos/vel
+    /// `particles`: test particle state vectors, heliocentric pos/vel
+    /// `active`: which particles are still active
+    /// `dt`: timestep in days (must resolve the innermost body, see
+    ///       [`validate_timestep`]; checked via debug_assert)
+    pub fn step(
+        &self,
+        bodies: &mut [MassiveBody],
+        particles: &mut [StateVector],
+        active: &mut [bool],
+        dt: f64,
+        config: &SimConfig,
+    ) {
+        debug_assert!(
+            validate_timestep(bodies, dt).is_ok(),
+            "{}",
+            validate_timestep(bodies, dt).err().unwrap_or_default()
+        );
+
+        let half_dt = 0.5 * dt;
+
+        // Heliocentric velocities -> barycentric (canonical DH momenta).
+        helio_to_democratic(bodies, particles, 1.0);
+
+        // === KICK dt/2 (direct interactions + extra forces) ===
+        self.kick(bodies, particles, active, half_dt);
+
+        // === SOLAR DRIFT dt/2 ===
+        solar_drift(bodies, particles, active, half_dt, 1.0);
+
+        // === KEPLER DRIFT dt about GM_sun ===
+        // In DH variables the Kepler Hamiltonian is p²/2m − GM_sun·m/r for
+        // every body, so the drift central mass is GM_sun (not GM_sun + gm).
+        for body in bodies.iter_mut() {
+            body.state = kepler_drift(&body.state, dt, GM_SUN);
+        }
+        for (i, particle) in particles.iter_mut().enumerate() {
+            if !active[i] {
+                continue;
+            }
+            *particle = kepler_drift(particle, dt, GM_SUN);
+        }
+
+        // === SOLAR DRIFT dt/2 ===
+        solar_drift(bodies, particles, active, half_dt, 1.0);
+
+        // === KICK dt/2 ===
+        self.kick(bodies, particles, active, half_dt);
+
+        // Barycentric velocities -> heliocentric (re-evaluated: the momentum
+        // sum changes during the Kepler drift).
+        let v_back = dh_velocity_correction(bodies, 1.0);
+        democratic_to_helio(bodies, particles, &v_back);
+
+        // === BOUNDARY CHECK ===
+        for (i, particle) in particles.iter().enumerate() {
+            if !active[i] {
+                continue;
+            }
+            let r = particle.pos.norm();
+            if r < config.removal_inner_au || r > config.removal_outer_au {
+                active[i] = false;
+            }
+        }
+    }
+}
+
+/// Compute total energy of the system in *heliocentric* coordinates
+/// (for diagnostics). Returns (kinetic, potential, total).
+///
+/// Note: this is not the conserved quantity — heliocentric velocities omit
+/// the barycentric correction and active test particles pollute the budget.
+/// Use [`barycentric_energy`] / [`total_angular_momentum`] for conservation
+/// checks and [`particle_energies`] for per-particle diagnostics.
+pub fn system_energy(
+    bodies: &[MassiveBody],
+    particles: &[StateVector],
+    active: &[bool],
+) -> (f64, f64, f64) {
+    let mut kinetic = 0.0;
+    let mut potential = 0.0;
+
+    // Body kinetic energy (relative to Sun)
+    for body in bodies {
+        kinetic += 0.5 * body.mass * body.state.vel.norm_squared();
+    }
+
+    // Body-Sun potential
+    for body in bodies {
+        let r = body.state.pos.norm();
+        if r > 0.0 {
+            potential -= GM_SUN * body.mass / r;
+        }
+    }
+
+    // Body-body potential
+    for i in 0..bodies.len() {
+        for j in (i + 1)..bodies.len() {
+            let dr = (bodies[i].state.pos - bodies[j].state.pos).norm();
+            if dr > 0.0 {
+                potential -= bodies[i].gm * bodies[j].mass / dr;
+            }
+        }
+    }
+
+    // Particle kinetic energy (massless, but track for diagnostics using unit mass)
+    for (i, p) in particles.iter().enumerate() {
+        if !active[i] {
+            continue;
+        }
+        kinetic += 0.5 * p.vel.norm_squared(); // unit mass
+        let r = p.pos.norm();
+        if r > 0.0 {
+            potential -= GM_SUN / r;
+            for body in bodies {
+                let dr = (p.pos - body.state.pos).norm();
+                if dr > 0.0 {
+                    potential -= body.gm / dr;
+                }
+            }
+        }
+    }
+
+    (kinetic, potential, kinetic + potential)
+}
+
+/// Barycentric total energy of the Sun + massive bodies, in
+/// M_sun·AU²/day². Test particles are massless and excluded; see
+/// [`particle_energies`] for their diagnostics.
+///
+/// This is the quantity a symplectic integrator conserves (up to bounded
+/// oscillation); the heliocentric [`system_energy`] is not.
+pub fn barycentric_energy(bodies: &[MassiveBody]) -> f64 {
+    // Heliocentric Sun state: origin, at rest.
+    let mut m_total = 1.0;
+    let mut p_total = Vector3::zeros();
+    for b in bodies {
+        m_total += b.mass;
+        p_total += b.mass * b.state.vel;
+    }
+    let v_bary = p_total / m_total;
+
+    // Kinetic: bodies + Sun, in the barycentric frame.
+    let mut kinetic = 0.5 * v_bary.norm_squared(); // Sun, mass 1, v = -v_bary
+    for b in bodies {
+        kinetic += 0.5 * b.mass * (b.state.vel - v_bary).norm_squared();
+    }
+
+    // Potential: Sun-body + body-body (gm = G * mass in these units).
+    let mut potential = 0.0;
+    for b in bodies {
+        potential -= GM_SUN * b.mass / b.state.pos.norm();
+    }
+    for i in 0..bodies.len() {
+        for j in (i + 1)..bodies.len() {
+            let dr = (bodies[i].state.pos - bodies[j].state.pos).norm();
+            potential -= bodies[i].gm * bodies[j].mass / dr;
+        }
+    }
+
+    kinetic + potential
+}
+
+/// Barycentric total angular momentum of the Sun + massive bodies,
+/// in M_sun·AU²/day. Exactly conserved by the DH splitting (each substep
+/// Hamiltonian is rotation-invariant).
+pub fn total_angular_momentum(bodies: &[MassiveBody]) -> Vector3<f64> {
+    let mut m_total = 1.0;
+    let mut p_total = Vector3::zeros();
+    let mut mr_total = Vector3::zeros();
+    for b in bodies {
+        m_total += b.mass;
+        p_total += b.mass * b.state.vel;
+        mr_total += b.mass * b.state.pos;
+    }
+    let v_bary = p_total / m_total;
+    let r_bary = mr_total / m_total;
+
+    // Sun: heliocentric origin/rest -> barycentric (-r_bary, -v_bary).
+    let mut l = (-r_bary).cross(&(-v_bary)); // mass 1
+    for b in bodies {
+        l += b.mass * (b.state.pos - r_bary).cross(&(b.state.vel - v_bary));
+    }
+    l
+}
+
+/// Specific orbital energies (AU²/day²) of the test particles in the
+/// heliocentric frame, including the body potentials. Kept separate from the
+/// planetary energy budget: particle "energy" is a per-particle diagnostic
+/// (escape/capture flagging), not a conserved system quantity.
+pub fn particle_energies(
+    particles: &[StateVector],
+    active: &[bool],
+    bodies: &[MassiveBody],
+) -> Vec<f64> {
+    particles
+        .iter()
+        .enumerate()
+        .map(|(i, p)| {
+            if !active[i] {
+                return f64::NAN;
+            }
+            let mut e = 0.5 * p.vel.norm_squared() - GM_SUN / p.pos.norm();
+            for body in bodies {
+                let dr = (p.pos - body.state.pos).norm();
+                if dr > 0.0 {
+                    e -= body.gm / dr;
+                }
+            }
+            e
+        })
+        .collect()
+}
+
+/// Compute the Jacobi constant for the circular restricted three-body problem.
+/// Useful for testing. `mu` is the mass ratio m2/(m1+m2).
+pub fn jacobi_constant(state: &StateVector, mu: f64, omega: f64) -> f64 {
+    let x = state.pos.x;
+    let y = state.pos.y;
+
+    let r1 = ((x + mu).powi(2) + y.powi(2) + state.pos.z.powi(2)).sqrt();
+    let r2 = ((x - 1.0 + mu).powi(2) + y.powi(2) + state.pos.z.powi(2)).sqrt();
+
+    let v2 = state.vel.norm_squared();
+
+    // Jacobi constant: C_J = -2E - 2 * omega * L_z in rotating frame
+    // Or equivalently: C_J = (x^2 + y^2)*omega^2 + 2*(1-mu)/r1 + 2*mu/r2 - v^2
+    omega * omega * (x * x + y * y) + 2.0 * (1.0 - mu) / r1 + 2.0 * mu / r2 - v2
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::J2000;
+    use crate::jplephem::kernel::SpiceKernel;
+    use crate::nbodylib::types::giant_planets_from_ephemeris;
+    use crate::planetlib::Ephemeris;
+    use crate::time::Timescale;
+    use approx::assert_relative_eq;
+    use nalgebra::Vector3;
+
+    fn test_config(dt: f64) -> SimConfig {
+        SimConfig {
+            dt,
+            removal_inner_au: 0.1,
+            removal_outer_au: 1e6,
+            hybrid_changeover_hill: 3.0,
+            bs_epsilon: 1e-12,
+        }
+    }
+
+    fn jupiter_like() -> MassiveBody {
+        let a = 5.2;
+        let gm_planet = 1e-3 * GM_SUN;
+        let v = (GM_SUN / a).sqrt();
+        MassiveBody::new(
+            "Jupiter",
+            gm_planet,
+            StateVector::new(Vector3::new(a, 0.0, 0.0), Vector3::new(0.0, v, 0.0)),
+        )
+    }
+
+    fn saturn_like() -> MassiveBody {
+        let a = 9.55;
+        let gm_planet = 2.86e-4 * GM_SUN;
+        let v = (GM_SUN / a).sqrt();
+        MassiveBody::new(
+            "Saturn",
+            gm_planet,
+            StateVector::new(Vector3::new(0.0, a, 0.0), Vector3::new(-v, 0.0, 0.0)),
+        )
+    }
+
+    #[test]
+    fn test_whm_two_body_energy_conservation() {
+        let mut bodies = vec![jupiter_like()];
+        let mut particles = vec![];
+        let mut active = vec![];
+
+        let config = test_config(100.0);
+        let integrator = WhmIntegrator::new();
+        let e0 = barycentric_energy(&bodies);
+
+        let mut max_de: f64 = 0.0;
+        for step in 0..1000 {
+            integrator.step(&mut bodies, &mut particles, &mut active, config.dt, &config);
+            if step % 50 == 0 {
+                let e1 = barycentric_energy(&bodies);
+                max_de = max_de.max(((e1 - e0) / e0).abs());
+            }
+        }
+
+        // Symplectic integrator: bounded (not zero) energy oscillation.
+        assert!(max_de < 1e-5, "Energy error too large: {:.2e}", max_de);
+    }
+
+    #[test]
+    fn test_whm_two_planet_long_run_energy_bounded() {
+        // 1e5 steps (~41 kyr): a non-symplectic splitting drifts secularly,
+        // the DH scheme oscillates within a bounded band.
+        let mut bodies = vec![jupiter_like(), saturn_like()];
+        let mut particles = vec![];
+        let mut active = vec![];
+
+        let config = test_config(150.0);
+        let integrator = WhmIntegrator::new();
+        let e0 = barycentric_energy(&bodies);
+
+        let mut max_de: f64 = 0.0;
+        for step in 0..100_000 {
+            integrator.step(&mut bodies, &mut particles, &mut active, config.dt, &config);
+            if step % 1000 == 999 {
+                let e1 = barycentric_energy(&bodies);
+                max_de = max_de.max(((e1 - e0) / e0).abs());
+            }
+        }
+
+        assert!(
+            max_de < 1e-5,
+            "Long-run energy error not bounded: {:.2e}",
+            max_de
+        );
+    }
+
+    #[test]
+    fn test_whm_angular_momentum_conservation() {
+        // Every substep Hamiltonian is rotation invariant, so the total
+        // barycentric L is conserved to roundoff.
+        let mut bodies = vec![jupiter_like(), saturn_like()];
+        // Tilt Saturn a little so L has all three components.
+        bodies[1].state.vel.z = 0.1 * bodies[1].state.vel.norm();
+
+        let mut particles = vec![];
+        let mut active = vec![];
+
+        let config = test_config(150.0);
+        let integrator = WhmIntegrator::new();
+        let l0 = total_angular_momentum(&bodies);
+
+        for _ in 0..10_000 {
+            integrator.step(&mut bodies, &mut particles, &mut active, config.dt, &config);
+        }
+
+        let l1 = total_angular_momentum(&bodies);
+        let dl = (l1 - l0).norm() / l0.norm();
+        // Conserved up to accumulated roundoff (~1e-13/step random walk).
+        assert!(dl < 1e-8, "Angular momentum drift: {:.2e}", dl);
+    }
+
+    #[test]
+    fn test_whm_second_order_dt_scaling() {
+        // The energy-error amplitude of a second-order symplectic map scales
+        // as dt²: halving dt should reduce it by ~4x.
+        let amplitude = |dt: f64| -> f64 {
+            let mut bodies = vec![jupiter_like(), saturn_like()];
+            let mut particles = vec![];
+            let mut active = vec![];
+            let config = test_config(dt);
+            let integrator = WhmIntegrator::new();
+            let e0 = barycentric_energy(&bodies);
+
+            let n_steps = (40_000.0 / dt).round() as usize;
+            let mut max_de: f64 = 0.0;
+            for _ in 0..n_steps {
+                integrator.step(&mut bodies, &mut particles, &mut active, dt, &config);
+                let e1 = barycentric_energy(&bodies);
+                max_de = max_de.max(((e1 - e0) / e0).abs());
+            }
+            max_de
+        };
+
+        let err_coarse = amplitude(200.0);
+        let err_fine = amplitude(100.0);
+        let ratio = err_coarse / err_fine;
+        assert!(
+            (2.5..6.0).contains(&ratio),
+            "dt-scaling ratio {ratio:.2} not consistent with 2nd order (expect ~4)"
+        );
+    }
+
+    #[test]
+    fn test_whm_particle_on_circular_orbit() {
+        // No planets, just a particle on a circular orbit
+        let a = 30.0; // Neptune distance
+        let v = (GM_SUN / a).sqrt();
+
+        let mut bodies = vec![];
+        let mut particles = vec![StateVector::new(
+            Vector3::new(a, 0.0, 0.0),
+            Vector3::new(0.0, v, 0.0),
+        )];
+        let mut active = vec![true];
+
+        let config = test_config(300.0);
+        let integrator = WhmIntegrator::new();
+
+        // One orbital period of Neptune
+        let period = 2.0 * std::f64::consts::PI * (a * a * a / GM_SUN).sqrt();
+        let n_steps = (period / config.dt).round() as usize;
+
+        for _ in 0..n_steps {
+            integrator.step(&mut bodies, &mut particles, &mut active, config.dt, &config);
+        }
+
+        // Should return close to starting position
+        assert_relative_eq!(particles[0].pos.x, a, epsilon = 0.1);
+        assert_relative_eq!(particles[0].pos.y, 0.0, epsilon = 0.1);
+    }
+
+    #[test]
+    fn test_extra_force_j2_giants_induces_apsidal_precession() {
+        // A q = 35 AU, a = 100 AU particle under the J2-averaged giants
+        // precesses; without the extra force it stays Keplerian.
+        use crate::nbodylib::types::{cartesian_to_elements, OrbitalElements};
+
+        let elements = OrbitalElements {
+            a: 100.0,
+            e: 0.65,
+            i: 0.1,
+            omega_big: 0.3,
+            omega: 0.5,
+            mean_anomaly: 1.0,
+        };
+        let state = elements.to_state_vector(GM_SUN);
+
+        let mut bodies = vec![];
+        let mut particles = vec![state];
+        let mut active = vec![true];
+        let config = test_config(3000.0);
+        let integrator = WhmIntegrator::with_extra_forces(vec![ExtraForce::j2_giants()]);
+
+        // ~8 kyr per 1000 steps at dt = 3000 d
+        for _ in 0..1000 {
+            integrator.step(&mut bodies, &mut particles, &mut active, config.dt, &config);
+        }
+
+        let elem1 = cartesian_to_elements(&particles[0], GM_SUN);
+        let varpi0 = elements.omega + elements.omega_big;
+        let varpi1 = elem1.omega + elem1.omega_big;
+        let dvarpi = (varpi1 - varpi0).rem_euclid(TWO_PI);
+        let dvarpi = if dvarpi > std::f64::consts::PI {
+            dvarpi - TWO_PI
+        } else {
+            dvarpi
+        };
+        assert!(
+            dvarpi.abs() > 1e-4,
+            "J2 giants extra force produced no apsidal precession (dvarpi = {dvarpi:.2e})"
+        );
+        // Semi-major axis is secularly preserved by the axisymmetric field.
+        assert!((elem1.a - 100.0).abs() < 1.0, "a drifted: {}", elem1.a);
+    }
+
+    #[test]
+    fn test_validate_timestep() {
+        let bodies = vec![jupiter_like()];
+        // P_jup ~ 4333 d -> max dt ~ 217 d
+        assert!(validate_timestep(&bodies, 200.0).is_ok());
+        assert!(validate_timestep(&bodies, 300.0).is_err());
+    }
+
+    #[test]
+    fn test_whm_giants_from_ephemeris_energy_bounded() {
+        // Real DE421 initial conditions at J2000, integrated 1000 years:
+        // barycentric energy and angular momentum stay bounded.
+        let kernel = SpiceKernel::open("test_data/de421.bsp").expect("Failed to open DE421");
+        let mut eph = Ephemeris::from_kernel(kernel);
+        let ts = Timescale::default();
+        let t0 = ts.tdb_jd(J2000);
+        let mut bodies = giant_planets_from_ephemeris(&mut eph, &t0).expect("kernel lookup");
+
+        let dt = 150.0; // resolves Jupiter (P/20 ≈ 217 d)
+        validate_timestep(&bodies, dt).expect("timestep must resolve Jupiter");
+
+        let mut particles = vec![];
+        let mut active = vec![];
+        let config = test_config(dt);
+        let integrator = WhmIntegrator::new();
+
+        let e0 = barycentric_energy(&bodies);
+        let l0 = total_angular_momentum(&bodies);
+
+        let n_steps = (1000.0 * 365.25 / dt).round() as usize;
+        let mut max_de: f64 = 0.0;
+        for step in 0..n_steps {
+            integrator.step(&mut bodies, &mut particles, &mut active, dt, &config);
+            if step % 100 == 99 {
+                let e1 = barycentric_energy(&bodies);
+                max_de = max_de.max(((e1 - e0) / e0).abs());
+            }
+        }
+
+        // Bounded symplectic oscillation: ~2e-6 for the real (eccentric,
+        // inclined) giants at dt = 150 d.
+        assert!(max_de < 1e-5, "energy drift over 1 kyr: {max_de:.2e}");
+        let dl = (total_angular_momentum(&bodies) - l0).norm() / l0.norm();
+        assert!(dl < 1e-8, "angular momentum drift: {dl:.2e}");
+
+        // The giants stay near their catalog semi-major axes.
+        for (body, a) in bodies.iter().zip([5.2, 9.5, 19.2, 30.1]) {
+            let r = body.state.distance();
+            assert!(
+                (r - a).abs() / a < 0.15,
+                "{} wandered to r = {r:.2} AU",
+                body.name
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fills starfield's largest documented gap — no N-body capability existed (two-body keplerlib, SGP4, SPK lookup only). Ports the integrator stack from OrbitalCommons/planet9 where it was built, reviewed, and hardened:

- Wisdom-Holman symplectic map in democratic-heliocentric coordinates (Duncan, Levison & Lee 1998) with timestep validation and energy/angular-momentum/Jacobi diagnostics
- Hardened universal-variable Kepler drift (dt mod period, single-revolution bracketing, hyperbolic Stumpff-overflow caps, noise-floor acceptance — the planet9 bug-history comments travel)
- Bulirsch-Stoer with recursive step halving and moving-planet substep drift
- Chambers (1999) hybrid switching with smooth changeover and predicted-minimum-separation encounter detection
- Composable ExtraForce hook: J2Averaged (giant-planet quadrupole with GM boost), GalacticTide (built on framelib::GALACTIC), Custom closures

Integration points: MassiveBody::from_ephemeris / giant_planets_from_ephemeris over planetlib, StateVector::from_kepler_orbit, oracle test grids against keplerlib and elementslib, kernel tests on the shipped de421.bsp. examples/nbody_giants.rs runs the four giants 1000 yr from DE421 ICs (|dE/E| ~ 2e-6, |dL|/|L| ~ 2e-10).

38 unit tests + doc-test; clippy -D warnings clean; zero new dependencies.

Closes OrbitalCommons/planet9#30