### PR TITLE
Add ItrsFrame to framelib

### DIFF
--- a/examples/itrs_frame.rs
+++ b/examples/itrs_frame.rs
@@ -1,0 +1,47 @@
+//! ITRS (Earth-fixed) frame rotations
+//!
+//! Demonstrates `framelib::ItrsFrame`, the ICRF → ITRS rotation of the IERS
+//! conventions: precession, nutation, the daily sidereal rotation and polar
+//! motion. Rotating a ground site's Earth-fixed vector by its transpose gives
+//! the geocentric (GCRS) offset that `GeographicPosition::at` adds to Earth.
+//!
+//! Usage: cargo run --example itrs_frame
+
+use starfield::framelib::{Frame, ItrsFrame};
+use starfield::toposlib::WGS84;
+use starfield::Timescale;
+
+fn main() {
+    let ts = Timescale::default();
+    let boston = WGS84.latlon(42.3583, -71.0603, 43.0);
+
+    println!("ITRS frame rotation for a site in Boston");
+    println!("========================================\n");
+    println!(
+        "ITRS position: ({:.9}, {:.9}, {:.9}) AU\n",
+        boston.itrs_xyz.x, boston.itrs_xyz.y, boston.itrs_xyz.z
+    );
+
+    // Six hours of Earth rotation, sampled every two hours.
+    for step in 0..4 {
+        let jd = 2451545.0 + step as f64 * 2.0 / 24.0;
+        let t = ts.tt_jd(jd, None);
+
+        let icrf_to_itrs = ItrsFrame.rotation_at(&t);
+        let gcrs = icrf_to_itrs.transpose() * boston.itrs_xyz;
+
+        println!("TT JD {jd:.5}  (GAST {:.6} h)", t.gast());
+        println!(
+            "  GCRS offset: ({:>12.9}, {:>12.9}, {:>12.9}) AU",
+            gcrs.x, gcrs.y, gcrs.z
+        );
+    }
+
+    // The rotation is orthonormal, so the transpose is the inverse.
+    let t = ts.tt_jd(2451545.0, None);
+    let round_trip = ItrsFrame.rotation_at(&t) * (ItrsFrame.rotation_at(&t).transpose());
+    println!(
+        "\nR·Rᵀ deviation from identity: {:.3e}",
+        (round_trip - nalgebra::Matrix3::identity()).abs().max()
+    );
+}

--- a/src/framelib/mod.rs
+++ b/src/framelib/mod.rs
@@ -2,6 +2,9 @@ mod frame_rotations;
 pub mod inertial;
 pub mod random;
 
+#[cfg(feature = "python-tests")]
+mod python_tests;
+
 use crate::constants::ASEC2RAD;
 use crate::time::Time;
 use nalgebra::Matrix3;
@@ -69,6 +72,32 @@ impl Frame for EclipticOfDateFrame {
     }
 }
 
+/// ITRS — the Earth-fixed frame of the IERS conventions.
+///
+/// `rotation_at` returns [`Time::c_matrix`], which already is the complete
+/// ICRF → ITRS chain: frame bias, precession and nutation (the `M` matrix),
+/// the daily rotation `R_z(-GAST)`, and polar motion `W` when a polar motion
+/// table has been loaded into the [`crate::time::Timescale`]. Nothing is
+/// recomputed here; this type only gives that rotation a [`Frame`] identity so
+/// it can be used wherever body-fixed frames are accepted.
+///
+/// Use this frame for the Earth. The WGCCRE / IAU rotational elements that
+/// serve other bodies are only accurate to roughly a tenth of a degree for the
+/// Earth, because they ignore nutation and the observed variation of the
+/// rotation rate; `c_matrix` is IERS-grade.
+///
+/// The transpose maps ITRS → ICRF (see [`Time::ct_matrix`]), which is how a
+/// site on the ground becomes a geocentric offset.
+///
+/// Matches Skyfield's `skyfield.framelib.itrs`.
+pub struct ItrsFrame;
+
+impl Frame for ItrsFrame {
+    fn rotation_at(&self, t: &Time) -> Matrix3<f64> {
+        t.c_matrix()
+    }
+}
+
 /// Galactic coordinate frame (static rotation).
 pub struct GalacticFrame;
 
@@ -84,6 +113,7 @@ pub static TRUE_EQUATOR_OF_DATE: TrueEquatorFrame = TrueEquatorFrame;
 pub static ECLIPTIC_J2000: EclipticJ2000Frame = EclipticJ2000Frame;
 pub static ECLIPTIC_OF_DATE: EclipticOfDateFrame = EclipticOfDateFrame;
 pub static GALACTIC: GalacticFrame = GalacticFrame;
+pub static ITRS: ItrsFrame = ItrsFrame;
 
 /// ECLIPJ2000 rotation matrix: equatorial J2000 to ecliptic J2000.
 ///
@@ -132,3 +162,62 @@ pub static ICRS_TO_J2000: Lazy<Matrix3<f64>> = Lazy::new(|| {
 
     Matrix3::new(xx, xy, xz, yx, yy, yz, zx, zy, zz)
 });
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jplephem::kernel::SpiceKernel;
+    use crate::jplephem_ext::SpiceKernelExt;
+    use crate::time::Timescale;
+    use crate::toposlib::WGS84;
+
+    /// `ItrsFrame` and `GeographicPosition::at` must agree.
+    ///
+    /// Both go through `Time::c_matrix`, so this is a guard against one of them
+    /// drifting away from the other, not a discovery.
+    #[test]
+    fn test_itrs_frame_matches_geographic_position() {
+        let mut kernel = SpiceKernel::open("test_data/de421.bsp").expect("Failed to open DE421");
+        let ts = Timescale::default();
+        let boston = WGS84.latlon(42.3583, -71.0603, 43.0);
+
+        for jd in [2451545.0, 2455000.5, 2458849.5] {
+            let t = ts.tdb_jd(jd);
+            let earth = kernel.at("earth", &t).unwrap();
+            let observer = boston.at(&t, &mut kernel).unwrap();
+            let gcrs_offset = observer.position - earth.position;
+
+            let from_frame = ItrsFrame.rotation_at(&t).transpose() * boston.itrs_xyz;
+
+            for axis in 0..3 {
+                let diff = (from_frame[axis] - gcrs_offset[axis]).abs();
+                assert!(
+                    diff < 1e-15,
+                    "axis {axis} at JD {jd}: frame={} topos={} diff={diff}",
+                    from_frame[axis],
+                    gcrs_offset[axis]
+                );
+            }
+        }
+    }
+
+    /// The ITRS rotation is orthonormal at every epoch.
+    #[test]
+    fn test_itrs_frame_is_orthonormal() {
+        let ts = Timescale::default();
+        for jd in [2451545.0, 2458849.5, 2460000.5] {
+            let r = ItrsFrame.rotation_at(&ts.tt_jd(jd, None));
+            let should_be_identity = r * r.transpose();
+            for i in 0..3 {
+                for j in 0..3 {
+                    let expected = if i == j { 1.0 } else { 0.0 };
+                    assert!(
+                        (should_be_identity[(i, j)] - expected).abs() < 1e-12,
+                        "R·Rᵀ[{i},{j}] at JD {jd} = {}",
+                        should_be_identity[(i, j)]
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/framelib/python_tests.rs
+++ b/src/framelib/python_tests.rs
@@ -1,0 +1,80 @@
+//! Python comparison tests for reference frames
+//!
+//! Validates `ItrsFrame` against Skyfield's `skyfield.framelib.itrs`.
+
+#[cfg(test)]
+mod tests {
+    use crate::framelib::{Frame, ItrsFrame};
+    use crate::pybridge::bridge::PyRustBridge;
+    use crate::pybridge::helpers::PythonResult;
+    use crate::time::Timescale;
+
+    fn parse_f64_array(result: &str) -> Vec<f64> {
+        let parsed = PythonResult::try_from(result).expect("Failed to parse Python result");
+        match parsed {
+            PythonResult::Array {
+                dtype,
+                shape: _,
+                data,
+            } => {
+                assert_eq!(dtype, "float64");
+                let n = data.len() / 8;
+                let mut values = Vec::with_capacity(n);
+                for i in 0..n {
+                    let bytes: [u8; 8] = data[i * 8..(i + 1) * 8].try_into().unwrap();
+                    values.push(f64::from_le_bytes(bytes));
+                }
+                values
+            }
+            _ => panic!("Expected Array result, got {:?}", parsed),
+        }
+    }
+
+    /// `ItrsFrame::rotation_at` must reproduce `skyfield.framelib.itrs.rotation_at`.
+    ///
+    /// Both sides are built from the same UT1 — the Skyfield time is created
+    /// with `ut1_jd` from the Rust time's own UT1 — so the comparison measures
+    /// the rotation chain rather than the difference between the two delta-T
+    /// models. (Feeding both `tt_jd` instead leaves a residual of ~1e-5 in the
+    /// elements that carry the daily rotation, which is what the existing
+    /// `c_matrix` tests see with their 1e-4 tolerance.) The half-second of TT
+    /// that delta-T disagreement moves has no visible effect on precession or
+    /// nutation at this tolerance.
+    #[test]
+    fn test_itrs_frame_vs_skyfield() {
+        let bridge = PyRustBridge::new().expect("Failed to create Python bridge");
+        let ts = Timescale::default();
+
+        for jd in [2451545.0, 2458849.5, 2460000.5] {
+            let t = ts.tt_jd(jd, None);
+            let ut1 = t.ut1();
+            let py_result = bridge
+                .run_py_to_json(&format!(
+                    r#"
+import numpy as np
+from skyfield.api import load
+from skyfield.framelib import itrs
+ts = load.timescale()
+t = ts.ut1_jd({ut1:.17})
+rust.collect_array(np.array(itrs.rotation_at(t).flatten(), dtype=np.float64))
+"#
+                ))
+                .unwrap_or_else(|e| panic!("Python ITRS failed at JD {jd}: {e}"));
+
+            let py_r = parse_f64_array(&py_result);
+            let r = ItrsFrame.rotation_at(&t);
+
+            for i in 0..3 {
+                for j in 0..3 {
+                    let rust_val = r[(i, j)];
+                    let py_val = py_r[i * 3 + j];
+                    let diff = (rust_val - py_val).abs();
+                    assert!(
+                        diff < 1e-9,
+                        "ITRS[{i},{j}] at JD {jd}: rust={rust_val} python={py_val} diff={diff}"
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`framelib::ItrsFrame` implements `Frame` by returning `Time::c_matrix()`, which already is the complete ICRF -> ITRS chain (frame bias, precession, nutation, `R_z(-GAST)`, and polar motion `W` when a polar motion table is loaded). Nothing is recomputed; the type only gives that rotation a `Frame` identity so it can be used wherever body-fixed frames are accepted, and its doc comment directs users to it for the Earth rather than the IAU/WGCCRE rotational elements, which are only good to ~0.1 deg there.

Also adds the `ITRS` static instance next to the other pre-built frames and an `itrs_frame` example.

Plan reference: docs/solar-system-bodies-plan.md, Wave 0 PR 1.

## Test plan

- `cargo test --lib framelib` — 26 passed, including:
  - `test_itrs_frame_matches_geographic_position`: `ItrsFrame::rotation_at(t).transpose() * itrs_xyz` equals the GCRS offset `GeographicPosition::at` adds to Earth, at three epochs, to 1e-15 AU.
  - `test_itrs_frame_is_orthonormal`.
- `cargo test --features python-tests --lib framelib::python_tests` — 1 passed. Compares against Skyfield `skyfield.framelib.itrs.rotation_at(t)` at three epochs, tolerance 1e-9 per matrix element. The Skyfield time is built with `ut1_jd` from the Rust time's own UT1 so the comparison measures the rotation chain rather than the two delta-T models; feeding both `tt_jd` leaves a ~1e-5 residual, which is why the existing `c_matrix` comparisons use 1e-4.
- `cargo fmt`, `cargo clippy -- -D warnings` clean; `cargo test` 614 passed / 0 failed (doctests fail to link in this sandbox with a linker bus error, unrelated to this change).
- `cargo run --example itrs_frame` runs.

Closes #161