### PR TITLE
Add surveylib: survey detection and completeness simulator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod secularlib;
 pub mod sgp4lib;
 pub mod starlib;
 pub mod statslib;
+pub mod surveylib;
 pub mod time;
 pub mod toposlib;
 pub mod units;

--- a/src/surveylib/detection.rs
+++ b/src/surveylib/detection.rs
@@ -1,0 +1,230 @@
+//! Per-epoch detection efficiency and multi-epoch linking.
+//!
+//! Two layers:
+//!
+//! 1. [`DetectionModel`] — the probability that a *single* exposure of a
+//!    source at apparent magnitude `m` yields a catalogued detection,
+//!    modeled as the logistic completeness curve used throughout the
+//!    survey literature.
+//! 2. [`LinkingRequirement`] — how many independent per-epoch detections
+//!    a survey's pipeline needs before it links them into a discoverable
+//!    object (a tracklet/orbit). The k-of-n probability is computed with
+//!    the **exact** Poisson-binomial tail ([`poisson_binomial_tail`]),
+//!    never a binomial approximation, so heterogeneous per-epoch
+//!    probabilities (different bands, depths, or footprint gating) are
+//!    handled exactly.
+//!
+//! # Every parameter here is fitted, not derived
+//!
+//! `m50`, `steepness`, and `ceiling` are calibration knobs measured by
+//! injecting synthetic sources into a real pipeline (or tuned to
+//! reproduce a published recovery fraction). They are not derivable from
+//! first principles, and values fitted for one survey/pipeline are
+//! meaningless for another. Keep your survey's numbers next to their
+//! provenance, and flag any parameter tuned to match an end-to-end result
+//! as *fitted* in its documentation.
+
+/// Survival probability `P(X >= k)` of a Poisson-binomial random variable:
+/// the number of successes among independent Bernoulli trials with
+/// heterogeneous probabilities `probs`.
+///
+/// Computed by exact dynamic programming over the count distribution in
+/// `O(n·k)` time and `O(k)` space: `dist[j]` tracks `P(exactly j successes
+/// so far)` for `j < k`, and `tail` absorbs `P(>= k)` as trials are folded
+/// in. No sampling, no normal/Poisson approximation.
+///
+/// Edge cases: `k = 0` returns 1 exactly; `k > probs.len()` returns 0.
+///
+/// # Example
+///
+/// ```
+/// use starfield::surveylib::poisson_binomial_tail;
+///
+/// // Homogeneous case reduces to the binomial: n = 10, p = 0.5,
+/// // P(X >= 6) = 386/1024.
+/// let tail = poisson_binomial_tail(&[0.5; 10], 6);
+/// assert!((tail - 386.0 / 1024.0).abs() < 1e-12);
+///
+/// // P(X >= 1) = 1 - prod(1 - p_i).
+/// let any = poisson_binomial_tail(&[0.1, 0.4, 0.7], 1);
+/// assert!((any - (1.0 - 0.9 * 0.6 * 0.3)).abs() < 1e-12);
+/// ```
+pub fn poisson_binomial_tail(probs: &[f64], k: u32) -> f64 {
+    let k = k as usize;
+    if k == 0 {
+        return 1.0;
+    }
+    // dist[j] = P(exactly j successes so far) for j < k; `tail` absorbs
+    // P(>= k successes).
+    let mut dist = vec![0.0_f64; k];
+    dist[0] = 1.0;
+    let mut tail = 0.0_f64;
+    for &p in probs {
+        tail += dist[k - 1] * p;
+        for j in (1..k).rev() {
+            dist[j] = dist[j] * (1.0 - p) + dist[j - 1] * p;
+        }
+        dist[0] *= 1.0 - p;
+    }
+    tail
+}
+
+/// Logistic single-epoch detection completeness:
+///
+/// ```text
+/// p(m) = ceiling / (1 + exp(steepness · (m − m50)))
+/// ```
+///
+/// `m50` is the magnitude of 50%-of-ceiling completeness, `steepness`
+/// sets the transition width (the curve falls from 0.73·ceiling to
+/// 0.27·ceiling over `2/steepness` magnitudes), and `ceiling` is the
+/// bright-end asymptote (real pipelines lose a few percent of even the
+/// brightest sources to masking, blends, and chip gaps, so `ceiling < 1`).
+///
+/// **All three parameters are fitted calibration values** — see the
+/// [module docs](self) — typically measured per band by synthetic-source
+/// injection. Model one band per `DetectionModel`; multi-band surveys
+/// carry one model (or one per-epoch [`m50`](crate::surveylib::Epoch)
+/// override) per band's epochs.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DetectionModel {
+    /// Magnitude at which completeness is half the ceiling (fitted).
+    pub m50: f64,
+    /// Logistic slope in 1/mag (fitted); larger is a sharper cutoff.
+    pub steepness: f64,
+    /// Bright-end asymptotic completeness in `[0, 1]` (fitted).
+    pub ceiling: f64,
+}
+
+impl DetectionModel {
+    /// New logistic model; see the field docs for parameter meanings.
+    pub fn new(m50: f64, steepness: f64, ceiling: f64) -> Self {
+        Self {
+            m50,
+            steepness,
+            ceiling,
+        }
+    }
+
+    /// Single-epoch detection probability at apparent magnitude `mag`.
+    pub fn efficiency(&self, mag: f64) -> f64 {
+        self.efficiency_at_depth(mag, self.m50)
+    }
+
+    /// Single-epoch detection probability with the 50%-completeness depth
+    /// overridden to `m50` (e.g. a per-epoch depth from varying observing
+    /// conditions or a different band); `steepness` and `ceiling` are
+    /// retained from the model.
+    pub fn efficiency_at_depth(&self, mag: f64, m50: f64) -> f64 {
+        self.ceiling / (1.0 + (self.steepness * (mag - m50)).exp())
+    }
+}
+
+/// How many per-epoch detections a survey pipeline requires before the
+/// object counts as found.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkingRequirement {
+    /// Detections on at least `k` of the survey's epochs, with each epoch
+    /// an independent Bernoulli trial at its own probability. `k = 1`
+    /// degenerates to "any single detection suffices"; multi-night
+    /// linking pipelines use larger `k` (a tracklet needs enough
+    /// detections to constrain an orbit).
+    KOfN {
+        /// Minimum number of detected epochs.
+        k: u32,
+    },
+}
+
+impl LinkingRequirement {
+    /// Probability that the requirement is met, given independent
+    /// per-epoch detection probabilities (exact Poisson-binomial tail).
+    pub fn probability(&self, epoch_probs: &[f64]) -> f64 {
+        match self {
+            LinkingRequirement::KOfN { k } => poisson_binomial_tail(epoch_probs, *k),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn poisson_binomial_tail_matches_binomial() {
+        let probs = vec![0.5; 10];
+        let tail = poisson_binomial_tail(&probs, 6);
+        assert!((tail - 386.0 / 1024.0).abs() < 1e-12, "tail = {tail}");
+        // Degenerate edges.
+        assert_eq!(poisson_binomial_tail(&probs, 0), 1.0);
+        assert!(poisson_binomial_tail(&probs, 11) < 1e-12);
+        assert_eq!(poisson_binomial_tail(&[], 0), 1.0);
+        assert_eq!(poisson_binomial_tail(&[], 1), 0.0);
+    }
+
+    #[test]
+    fn poisson_binomial_tail_heterogeneous() {
+        // P(X >= 1) = 1 - prod(1 - p_i).
+        let probs = [0.1, 0.4, 0.7];
+        let tail = poisson_binomial_tail(&probs, 1);
+        let expected = 1.0 - 0.9 * 0.6 * 0.3;
+        assert!((tail - expected).abs() < 1e-12);
+        // P(X >= 3) = prod(p_i).
+        let all = poisson_binomial_tail(&probs, 3);
+        assert!((all - 0.1 * 0.4 * 0.7).abs() < 1e-12);
+        // Exhaustive middle term: P(X >= 2) by enumeration.
+        let p2 = 0.1 * 0.4 * 0.3 + 0.1 * 0.6 * 0.7 + 0.9 * 0.4 * 0.7 + 0.1 * 0.4 * 0.7;
+        assert!((poisson_binomial_tail(&probs, 2) - p2).abs() < 1e-12);
+    }
+
+    #[test]
+    fn poisson_binomial_tail_monotone_in_k() {
+        let probs = [0.9, 0.2, 0.5, 0.8, 0.3];
+        let mut prev = 1.0;
+        for k in 0..=6 {
+            let t = poisson_binomial_tail(&probs, k);
+            assert!(t <= prev + 1e-15, "tail not monotone at k = {k}");
+            assert!((0.0..=1.0).contains(&t));
+            prev = t;
+        }
+    }
+
+    #[test]
+    fn logistic_efficiency_shape() {
+        let model = DetectionModel::new(24.0, 3.0, 0.95);
+        // Half the ceiling exactly at m50.
+        assert!((model.efficiency(24.0) - 0.475).abs() < 1e-12);
+        // Bright end approaches the ceiling, never exceeds it.
+        assert!(model.efficiency(18.0) > 0.94);
+        assert!(model.efficiency(18.0) <= 0.95);
+        // Faint end falls to zero.
+        assert!(model.efficiency(28.0) < 1e-4);
+        // Monotone decreasing.
+        let mut prev = model.efficiency(15.0);
+        for tenth in 151..=300 {
+            let p = model.efficiency(tenth as f64 / 10.0);
+            assert!(p <= prev + 1e-15);
+            prev = p;
+        }
+    }
+
+    #[test]
+    fn per_epoch_depth_override() {
+        let model = DetectionModel::new(24.0, 3.0, 1.0);
+        // Overriding the depth shifts the curve, keeping shape parameters.
+        assert!((model.efficiency_at_depth(22.0, 22.0) - 0.5).abs() < 1e-12);
+        assert_eq!(
+            model.efficiency_at_depth(20.0, 24.0),
+            model.efficiency(20.0)
+        );
+    }
+
+    #[test]
+    fn linking_k_of_n() {
+        let probs = [0.5; 10];
+        let link = LinkingRequirement::KOfN { k: 6 };
+        assert!((link.probability(&probs) - 386.0 / 1024.0).abs() < 1e-12);
+        // k = 1 is the complement of total non-detection.
+        let any = LinkingRequirement::KOfN { k: 1 };
+        assert!((any.probability(&[0.25, 0.25]) - (1.0 - 0.75 * 0.75)).abs() < 1e-12);
+    }
+}

--- a/src/surveylib/footprint.rs
+++ b/src/surveylib/footprint.rs
@@ -1,0 +1,261 @@
+//! Survey sky footprints in equatorial coordinates.
+//!
+//! A footprint answers two questions: *is this (RA, dec) inside the
+//! surveyed region?* and *how much sky does the region cover?* Both are
+//! always posed in **equatorial** coordinates (RA/dec in degrees). Survey
+//! footprints are instrumental — they live on the equatorial sky — so any
+//! position computed in ecliptic coordinates must be rotated through a
+//! typed frame transform (see [`super::geometry`]) before a membership
+//! test. Substituting ecliptic latitude for declination misclassifies
+//! exactly the survey-boundary regions that drive coverage estimates.
+
+use crate::constants::RAD2DEG;
+
+/// One declination band with a (possibly zero-wrapping) right-ascension
+/// range, the building block of box-union footprints.
+///
+/// The RA range runs **eastward** from `ra_start_deg` to `ra_end_deg` and
+/// may wrap through 0°/360° (e.g. `ra_start_deg = 300`, `ra_end_deg = 105`
+/// covers RA 300°→360°→105°). Membership is half-open in both axes:
+/// `dec_min_deg <= dec < dec_max_deg` and RA in `[ra_start, ra_end)`
+/// eastward, so abutting boxes tile without double counting.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SkyBox {
+    /// Minimum declination (degrees, inclusive).
+    pub dec_min_deg: f64,
+    /// Maximum declination (degrees, exclusive).
+    pub dec_max_deg: f64,
+    /// RA range start (degrees); the range runs eastward from here.
+    pub ra_start_deg: f64,
+    /// RA range end (degrees, exclusive); may be numerically smaller than
+    /// `ra_start_deg`, in which case the range wraps through 0°.
+    pub ra_end_deg: f64,
+}
+
+impl SkyBox {
+    /// Whether the equatorial position falls inside the box.
+    pub fn contains(&self, ra_deg: f64, dec_deg: f64) -> bool {
+        (self.dec_min_deg..self.dec_max_deg).contains(&dec_deg)
+            && ra_in_range(ra_deg, self.ra_start_deg, self.ra_end_deg)
+    }
+
+    /// Eastward RA span of the box in degrees, in `[0°, 360°)`.
+    pub fn ra_span_deg(&self) -> f64 {
+        (self.ra_end_deg - self.ra_start_deg).rem_euclid(360.0)
+    }
+
+    /// Exact solid angle of the box in square degrees:
+    /// `ΔRA · (sin dec_max − sin dec_min) · 180/π`.
+    pub fn solid_angle_deg2(&self) -> f64 {
+        let dsin = self.dec_max_deg.to_radians().sin() - self.dec_min_deg.to_radians().sin();
+        self.ra_span_deg() * dsin * RAD2DEG
+    }
+}
+
+/// Whether `ra` lies in the eastward range `[start, end)`, wrapping
+/// through 0° when `start > end`.
+fn ra_in_range(ra: f64, start: f64, end: f64) -> bool {
+    let ra = ra.rem_euclid(360.0);
+    if start <= end {
+        (start..end).contains(&ra)
+    } else {
+        ra >= start || ra < end
+    }
+}
+
+/// A survey's sky coverage in equatorial coordinates.
+///
+/// The variants cover the footprint shapes that real wide-field surveys
+/// declare:
+///
+/// * [`Footprint::AllSky`] — the whole celestial sphere (toy surveys,
+///   completeness baselines).
+/// * [`Footprint::DecRange`] — a declination band, the natural model for
+///   hemispheric surveys driven by a single site's horizon (e.g. a
+///   "dec > −30°" cut).
+/// * [`Footprint::BoxUnion`] — a union of RA/dec boxes approximating an
+///   irregular contiguous footprint, with an exact analytic solid angle.
+/// * [`Footprint::Custom`] — an arbitrary membership predicate (polygon
+///   tests, HEALPix masks, ...) with a caller-declared solid angle.
+///
+/// # Solid angle
+///
+/// [`Footprint::solid_angle_deg2`] is **exact** for `AllSky` and
+/// `DecRange`, and exact for `BoxUnion` **only when the boxes are
+/// disjoint** (overlapping boxes are double counted — keep the union a
+/// tiling). For `Custom` the value is whatever the caller declared; it is
+/// the caller's responsibility that it integrates the predicate. A good
+/// validation pattern is a Monte-Carlo cross-check: sample uniformly on
+/// the sphere (`ra ~ U[0°, 360°)`, `dec = asin(U[−1, 1])`) and compare the
+/// hit fraction times 4π sr against the declared value.
+#[derive(Debug, Clone)]
+pub enum Footprint {
+    /// The full celestial sphere.
+    AllSky,
+    /// All right ascensions within a declination band
+    /// (`dec_min_deg <= dec <= dec_max_deg`, inclusive).
+    DecRange {
+        /// Minimum declination (degrees).
+        dec_min_deg: f64,
+        /// Maximum declination (degrees).
+        dec_max_deg: f64,
+    },
+    /// A union of RA/dec boxes. The solid angle is the sum of the box
+    /// solid angles, exact only for disjoint boxes.
+    BoxUnion(Vec<SkyBox>),
+    /// An arbitrary membership test with a caller-declared solid angle.
+    Custom {
+        /// Membership predicate: `contains(ra_deg, dec_deg)`.
+        contains: fn(f64, f64) -> bool,
+        /// The region's solid angle in square degrees, as declared by the
+        /// caller (not derived from the predicate).
+        solid_angle_deg2: f64,
+    },
+}
+
+/// Solid angle of the full sphere in square degrees (≈ 41 252.96).
+pub const FULL_SKY_DEG2: f64 = 4.0 * std::f64::consts::PI * RAD2DEG * RAD2DEG;
+
+impl Footprint {
+    /// Whether the equatorial position (degrees) falls inside the
+    /// footprint. RA is reduced modulo 360°.
+    pub fn contains(&self, ra_deg: f64, dec_deg: f64) -> bool {
+        match self {
+            Footprint::AllSky => true,
+            Footprint::DecRange {
+                dec_min_deg,
+                dec_max_deg,
+            } => (*dec_min_deg..=*dec_max_deg).contains(&dec_deg),
+            Footprint::BoxUnion(boxes) => boxes.iter().any(|b| b.contains(ra_deg, dec_deg)),
+            Footprint::Custom { contains, .. } => contains(ra_deg, dec_deg),
+        }
+    }
+
+    /// The footprint's solid angle in square degrees. See the type-level
+    /// docs for exactness caveats per variant.
+    pub fn solid_angle_deg2(&self) -> f64 {
+        match self {
+            Footprint::AllSky => FULL_SKY_DEG2,
+            Footprint::DecRange {
+                dec_min_deg,
+                dec_max_deg,
+            } => {
+                let dsin = dec_max_deg.to_radians().sin() - dec_min_deg.to_radians().sin();
+                360.0 * dsin * RAD2DEG
+            }
+            Footprint::BoxUnion(boxes) => boxes.iter().map(SkyBox::solid_angle_deg2).sum(),
+            Footprint::Custom {
+                solid_angle_deg2, ..
+            } => *solid_angle_deg2,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_sky_contains_everything_and_integrates_to_full_sphere() {
+        let fp = Footprint::AllSky;
+        assert!(fp.contains(0.0, 90.0));
+        assert!(fp.contains(359.9, -90.0));
+        assert!((fp.solid_angle_deg2() - 41_252.96).abs() < 0.01);
+    }
+
+    #[test]
+    fn dec_range_solid_angle() {
+        // Northern hemisphere: exactly half the sphere.
+        let north = Footprint::DecRange {
+            dec_min_deg: 0.0,
+            dec_max_deg: 90.0,
+        };
+        assert!((north.solid_angle_deg2() - FULL_SKY_DEG2 / 2.0).abs() < 1e-9);
+        // dec > -30: 360 * (1 + sin 30) * 180/pi = 3/4 of the sphere.
+        let band = Footprint::DecRange {
+            dec_min_deg: -30.0,
+            dec_max_deg: 90.0,
+        };
+        assert!((band.solid_angle_deg2() - 0.75 * FULL_SKY_DEG2).abs() < 1e-9);
+        assert!(band.contains(123.0, -29.9));
+        assert!(!band.contains(123.0, -30.1));
+    }
+
+    #[test]
+    fn sky_box_ra_wrap() {
+        let b = SkyBox {
+            dec_min_deg: -65.0,
+            dec_max_deg: -40.0,
+            ra_start_deg: 300.0,
+            ra_end_deg: 105.0,
+        };
+        // The eastward range 300 -> 105 wraps through 0.
+        assert!((b.ra_span_deg() - 165.0).abs() < 1e-12);
+        assert!(b.contains(350.0, -50.0));
+        assert!(b.contains(30.0, -55.0));
+        assert!(b.contains(100.0, -45.0));
+        assert!(!b.contains(150.0, -50.0));
+        // RA outside [0, 360) is reduced.
+        assert!(b.contains(360.0 + 30.0, -55.0));
+        // Half-open declination edges.
+        assert!(b.contains(30.0, -65.0));
+        assert!(!b.contains(30.0, -40.0));
+    }
+
+    #[test]
+    fn box_union_solid_angle_monte_carlo() {
+        // Cross-check the analytic solid angle of a disjoint union with
+        // uniform-sphere sampling.
+        use rand::{Rng, SeedableRng};
+        let fp = Footprint::BoxUnion(vec![
+            SkyBox {
+                dec_min_deg: -65.0,
+                dec_max_deg: -40.0,
+                ra_start_deg: 300.0,
+                ra_end_deg: 105.0,
+            },
+            SkyBox {
+                dec_min_deg: -40.0,
+                dec_max_deg: -20.0,
+                ra_start_deg: 335.0,
+                ra_end_deg: 55.0,
+            },
+            SkyBox {
+                dec_min_deg: -20.0,
+                dec_max_deg: 5.0,
+                ra_start_deg: 355.0,
+                ra_end_deg: 40.0,
+            },
+        ]);
+        let analytic = fp.solid_angle_deg2();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(2026);
+        let n = 200_000;
+        let mut hits = 0u32;
+        for _ in 0..n {
+            let ra = rng.random::<f64>() * 360.0;
+            let z: f64 = rng.random::<f64>() * 2.0 - 1.0;
+            if fp.contains(ra, z.asin().to_degrees()) {
+                hits += 1;
+            }
+        }
+        let mc = FULL_SKY_DEG2 * hits as f64 / n as f64;
+        assert!(
+            (mc - analytic).abs() < 150.0,
+            "MC = {mc:.0} deg^2 vs analytic {analytic:.0} deg^2"
+        );
+    }
+
+    #[test]
+    fn custom_footprint_uses_declared_values() {
+        fn south_cap(_ra: f64, dec: f64) -> bool {
+            dec < -60.0
+        }
+        let fp = Footprint::Custom {
+            contains: south_cap,
+            solid_angle_deg2: 1000.0,
+        };
+        assert!(fp.contains(10.0, -70.0));
+        assert!(!fp.contains(10.0, 0.0));
+        assert_eq!(fp.solid_angle_deg2(), 1000.0);
+    }
+}

--- a/src/surveylib/geometry.rs
+++ b/src/surveylib/geometry.rs
@@ -1,0 +1,305 @@
+//! Per-epoch apparent geometry: heliocentric ecliptic states to apparent
+//! geocentric equatorial positions.
+//!
+//! The chain is deliberately small and *typed*: target and Earth positions
+//! are heliocentric **ecliptic J2000** vectors in AU; the geocentric
+//! direction is their difference; and the rotation to the equatorial frame
+//! is the ECLIPJ2000 matrix from [`crate::framelib`]. Declination only
+//! ever comes out of that rotation — never substitute ecliptic latitude
+//! for declination (an `i = 0` orbit has β ≈ 0 everywhere while its
+//! declination swings ±23.4°, which misclassifies exactly the
+//! survey-boundary sky).
+//!
+//! The geocentric difference captures the two effects that move a distant
+//! object across a footprint boundary during a survey: the annual
+//! parallactic oscillation (~`asin(1 AU / r)`, i.e. ±0.14° at 400 AU) and
+//! the slow orbital drift over the survey baseline.
+//! [`apparent_equatorial_light_time`] additionally iterates the
+//! light-time retardation (days at hundreds of AU). Stellar aberration
+//! (≤ 20.5″) is *not* applied — it is far below the footprint scales this
+//! module serves; use the full `positions` observe chain when arcsecond
+//! astrometry matters.
+//!
+//! Earth positions come from starfield's own ephemeris
+//! ([`earth_positions_from_ephemeris`], e.g. DE421 via
+//! [`crate::planetlib::Ephemeris`]) or from any caller-supplied model
+//! ([`earth_positions_with`] — analytic circular Earths are often ample
+//! for footprint membership and keep inner Monte-Carlo loops kernel-free).
+
+use nalgebra::Vector3;
+
+use crate::constants::C_AUDAY;
+use crate::framelib::ECLIPJ2000_MATRIX_INV;
+use crate::planetlib::{Body, Ephemeris};
+use crate::time::Time;
+use crate::{Result, StarfieldError};
+
+/// An apparent geocentric equatorial position.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ApparentPosition {
+    /// Right ascension in degrees, in `[0°, 360°)`.
+    pub ra_deg: f64,
+    /// Declination in degrees.
+    pub dec_deg: f64,
+    /// Geocentric distance in AU.
+    pub delta_au: f64,
+}
+
+/// Geometric (instantaneous) apparent geocentric equatorial position of a
+/// target, from its heliocentric **ecliptic J2000** position and the
+/// Earth's heliocentric ecliptic J2000 position (both AU).
+///
+/// # Example
+///
+/// ```
+/// use nalgebra::Vector3;
+/// use starfield::surveylib::geometry::apparent_equatorial;
+///
+/// // A target toward the north ecliptic pole sits at dec = 90° − ε.
+/// let pos = apparent_equatorial(&Vector3::new(0.0, 0.0, 400.0), &Vector3::zeros());
+/// assert!((pos.dec_deg - (90.0 - 23.4393)).abs() < 1e-3);
+/// ```
+pub fn apparent_equatorial(
+    target_helio_ecliptic_au: &Vector3<f64>,
+    earth_helio_ecliptic_au: &Vector3<f64>,
+) -> ApparentPosition {
+    let geocentric_ecliptic = target_helio_ecliptic_au - earth_helio_ecliptic_au;
+    let geocentric_equatorial = *ECLIPJ2000_MATRIX_INV * geocentric_ecliptic;
+    let delta_au = geocentric_equatorial.norm();
+    let ra_deg = geocentric_equatorial
+        .y
+        .atan2(geocentric_equatorial.x)
+        .to_degrees()
+        .rem_euclid(360.0);
+    let dec_deg = (geocentric_equatorial.z / delta_au).asin().to_degrees();
+    ApparentPosition {
+        ra_deg,
+        dec_deg,
+        delta_au,
+    }
+}
+
+/// Light-time-corrected apparent position: where the target *appears*,
+/// i.e. where it was `Δ/c` before the observation epoch.
+///
+/// `target_at(dt_days)` must return the target's heliocentric ecliptic
+/// J2000 position (AU) at `dt_days` relative to the observation epoch
+/// (`dt_days <= 0` during the iteration). The retardation is solved by
+/// fixed-point iteration `dt = −Δ(dt)/c`, which converges in two or three
+/// rounds for solar-system geometries; at hundreds of AU the light time
+/// is days and the correction shifts the apparent position by the
+/// object's sky motion over that interval.
+pub fn apparent_equatorial_light_time(
+    target_at: impl Fn(f64) -> Vector3<f64>,
+    earth_helio_ecliptic_au: &Vector3<f64>,
+) -> ApparentPosition {
+    let mut dt_days = 0.0;
+    let mut position = apparent_equatorial(&target_at(dt_days), earth_helio_ecliptic_au);
+    for _ in 0..10 {
+        let next_dt = -position.delta_au / C_AUDAY;
+        if (next_dt - dt_days).abs() < 1e-9 {
+            break;
+        }
+        dt_days = next_dt;
+        position = apparent_equatorial(&target_at(dt_days), earth_helio_ecliptic_au);
+    }
+    position
+}
+
+/// Heliocentric ecliptic J2000 Earth positions (AU) at the given times,
+/// from a real ephemeris kernel (e.g. DE421 loaded into
+/// [`crate::planetlib::Ephemeris`]).
+///
+/// Precompute these once per survey epoch grid and share them across
+/// every orbit in a population run — the grid is orbit-independent, so
+/// the kernel is never queried inside per-orbit loops.
+pub fn earth_positions_from_ephemeris(
+    ephemeris: &mut Ephemeris,
+    times: &[Time],
+) -> Result<Vec<Vector3<f64>>> {
+    times
+        .iter()
+        .map(|t| {
+            ephemeris
+                .ecliptic_state(Body::Earth, t)
+                .map(|state| state.position.to_vector3())
+                .map_err(|e| StarfieldError::CalculationError(format!("Earth ephemeris: {e}")))
+        })
+        .collect()
+}
+
+/// Heliocentric ecliptic J2000 Earth positions (AU) at the given times,
+/// from a caller-supplied model (analytic circular orbit, cached table,
+/// test stub, ...). The counterpart of [`earth_positions_from_ephemeris`]
+/// for kernel-free callers.
+pub fn earth_positions_with(
+    mut earth_at: impl FnMut(&Time) -> Vector3<f64>,
+    times: &[Time],
+) -> Vec<Vector3<f64>> {
+    times.iter().map(&mut earth_at).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::GM_SUN;
+    use crate::jplephem::SpiceKernel;
+    use crate::keplerlib::KeplerOrbit;
+    use crate::time::Timescale;
+
+    /// Heliocentric *ecliptic* position of a Keplerian orbit at `t`:
+    /// `from_mean_anomaly` without the ecliptic rotation keeps the state
+    /// in the frame the elements were given in.
+    fn ecliptic_orbit(a: f64, e: f64, i_deg: f64, m_deg: f64, epoch: &Time) -> KeplerOrbit {
+        KeplerOrbit::from_mean_anomaly(
+            a * (1.0 - e * e),
+            e,
+            i_deg,
+            0.0,
+            0.0,
+            m_deg,
+            epoch,
+            GM_SUN,
+            Some(10),
+            None,
+        )
+    }
+
+    #[test]
+    fn ecliptic_pole_maps_to_obliquity_complement() {
+        let pos = apparent_equatorial(&Vector3::new(0.0, 0.0, 1.0), &Vector3::zeros());
+        assert!(
+            (pos.dec_deg - (90.0 - 23.439_291)).abs() < 1e-4,
+            "dec = {}",
+            pos.dec_deg
+        );
+    }
+
+    #[test]
+    fn equinox_direction_unchanged() {
+        // The vernal-equinox direction is shared by both frames.
+        let pos = apparent_equatorial(&Vector3::new(1.0, 0.0, 0.0), &Vector3::zeros());
+        assert!(pos.ra_deg.abs() < 1e-9 || (pos.ra_deg - 360.0).abs() < 1e-9);
+        assert!(pos.dec_deg.abs() < 1e-9);
+    }
+
+    #[test]
+    fn ecliptic_plane_orbit_declination_swings_by_obliquity() {
+        // The beta-for-delta regression: an i = 0 orbit has ecliptic
+        // latitude ~0 everywhere, but its *declination* must swing by
+        // +/- the obliquity (~23.4 deg) around the orbit. A conflated
+        // implementation reports ~0 everywhere.
+        let ts = Timescale::default();
+        let epoch = ts.tt_jd(2_451_545.0, None);
+        let mut min_dec = f64::INFINITY;
+        let mut max_dec = f64::NEG_INFINITY;
+        for k in 0..72 {
+            // e is tiny but nonzero: the universal-variable Kepler solver
+            // is singular at exactly e = 0.
+            let orbit = ecliptic_orbit(400.0, 1e-6, 0.0, k as f64 * 5.0, &epoch);
+            let helio = orbit.at(&epoch).position;
+            let pos = apparent_equatorial(&helio, &Vector3::zeros());
+            min_dec = min_dec.min(pos.dec_deg);
+            max_dec = max_dec.max(pos.dec_deg);
+        }
+        assert!(min_dec < -20.0, "min dec = {min_dec:.1}");
+        assert!(max_dec > 20.0, "max dec = {max_dec:.1}");
+        assert!(max_dec < 23.5 && min_dec > -23.5);
+    }
+
+    #[test]
+    fn parallax_amplitude_scales_inversely_with_distance() {
+        // Over one year the apparent RA of a distant stationary object
+        // oscillates with half-amplitude ~ asin(1 AU / r).
+        let target = Vector3::new(0.0, 400.0, 0.0);
+        let mut ra_min = f64::INFINITY;
+        let mut ra_max = f64::NEG_INFINITY;
+        for k in 0..=24 {
+            let theta = std::f64::consts::TAU * k as f64 / 24.0;
+            let earth = Vector3::new(theta.cos(), theta.sin(), 0.0);
+            let pos = apparent_equatorial(&target, &earth);
+            ra_min = ra_min.min(pos.ra_deg);
+            ra_max = ra_max.max(pos.ra_deg);
+        }
+        let half_amplitude = (ra_max - ra_min) / 2.0;
+        // ~0.143 deg of ecliptic longitude; the RA projection at lambda =
+        // 90 deg stretches it by 1/cos(obliquity) (~9%).
+        let expected = (1.0_f64 / 400.0).asin().to_degrees();
+        assert!(
+            (half_amplitude - expected).abs() < 0.03,
+            "half-amplitude = {half_amplitude:.4} deg, expected ~{expected:.4}"
+        );
+    }
+
+    #[test]
+    fn light_time_displaces_by_sky_motion_over_delta_over_c() {
+        // A target moving at constant velocity appears where it was a
+        // light time ago: displaced *backward* along its motion by
+        // v * delta/c (in ecliptic longitude; the RA projection at
+        // lambda = 90 deg stretches it by 1/cos(obliquity)).
+        let r = 400.0;
+        let v = Vector3::new(0.001, 0.0, 0.0); // AU/day
+        let target_at = |dt: f64| Vector3::new(v.x * dt, r, 0.0);
+        let earth = Vector3::zeros();
+        let instantaneous = apparent_equatorial(&target_at(0.0), &earth);
+        let apparent = apparent_equatorial_light_time(target_at, &earth);
+        // Light time at 400 AU is ~2.31 days.
+        let lt_days = r / C_AUDAY;
+        assert!((2.0..2.5).contains(&lt_days), "lt = {lt_days:.2} d");
+        let lambda_shift = (v.x * lt_days / r).to_degrees();
+        let expected_shift = -lambda_shift / 23.439_291_f64.to_radians().cos();
+        let actual_shift = instantaneous.ra_deg - apparent.ra_deg;
+        assert!(
+            (actual_shift - expected_shift).abs() < 2e-6,
+            "shift = {actual_shift:.2e} deg, expected {expected_shift:.2e}"
+        );
+    }
+
+    #[test]
+    fn ephemeris_earth_positions_are_one_au_heliocentric() {
+        let Ok(kernel) = SpiceKernel::open("test_data/de421.bsp") else {
+            eprintln!("skipping: test_data/de421.bsp not available");
+            return;
+        };
+        let mut ephemeris = Ephemeris::from_kernel(kernel);
+        let ts = Timescale::default();
+        let times: Vec<Time> = (0..12)
+            .map(|k| ts.tt_jd(2_456_000.0 + 30.0 * k as f64, None))
+            .collect();
+        let positions = earth_positions_from_ephemeris(&mut ephemeris, &times).unwrap();
+        assert_eq!(positions.len(), times.len());
+        for p in &positions {
+            let r = p.norm();
+            assert!((0.97..1.03).contains(&r), "|Earth| = {r:.4} AU");
+            // Heliocentric ecliptic frame: Earth stays in the ecliptic
+            // plane to well under a degree.
+            assert!((p.z / r).asin().to_degrees().abs() < 0.01);
+        }
+        // The twelve samples actually sweep the orbit (not a constant).
+        let spread = positions
+            .iter()
+            .map(|p| p.x)
+            .fold((f64::INFINITY, f64::NEG_INFINITY), |(lo, hi), x| {
+                (lo.min(x), hi.max(x))
+            });
+        assert!(spread.1 - spread.0 > 1.0);
+    }
+
+    #[test]
+    fn closure_earth_positions_align_with_times() {
+        let ts = Timescale::default();
+        let times: Vec<Time> = (0..4)
+            .map(|k| ts.tt_jd(2_451_545.0 + k as f64, None))
+            .collect();
+        let positions = earth_positions_with(
+            |t| {
+                let theta = std::f64::consts::TAU * (t.tt() - 2_451_545.0) / 365.25;
+                Vector3::new(theta.cos(), theta.sin(), 0.0)
+            },
+            &times,
+        );
+        assert_eq!(positions.len(), 4);
+        assert!((positions[0] - Vector3::new(1.0, 0.0, 0.0)).norm() < 1e-12);
+        assert!(positions[1].y > 0.0);
+    }
+}

--- a/src/surveylib/mod.rs
+++ b/src/surveylib/mod.rs
@@ -1,0 +1,571 @@
+//! Survey-agnostic detection and completeness simulation.
+//!
+//! Answers the question *"would survey X have detected object Y?"* — and
+//! its population form, *"what fraction of this population would have been
+//! found?"* — for any imaging survey describable as a footprint, an epoch
+//! grid, a magnitude-efficiency curve, and a linking rule. The machinery
+//! was extracted from Planet Nine survey-exclusion analyses (ZTF, DES,
+//! Pan-STARRS) but contains no survey-specific numbers; concrete survey
+//! definitions (real footprints, fitted depths, cadences) belong
+//! downstream, next to their provenance.
+//!
+//! # The pipeline
+//!
+//! 1. **Geometry** ([`geometry`]): per-epoch apparent geocentric
+//!    equatorial positions from heliocentric *ecliptic* J2000 target and
+//!    Earth states. Earth states come from a real ephemeris kernel
+//!    ([`geometry::earth_positions_from_ephemeris`]) or any
+//!    caller-supplied model ([`geometry::earth_positions_with`]),
+//!    precomputed once per survey grid. The ecliptic→equatorial rotation
+//!    is the typed [`framelib`](crate::framelib) transform — declination
+//!    is never approximated by ecliptic latitude.
+//! 2. **Footprint** ([`footprint`]): equatorial membership tests with
+//!    exact solid angles (declination bands, box unions, custom
+//!    predicates).
+//! 3. **Detection** ([`detection`]): logistic per-epoch magnitude
+//!    efficiency, then the pipeline's k-of-n linking requirement via the
+//!    exact Poisson-binomial tail over the heterogeneous per-epoch
+//!    probabilities.
+//! 4. **Accumulation** (this module): [`detection_probability`] per
+//!    orbit, [`expected_completeness`] over a population —
+//!    *deterministic* sums of probabilities, never Bernoulli draws, so
+//!    results carry no Monte-Carlo noise — and [`combined_detection`] /
+//!    [`unique_contributions`] for the per-orbit OR across several
+//!    surveys evaluated on one shared reference population.
+//!
+//! Apparent magnitudes are the caller's job: supply them per epoch in
+//! [`EpochState`], e.g. from
+//! [`magnitudelib::small_body`](crate::magnitudelib::small_body)
+//! (mass→radius→H→`m = H + 5 log10(rΔ)`, optionally with the IAU H-G
+//! phase term). No survey's depth or color model is hard-wired here.
+//!
+//! # Fitted parameters, not derived ones
+//!
+//! Completeness models are *calibrated*, not deduced: `m50`, `steepness`,
+//! and `ceiling` in [`DetectionModel`] come from synthetic-source
+//! injection into a real pipeline, and published recovery fractions are
+//! often reproduced only after tuning an extra efficiency knob (per-night
+//! usability, weather, focal-plane fill). When you build a concrete
+//! survey definition downstream, document every such value as **fitted**,
+//! with its source — a completeness number is only as honest as its least
+//! documented calibration parameter.
+//!
+//! # Example
+//!
+//! ```
+//! use starfield::surveylib::{
+//!     detection_probability, expected_completeness, DetectionModel, Epoch, EpochState,
+//!     Footprint, LinkingRequirement, SurveyDefinition,
+//! };
+//! use starfield::time::Timescale;
+//!
+//! let ts = Timescale::default();
+//! // A toy survey: northern sky, four epochs, detections on >= 2 epochs
+//! // required for linking. (Real definitions live downstream, with
+//! // documented fitted parameters.)
+//! let survey = SurveyDefinition {
+//!     name: "toy-north".to_string(),
+//!     footprint: Footprint::DecRange {
+//!         dec_min_deg: 0.0,
+//!         dec_max_deg: 90.0,
+//!     },
+//!     epochs: (0..4)
+//!         .map(|k| Epoch::new(ts.tt_jd(2_456_000.0 + 90.0 * k as f64, None)))
+//!         .collect(),
+//!     linking: LinkingRequirement::KOfN { k: 2 },
+//! };
+//! let model = DetectionModel::new(23.0, 3.0, 0.95);
+//!
+//! // Per-epoch apparent states of one bright northern object (normally
+//! // computed via surveylib::geometry from orbit + Earth states).
+//! let states: Vec<EpochState> = (0..4)
+//!     .map(|k| EpochState {
+//!         ra_deg: 30.0 + 0.1 * k as f64,
+//!         dec_deg: 20.0,
+//!         apparent_mag: 19.0,
+//!     })
+//!     .collect();
+//! let p = detection_probability(&survey, &model, &states);
+//! assert!(p > 0.99);
+//!
+//! // Deterministic population completeness: the mean per-orbit
+//! // probability, no Bernoulli sampling.
+//! let completeness = expected_completeness([p, 0.0, 0.5]);
+//! assert!((completeness - (p + 0.5) / 3.0).abs() < 1e-12);
+//! ```
+
+pub mod detection;
+pub mod footprint;
+pub mod geometry;
+pub mod survey;
+
+pub use detection::{poisson_binomial_tail, DetectionModel, LinkingRequirement};
+pub use footprint::{Footprint, SkyBox, FULL_SKY_DEG2};
+pub use geometry::{
+    apparent_equatorial, apparent_equatorial_light_time, earth_positions_from_ephemeris,
+    earth_positions_with, ApparentPosition,
+};
+pub use survey::{Epoch, SurveyDefinition};
+
+/// The apparent state of one target at one survey epoch: equatorial
+/// position (degrees) and apparent magnitude in the epoch's band.
+///
+/// Produce these per epoch from your orbit model and Earth states (see
+/// [`geometry`]) and your photometry (see
+/// [`magnitudelib::small_body`](crate::magnitudelib::small_body)).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EpochState {
+    /// Apparent right ascension (degrees).
+    pub ra_deg: f64,
+    /// Apparent declination (degrees).
+    pub dec_deg: f64,
+    /// Apparent magnitude in the band this epoch is observed in.
+    pub apparent_mag: f64,
+}
+
+/// Per-epoch detection probabilities of one target: the logistic
+/// magnitude efficiency (with any per-epoch depth override) gated by
+/// footprint membership of the epoch's *apparent* position — an epoch
+/// whose position falls outside the footprint contributes exactly 0.
+///
+/// `states` must align one-to-one with `survey.epochs`.
+///
+/// # Panics
+///
+/// Panics if `states.len() != survey.epochs.len()`.
+pub fn epoch_detection_probabilities(
+    survey: &SurveyDefinition,
+    model: &DetectionModel,
+    states: &[EpochState],
+) -> Vec<f64> {
+    assert_eq!(
+        states.len(),
+        survey.epochs.len(),
+        "one EpochState per survey epoch (survey '{}' has {} epochs)",
+        survey.name,
+        survey.epochs.len()
+    );
+    survey
+        .epochs
+        .iter()
+        .zip(states)
+        .map(|(epoch, state)| {
+            if survey.footprint.contains(state.ra_deg, state.dec_deg) {
+                let m50 = epoch.m50.unwrap_or(model.m50);
+                model.efficiency_at_depth(state.apparent_mag, m50)
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
+/// End-to-end probability that the survey detects *and links* the target:
+/// the linking requirement's probability (exact Poisson-binomial tail for
+/// k-of-n) over the per-epoch probabilities of
+/// [`epoch_detection_probabilities`].
+///
+/// # Panics
+///
+/// Panics if `states.len() != survey.epochs.len()`.
+pub fn detection_probability(
+    survey: &SurveyDefinition,
+    model: &DetectionModel,
+    states: &[EpochState],
+) -> f64 {
+    let probs = epoch_detection_probabilities(survey, model, states);
+    survey.linking.probability(&probs)
+}
+
+/// Expected completeness over a population: the mean of per-orbit
+/// detection probabilities, accumulated **deterministically** (a sum of
+/// probabilities, not Bernoulli realizations), so the result is exact for
+/// the given population — no Monte-Carlo noise term. Returns 0 for an
+/// empty population.
+///
+/// Feed it [`detection_probability`] evaluated per orbit; for a
+/// non-detection survey this same number is the expected *excluded*
+/// fraction of the population.
+pub fn expected_completeness(orbit_probabilities: impl IntoIterator<Item = f64>) -> f64 {
+    let mut sum = 0.0;
+    let mut n = 0u64;
+    for p in orbit_probabilities {
+        sum += p;
+        n += 1;
+    }
+    if n == 0 {
+        0.0
+    } else {
+        sum / n as f64
+    }
+}
+
+/// Per-orbit OR across surveys: the probability that *at least one*
+/// survey detects the orbit, `1 − Π(1 − pᵢ)`, from the same orbit's
+/// detection probability in each survey.
+///
+/// This is the rigorous multi-survey combination — evaluate every survey
+/// on one shared reference population and average this per-orbit OR —
+/// as opposed to combining published population-level fractions, which is
+/// only valid when they are already disjoint ("unique") contributions.
+pub fn combined_detection(per_survey_probabilities: &[f64]) -> f64 {
+    1.0 - per_survey_probabilities
+        .iter()
+        .map(|p| 1.0 - p)
+        .product::<f64>()
+}
+
+/// Decompose the per-orbit OR into *unique* survey contributions in the
+/// given order: element `i` is `pᵢ · Π_{j<i}(1 − pⱼ)`, the probability
+/// that survey `i` detects the orbit and no earlier survey does. The
+/// elements sum to [`combined_detection`] exactly.
+pub fn unique_contributions(per_survey_probabilities: &[f64]) -> Vec<f64> {
+    let mut none_so_far = 1.0;
+    per_survey_probabilities
+        .iter()
+        .map(|&p| {
+            let unique = p * none_so_far;
+            none_so_far *= 1.0 - p;
+            unique
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::catalogs::synthetic::orbits::{InclinationModel, SyntheticOrbitPopulation};
+    use crate::constants::GM_SUN;
+    use crate::keplerlib::KeplerOrbit;
+    use crate::time::{Time, Timescale};
+    use nalgebra::Vector3;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    /// Heliocentric *ecliptic* Keplerian orbit (no equatorial rotation):
+    /// `at(t).position` stays in the frame the elements are given in.
+    fn ecliptic_kepler(
+        a: f64,
+        e: f64,
+        i_deg: f64,
+        omega_big_deg: f64,
+        omega_deg: f64,
+        m_deg: f64,
+        epoch: &Time,
+    ) -> KeplerOrbit {
+        KeplerOrbit::from_mean_anomaly(
+            a * (1.0 - e * e),
+            e,
+            i_deg,
+            omega_big_deg,
+            omega_deg,
+            m_deg,
+            epoch,
+            GM_SUN,
+            Some(10),
+            None,
+        )
+    }
+
+    /// Analytic circular coplanar 1-AU Earth (phase zero at `t0_tt`) —
+    /// a caller-supplied model, exercising the closure path.
+    fn circular_earth(t0_tt: f64) -> impl FnMut(&Time) -> Vector3<f64> {
+        move |t: &Time| {
+            let theta = std::f64::consts::TAU * (t.tt() - t0_tt) / 365.25;
+            Vector3::new(theta.cos(), theta.sin(), 0.0)
+        }
+    }
+
+    fn toy_survey(
+        ts: &Timescale,
+        footprint: Footprint,
+        n_epochs: usize,
+        k: u32,
+    ) -> SurveyDefinition {
+        SurveyDefinition {
+            name: "toy".to_string(),
+            footprint,
+            epochs: (0..n_epochs)
+                .map(|j| Epoch::new(ts.tt_jd(2_456_000.0 + 180.0 * j as f64, None)))
+                .collect(),
+            linking: LinkingRequirement::KOfN { k },
+        }
+    }
+
+    /// Per-epoch apparent states of a synthetic orbit at constant
+    /// apparent magnitude, through the real geometry chain.
+    fn states_for_orbit(
+        orbit: &KeplerOrbit,
+        survey: &SurveyDefinition,
+        earth_positions: &[Vector3<f64>],
+        mag: f64,
+    ) -> Vec<EpochState> {
+        survey
+            .epochs
+            .iter()
+            .zip(earth_positions)
+            .map(|(epoch, earth)| {
+                let helio = orbit.at(&epoch.time).position;
+                let pos = apparent_equatorial(&helio, earth);
+                EpochState {
+                    ra_deg: pos.ra_deg,
+                    dec_deg: pos.dec_deg,
+                    apparent_mag: mag,
+                }
+            })
+            .collect()
+    }
+
+    /// End-to-end: a full-sky survey deep enough to see everything finds
+    /// (essentially) the whole synthetic population.
+    #[test]
+    fn full_sky_deep_survey_complete_on_bright_population() {
+        let ts = Timescale::default();
+        let survey = toy_survey(&ts, Footprint::AllSky, 8, 3);
+        let model = DetectionModel::new(24.0, 3.0, 1.0);
+        let earths = earth_positions_with(circular_earth(2_456_000.0), &survey.epoch_times());
+
+        let mut rng = StdRng::seed_from_u64(42);
+        let population = SyntheticOrbitPopulation::scattered_disk()
+            .with_count(50)
+            .generate(&mut rng)
+            .unwrap();
+
+        let epoch0 = ts.tt_jd(2_456_000.0, None);
+        let completeness = expected_completeness(population.iter().map(|o| {
+            let orbit = ecliptic_kepler(
+                o.a,
+                o.e,
+                o.i_deg,
+                o.omega_big_deg,
+                o.omega_deg,
+                o.mean_anomaly_deg,
+                &epoch0,
+            );
+            let states = states_for_orbit(&orbit, &survey, &earths, 18.0);
+            detection_probability(&survey, &model, &states)
+        }));
+        assert!(completeness > 0.999, "completeness = {completeness}");
+    }
+
+    /// End-to-end: a magnitude-limited survey sees (essentially) none of
+    /// a population fainter than its depth.
+    #[test]
+    fn shallow_survey_blind_to_faint_population() {
+        let ts = Timescale::default();
+        let survey = toy_survey(&ts, Footprint::AllSky, 8, 3);
+        let model = DetectionModel::new(20.0, 3.0, 1.0);
+        let earths = earth_positions_with(circular_earth(2_456_000.0), &survey.epoch_times());
+
+        let mut rng = StdRng::seed_from_u64(42);
+        let population = SyntheticOrbitPopulation::scattered_disk()
+            .with_count(50)
+            .generate(&mut rng)
+            .unwrap();
+
+        let epoch0 = ts.tt_jd(2_456_000.0, None);
+        let completeness = expected_completeness(population.iter().map(|o| {
+            let orbit = ecliptic_kepler(
+                o.a,
+                o.e,
+                o.i_deg,
+                o.omega_big_deg,
+                o.omega_deg,
+                o.mean_anomaly_deg,
+                &epoch0,
+            );
+            let states = states_for_orbit(&orbit, &survey, &earths, 26.0);
+            detection_probability(&survey, &model, &states)
+        }));
+        assert!(completeness < 1e-6, "completeness = {completeness}");
+    }
+
+    /// k-of-n with a hand-computable Poisson-binomial expectation: at
+    /// mag = m50 with ceiling 1 every epoch is an exact fair coin, so a
+    /// 6-of-10 requirement gives the binomial tail 386/1024.
+    #[test]
+    fn k_of_n_matches_hand_computed_binomial_tail() {
+        let ts = Timescale::default();
+        let survey = toy_survey(&ts, Footprint::AllSky, 10, 6);
+        let model = DetectionModel::new(22.0, 3.0, 1.0);
+        let states: Vec<EpochState> = (0..10)
+            .map(|_| EpochState {
+                ra_deg: 100.0,
+                dec_deg: 0.0,
+                apparent_mag: 22.0,
+            })
+            .collect();
+        let p = detection_probability(&survey, &model, &states);
+        assert!((p - 386.0 / 1024.0).abs() < 1e-12, "p = {p}");
+
+        // One epoch outside the footprint becomes a structural zero:
+        // 6 of the 9 remaining fair coins, P = C(9,>=6)/2^9 = 130/512.
+        let mut survey_north = survey;
+        survey_north.footprint = Footprint::DecRange {
+            dec_min_deg: -10.0,
+            dec_max_deg: 90.0,
+        };
+        let mut states_one_out = states;
+        states_one_out[3].dec_deg = -45.0;
+        let p9 = detection_probability(&survey_north, &model, &states_one_out);
+        assert!((p9 - 130.0 / 512.0).abs() < 1e-12, "p = {p9}");
+    }
+
+    /// Declination-footprint regression for the beta-for-delta bug class:
+    /// an ecliptic-plane (i = 0) object has ecliptic latitude ~0
+    /// everywhere, but its *declination* swings +/- the obliquity, so a
+    /// northern declination cut must pass it near ecliptic longitude 90
+    /// deg and reject it near 270 deg. Conflating latitude with
+    /// declination zeroes both (and the planar-population completeness).
+    #[test]
+    fn declination_footprint_distinguishes_ecliptic_longitudes() {
+        let ts = Timescale::default();
+        let footprint = Footprint::DecRange {
+            dec_min_deg: 5.0,
+            dec_max_deg: 90.0,
+        };
+        let survey = toy_survey(&ts, footprint, 1, 1);
+        let model = DetectionModel::new(24.0, 3.0, 1.0);
+        let epoch0 = ts.tt_jd(2_456_000.0, None);
+        // Heliocentric view (Earth at the Sun) isolates the frame
+        // transform from parallax.
+        let earths = vec![Vector3::zeros()];
+
+        // Near-circular planar orbit at ecliptic longitude ~90 deg:
+        // dec ~ +23.4. (e is tiny but nonzero: the universal-variable
+        // Kepler solver is singular at exactly e = 0.)
+        let north = ecliptic_kepler(400.0, 1e-6, 0.0, 0.0, 0.0, 90.0, &epoch0);
+        let states = states_for_orbit(&north, &survey, &earths, 18.0);
+        assert!(states[0].dec_deg > 20.0, "dec = {}", states[0].dec_deg);
+        assert!(detection_probability(&survey, &model, &states) > 0.99);
+
+        // Same orbit at longitude ~270 deg: dec ~ -23.4, outside the cut.
+        let south = ecliptic_kepler(400.0, 1e-6, 0.0, 0.0, 0.0, 270.0, &epoch0);
+        let states = states_for_orbit(&south, &survey, &earths, 18.0);
+        assert!(states[0].dec_deg < -20.0, "dec = {}", states[0].dec_deg);
+        assert_eq!(detection_probability(&survey, &model, &states), 0.0);
+
+        // Population level: a planar population is found at the fraction
+        // of longitudes whose declination clears the cut, ~0.43 for
+        // dec > 5 deg — emphatically not 0 (the conflated result, beta = 0
+        // for every planar orbit) and not 1.
+        let mut rng = StdRng::seed_from_u64(7);
+        let population = SyntheticOrbitPopulation::scattered_disk()
+            .with_count(400)
+            .with_inclination(InclinationModel::Planar)
+            .generate(&mut rng)
+            .unwrap();
+        let completeness = expected_completeness(population.iter().map(|o| {
+            let orbit = ecliptic_kepler(
+                o.a,
+                o.e,
+                o.i_deg,
+                o.omega_big_deg,
+                o.omega_deg,
+                o.mean_anomaly_deg,
+                &epoch0,
+            );
+            let states = states_for_orbit(&orbit, &survey, &earths, 18.0);
+            detection_probability(&survey, &model, &states)
+        }));
+        assert!(
+            (0.3..0.55).contains(&completeness),
+            "planar-population completeness = {completeness}"
+        );
+    }
+
+    #[test]
+    fn per_epoch_depth_overrides_apply() {
+        let ts = Timescale::default();
+        let mut survey = toy_survey(&ts, Footprint::AllSky, 2, 1);
+        // Second epoch is two magnitudes shallower.
+        survey.epochs[1].m50 = Some(20.0);
+        let model = DetectionModel::new(22.0, 3.0, 1.0);
+        let state = EpochState {
+            ra_deg: 10.0,
+            dec_deg: 10.0,
+            apparent_mag: 22.0,
+        };
+        let probs = epoch_detection_probabilities(&survey, &model, &[state, state]);
+        assert!((probs[0] - 0.5).abs() < 1e-12);
+        assert!(probs[1] < 0.01, "shallow epoch p = {}", probs[1]);
+    }
+
+    #[test]
+    fn expected_completeness_is_deterministic_mean() {
+        assert_eq!(expected_completeness(std::iter::empty::<f64>()), 0.0);
+        assert!((expected_completeness([0.2, 0.4, 0.9]) - 0.5).abs() < 1e-12);
+        // Repeated evaluation is bit-identical (no RNG anywhere).
+        let probs = [0.123, 0.456, 0.789, 0.0, 1.0];
+        assert_eq!(
+            expected_completeness(probs).to_bits(),
+            expected_completeness(probs).to_bits()
+        );
+    }
+
+    #[test]
+    fn combined_detection_is_per_orbit_or() {
+        assert_eq!(combined_detection(&[]), 0.0);
+        let p = combined_detection(&[0.5, 0.5]);
+        assert!((p - 0.75).abs() < 1e-12);
+        // Certain detection by one survey dominates.
+        assert!((combined_detection(&[1.0, 0.1]) - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn unique_contributions_sum_to_combined() {
+        let probs = [0.564, 0.3, 0.5];
+        let unique = unique_contributions(&probs);
+        assert_eq!(unique.len(), 3);
+        // First survey keeps its full probability.
+        assert!((unique[0] - 0.564).abs() < 1e-12);
+        // Later surveys are credited only with orbits no earlier survey saw.
+        assert!((unique[1] - 0.3 * (1.0 - 0.564)).abs() < 1e-12);
+        let sum: f64 = unique.iter().sum();
+        assert!((sum - combined_detection(&probs)).abs() < 1e-12);
+    }
+
+    #[test]
+    #[should_panic(expected = "one EpochState per survey epoch")]
+    fn mismatched_state_count_panics() {
+        let ts = Timescale::default();
+        let survey = toy_survey(&ts, Footprint::AllSky, 3, 1);
+        let model = DetectionModel::new(22.0, 3.0, 1.0);
+        let state = EpochState {
+            ra_deg: 0.0,
+            dec_deg: 0.0,
+            apparent_mag: 20.0,
+        };
+        detection_probability(&survey, &model, &[state]);
+    }
+
+    /// The geometry chain against a real DE421 Earth: ephemeris and
+    /// analytic circular Earth paths must agree to the parallax scale.
+    #[test]
+    fn ephemeris_and_analytic_earth_agree_on_detection() {
+        let Ok(kernel) = crate::jplephem::SpiceKernel::open("test_data/de421.bsp") else {
+            eprintln!("skipping: test_data/de421.bsp not available");
+            return;
+        };
+        let mut ephemeris = crate::planetlib::Ephemeris::from_kernel(kernel);
+        let ts = Timescale::default();
+        let survey = toy_survey(&ts, Footprint::AllSky, 6, 2);
+        let times = survey.epoch_times();
+        let earths_eph = earth_positions_from_ephemeris(&mut ephemeris, &times).unwrap();
+        let earths_circ = earth_positions_with(circular_earth(2_456_000.0), &times);
+
+        let epoch0 = ts.tt_jd(2_456_000.0, None);
+        let orbit = ecliptic_kepler(400.0, 0.2, 17.0, 100.0, 150.0, 60.0, &epoch0);
+        let helio = orbit.at(&epoch0).position;
+        for (e_eph, e_circ) in earths_eph.iter().zip(&earths_circ) {
+            let p_eph = apparent_equatorial(&helio, e_eph);
+            let p_circ = apparent_equatorial(&helio, e_circ);
+            // The analytic Earth's phase is arbitrary, so the apparent
+            // positions can differ by up to the full parallax amplitude,
+            // 2 asin(1/r) ~ 0.3 deg at r >~ 320 AU - but no more.
+            let dra = (p_eph.ra_deg - p_circ.ra_deg).abs().min(360.0);
+            let ddec = (p_eph.dec_deg - p_circ.dec_deg).abs();
+            assert!(dra < 0.4 && ddec < 0.4, "dra = {dra:.3}, ddec = {ddec:.3}");
+        }
+    }
+}

--- a/src/surveylib/survey.rs
+++ b/src/surveylib/survey.rs
@@ -1,0 +1,104 @@
+//! Survey definitions: footprint, epoch grid, and linking requirement as
+//! plain data.
+
+use crate::surveylib::detection::LinkingRequirement;
+use crate::surveylib::footprint::Footprint;
+use crate::time::Time;
+
+/// One observing epoch of a survey: a time on the survey's per-position
+/// visit grid, with an optional epoch-specific depth.
+///
+/// The grid is *per sky position*: each epoch is one visit of a given
+/// field, so a survey definition describes the cadence a typical position
+/// in the footprint receives (e.g. "ten nights per band over six years"),
+/// not the survey's full exposure log.
+#[derive(Debug, Clone)]
+pub struct Epoch {
+    /// Observation time.
+    pub time: Time,
+    /// Epoch-specific 50%-completeness magnitude, overriding the
+    /// [`DetectionModel`](crate::surveylib::DetectionModel)'s `m50` —
+    /// use this for per-band depths or per-night observing conditions.
+    /// `None` falls back to the model's depth.
+    pub m50: Option<f64>,
+}
+
+impl Epoch {
+    /// An epoch observed at the detection model's default depth.
+    pub fn new(time: Time) -> Self {
+        Self { time, m50: None }
+    }
+
+    /// An epoch with its own 50%-completeness depth (e.g. a different
+    /// band or degraded conditions).
+    pub fn with_depth(time: Time, m50: f64) -> Self {
+        Self {
+            time,
+            m50: Some(m50),
+        }
+    }
+}
+
+/// A survey as data: name, equatorial footprint, per-position epoch grid,
+/// and the pipeline's linking requirement.
+///
+/// The detection efficiency model is deliberately *not* part of the
+/// definition — it is a separate, explicitly-fitted
+/// [`DetectionModel`](crate::surveylib::DetectionModel) passed alongside
+/// (see the [module docs](crate::surveylib) on fitted parameters), so the
+/// same survey geometry can be evaluated under different calibrations.
+#[derive(Debug, Clone)]
+pub struct SurveyDefinition {
+    /// Human-readable survey name.
+    pub name: String,
+    /// Sky coverage in equatorial coordinates.
+    pub footprint: Footprint,
+    /// Observing epochs a typical footprint position receives.
+    pub epochs: Vec<Epoch>,
+    /// Detections required across the epochs to count as found.
+    pub linking: LinkingRequirement,
+}
+
+impl SurveyDefinition {
+    /// The epoch times, in grid order — the argument to hand to
+    /// [`earth_positions_from_ephemeris`](crate::surveylib::geometry::earth_positions_from_ephemeris)
+    /// or
+    /// [`earth_positions_with`](crate::surveylib::geometry::earth_positions_with)
+    /// when precomputing per-epoch Earth states (once per survey, shared
+    /// by every orbit).
+    pub fn epoch_times(&self) -> Vec<Time> {
+        self.epochs.iter().map(|e| e.time.clone()).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::time::Timescale;
+
+    #[test]
+    fn epoch_depth_override_is_optional() {
+        let ts = Timescale::default();
+        let t = ts.tt_jd(2_456_000.0, None);
+        assert_eq!(Epoch::new(t.clone()).m50, None);
+        assert_eq!(Epoch::with_depth(t, 23.5).m50, Some(23.5));
+    }
+
+    #[test]
+    fn epoch_times_preserve_grid_order() {
+        let ts = Timescale::default();
+        let survey = SurveyDefinition {
+            name: "toy".to_string(),
+            footprint: Footprint::AllSky,
+            epochs: (0..5)
+                .map(|k| Epoch::new(ts.tt_jd(2_456_000.0 + 10.0 * k as f64, None)))
+                .collect(),
+            linking: LinkingRequirement::KOfN { k: 2 },
+        };
+        let times = survey.epoch_times();
+        assert_eq!(times.len(), 5);
+        for (k, t) in times.iter().enumerate() {
+            assert!((t.tt() - (2_456_000.0 + 10.0 * k as f64)).abs() < 1e-9);
+        }
+    }
+}


### PR DESCRIPTION
Adds starfield::surveylib — the survey-agnostic 'would survey X have detected object Y' machinery extracted from OrbitalCommons/planet9's ZTF/DES/PS1 reproductions:

- Footprints (AllSky/DecRange/BoxUnion/Custom) with exact solid angles and zero-wrapping RA boxes
- Logistic magnitude efficiency with per-epoch depth overrides; k-of-n linking via an exact Poisson-binomial tail
- Typed apparent-position geometry (heliocentric ecliptic + Earth state to geocentric RA/dec, optional light-time retardation) with Earth states from planetlib or a caller closure — includes a regression test that fails if declination and ecliptic latitude are conflated (a real bug class from planet9's review)
- Deterministic expected-completeness accumulation (no Bernoulli noise), per-orbit OR combination and ordered unique-contribution decomposition for multi-survey exclusion

Paper-tuned survey numbers deliberately stay downstream; module docs carry the fitted-vs-derived calibration-knob honesty note. End-to-end tests drive a catalogs::synthetic::orbits population through toy surveys. 30 unit + 3 doc tests; clippy -D warnings clean; zero new dependencies.

Closes OrbitalCommons/planet9#34