### PR TITLE
Add binary PCK reader and lunar principal-axes frame

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,5 +127,22 @@ reads them and are pulled in with `include_str!`. The pattern, established by
   `src/planetarylib/pck00011_excerpt.tpc`) so a unit test can assert the table
   and the original agree. Do not check in whole kernels; excerpt them.
 
+## Kernel Fixtures and Golden Vectors
+
+`test_data/de421.bsp` is the only kernel checked into the repository. Do not
+add more; a test that needs another kernel follows the pattern established by
+`src/planetarylib/pck_frame.rs`:
+
+- Build the binary in memory instead of on disk when the test only exercises
+  parsing or interpolation. `src/jplephem/pck.rs` has a
+  `#[cfg(test)] pub(crate) mod test_support` that assembles a DAF/PCK file
+  around coefficients the test chooses, and other modules' tests import it.
+- When the real kernel is unavoidable, fetch it through `Loader` into
+  `~/.cache/starfield/` and mark the test `#[ignore]` with a reason naming the
+  file. CI does not download kernels.
+- Check the reference values in as `const` golden arrays next to the ignored
+  test, with a doc comment giving the Python that produced them, so the
+  agreement is still tested when the kernel is absent.
+
 ## Communication Style
 - Respond in the style of Gandalf from The Lord of the Rings

--- a/examples/moon_pa_frame.rs
+++ b/examples/moon_pa_frame.rs
@@ -1,0 +1,86 @@
+//! Print the lunar principal-axes rotation from a binary PCK kernel.
+//!
+//! Downloads `moon_pa_de421_1900-2050.bpc` and `moon_080317.tf` into the data
+//! directory (`~/.cache/starfield/` unless one is set) the first time it runs,
+//! then prints the `MOON_PA_DE421` rotation matrix at a few epochs, along with
+//! the Euler angles it is built from and the rate at which it turns.
+//!
+//! ```text
+//! cargo run --example moon_pa_frame
+//! ```
+//!
+//! `MOON_PA_DE421` is the principal-axes frame that comes with the DE421
+//! ephemeris, and is the frame lunar libration is expressed in. `MOON_ME_DE421`
+//! — the mean-Earth/mean-rotation frame that lunar maps use — is defined in the
+//! same text kernel as a fixed offset from it, and is printed too.
+
+use starfield::framelib::Frame;
+use starfield::Loader;
+
+/// The epochs to report, as TDB Julian dates.
+const EPOCHS: [(&str, f64); 3] = [
+    ("2000-01-01", 2451544.5),
+    ("2010-06-15", 2455362.5),
+    ("2025-03-01", 2460735.5),
+];
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let loader = Loader::new();
+
+    println!("Reading moon_080317.tf ...");
+    let mut pc = loader.open_text_pck("moon_080317.tf")?;
+
+    println!("Reading moon_pa_de421_1900-2050.bpc ...");
+    let pck = loader.open_binary_pck("moon_pa_de421_1900-2050.bpc")?;
+    println!("\n{pck}");
+    pc.read_binary(pck);
+
+    let frame = pc.build_frame_named("MOON_PA_DE421")?;
+    let mean_earth = pc.build_frame_named("MOON_ME_DE421")?;
+    println!(
+        "MOON_PA_DE421 is centred on body {} and reads frame {} of the kernel\n",
+        frame.center(),
+        frame.segment().body
+    );
+
+    let ts = loader.timescale();
+    for (label, jd) in EPOCHS {
+        let t = ts.tdb_jd(jd);
+        let (angles, rates) = frame.segment().compute(jd)?;
+        let (rotation, rate) = frame.rotation_and_rate_at(&t)?;
+
+        println!("{label}  (TDB JD {jd})");
+        println!(
+            "  Euler angles     {:+.9} {:+.9} {:+.9} rad",
+            angles[0], angles[1], angles[2]
+        );
+        println!(
+            "  rates            {:+.9} {:+.9} {:+.9} rad/day",
+            rates[0], rates[1], rates[2]
+        );
+        println!("  ICRF -> MOON_PA_DE421");
+        for row in 0..3 {
+            println!(
+                "    {:+.12} {:+.12} {:+.12}",
+                rotation[(row, 0)],
+                rotation[(row, 1)],
+                rotation[(row, 2)]
+            );
+        }
+        println!(
+            "  d/dt (per day)   norm {:.9}, largest element {:.9}",
+            rate.norm(),
+            rate.abs().max()
+        );
+
+        // The mean-Earth frame differs from the principal axes by less than a
+        // milliradian, so report the difference rather than the whole matrix.
+        let difference = mean_earth.rotation_at(&t) - rotation;
+        println!(
+            "  MOON_ME_DE421 differs by at most {:.3e} in any element\n",
+            difference.abs().max()
+        );
+    }
+
+    Ok(())
+}

--- a/src/data/downloader.rs
+++ b/src/data/downloader.rs
@@ -30,6 +30,14 @@ const NAIF_SATELLITES_URL: &str =
 /// e.g. `moon_pa_de440_200625.bpc` and `earth_latest_high_prec.bpc`).
 pub const NAIF_PCK_URL: &str = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/";
 
+/// Base URL for NAIF satellite frame kernels
+///
+/// Holds the text frame kernels (`.tf`) that name the body-fixed frames a
+/// binary PCK orients, such as `moon_080317.tf`, which defines
+/// `MOON_PA_DE421` and `MOON_ME`.
+pub const NAIF_FK_SATELLITES_URL: &str =
+    "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/fk/satellites/";
+
 /// Get the cache directory path
 pub fn get_cache_dir() -> PathBuf {
     let home = env::var("HOME").unwrap_or_else(|_| ".".to_string());
@@ -173,6 +181,7 @@ fn decompress_gzip<P: AsRef<Path>, Q: AsRef<Path>>(gz_path: P, output_path: Q) -
 /// - `*.bsp` — SPK ephemerides, from JPL, or from the NAIF satellite
 ///   directory when the name starts with `jup`
 /// - `*.tpc`, `*.bpc` — text and binary PCK kernels, from [`NAIF_PCK_URL`]
+/// - `*.tf` — text frame kernels, from [`NAIF_FK_SATELLITES_URL`]
 pub fn resolve_url(filename: &str) -> Option<String> {
     if filename.contains("://") {
         return Some(filename.to_string());
@@ -189,6 +198,10 @@ pub fn resolve_url(filename: &str) -> Option<String> {
 
     if filename.ends_with(".tpc") || filename.ends_with(".bpc") {
         return Some(format!("{}{}", NAIF_PCK_URL, filename));
+    }
+
+    if filename.ends_with(".tf") {
+        return Some(format!("{}{}", NAIF_FK_SATELLITES_URL, filename));
     }
 
     None
@@ -399,6 +412,17 @@ mod tests {
             resolve_url("moon_pa_de440_200625.bpc"),
             Some(
                 "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/moon_pa_de440_200625.bpc"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_resolve_url_frame_kernel() {
+        assert_eq!(
+            resolve_url("moon_080317.tf"),
+            Some(
+                "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/fk/satellites/moon_080317.tf"
                     .to_string()
             )
         );

--- a/src/jplephem/chebyshev.rs
+++ b/src/jplephem/chebyshev.rs
@@ -134,6 +134,212 @@ pub fn rescale_derivative(deriv_normalized: f64, radius: f64) -> Result<f64> {
     Ok(deriv_normalized / radius)
 }
 
+/// A run of equally spaced Chebyshev records, the coefficient layout shared by
+/// SPK types 2 and 3 and by binary PCK type 2.
+///
+/// A segment of any of those types is an array of `n_records` fixed-size
+/// records followed by four trailing numbers: the epoch of the first record,
+/// the length of each record, the record size and the record count. Each
+/// record holds its own midpoint and radius (in TDB seconds since J2000) and
+/// then `component_count` blocks of `n_coeffs` Chebyshev coefficients: three
+/// position components for SPK type 2, position and velocity for type 3, and
+/// three Euler angles for binary PCK type 2.
+#[derive(Debug, Clone)]
+pub struct ChebyshevRecords {
+    init: f64,
+    intlen: f64,
+    record_size: usize,
+    n_records: usize,
+    n_coeffs: usize,
+    component_count: usize,
+    coefficients: Vec<f64>,
+}
+
+impl ChebyshevRecords {
+    /// Parse a segment array of the given number of components per record.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JplephemError::InvalidFormat`] if the array is too short, if
+    /// the record size cannot hold at least one coefficient per component, or
+    /// if the record count and record size disagree with the array length.
+    pub fn load(array: &[f64], component_count: usize) -> Result<Self> {
+        if array.len() < 4 {
+            return Err(JplephemError::InvalidFormat(
+                "Segment data too small for a Chebyshev record array".to_string(),
+            ));
+        }
+
+        let n = array.len();
+        let init = array[n - 4];
+        let intlen = array[n - 3];
+        let record_size = array[n - 2] as usize;
+        let n_records = array[n - 1] as usize;
+
+        if record_size < 2 + component_count {
+            return Err(JplephemError::InvalidFormat(format!(
+                "Invalid record size for {component_count} components: {record_size}"
+            )));
+        }
+
+        let expected_size = n_records * record_size + 4;
+        if n != expected_size {
+            return Err(JplephemError::InvalidFormat(format!(
+                "Inconsistent array size: expected {expected_size}, got {n}"
+            )));
+        }
+
+        Ok(Self {
+            init,
+            intlen,
+            record_size,
+            n_records,
+            n_coeffs: (record_size - 2) / component_count,
+            component_count,
+            coefficients: array[0..n - 4].to_vec(),
+        })
+    }
+
+    /// Epoch of the start of the first record, in TDB seconds since J2000.
+    pub fn init(&self) -> f64 {
+        self.init
+    }
+
+    /// Length of each record, in seconds.
+    pub fn interval_length(&self) -> f64 {
+        self.intlen
+    }
+
+    /// Number of records in the segment.
+    pub fn len(&self) -> usize {
+        self.n_records
+    }
+
+    /// Whether the segment holds no records at all.
+    pub fn is_empty(&self) -> bool {
+        self.n_records == 0
+    }
+
+    /// Number of Chebyshev coefficients per component.
+    pub fn coefficient_count(&self) -> usize {
+        self.n_coeffs
+    }
+
+    /// Number of components stored in each record.
+    pub fn component_count(&self) -> usize {
+        self.component_count
+    }
+
+    /// Index of the record covering `et`, in TDB seconds since J2000.
+    ///
+    /// An epoch exactly at the end of the last record is clamped onto it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JplephemError::OutOfRangeError`] if `et` falls outside the
+    /// span of the records.
+    pub fn record_index(&self, et: f64) -> Result<usize> {
+        let out_of_range = || JplephemError::OutOfRangeError {
+            jd: super::spk::seconds_to_jd(et),
+            start_jd: super::spk::seconds_to_jd(self.init),
+            end_jd: super::spk::seconds_to_jd(self.init + self.intlen * self.n_records as f64),
+        };
+
+        let elapsed = et - self.init;
+        if elapsed < 0.0 || self.n_records == 0 {
+            return Err(out_of_range());
+        }
+        let index = (elapsed / self.intlen).floor() as usize;
+        match index.cmp(&self.n_records) {
+            std::cmp::Ordering::Less => Ok(index),
+            std::cmp::Ordering::Equal => Ok(self.n_records - 1),
+            std::cmp::Ordering::Greater => Err(out_of_range()),
+        }
+    }
+
+    /// Borrow one record by index.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JplephemError::InvalidFormat`] if the index is past the end
+    /// of the coefficient array.
+    pub fn record(&self, index: usize) -> Result<ChebyshevRecord<'_>> {
+        let start = index * self.record_size;
+        if index >= self.n_records || start + self.record_size > self.coefficients.len() {
+            return Err(JplephemError::InvalidFormat(
+                "Record index out of bounds".to_string(),
+            ));
+        }
+        Ok(ChebyshevRecord {
+            midpoint: self.coefficients[start],
+            radius: self.coefficients[start + 1],
+            coefficients: &self.coefficients[start + 2..start + self.record_size],
+            n_coeffs: self.n_coeffs,
+            component_count: self.component_count,
+        })
+    }
+
+    /// Borrow the record covering `et`, in TDB seconds since J2000.
+    ///
+    /// # Errors
+    ///
+    /// Returns the errors of [`record_index`](Self::record_index) and
+    /// [`record`](Self::record).
+    pub fn record_at(&self, et: f64) -> Result<ChebyshevRecord<'_>> {
+        self.record(self.record_index(et)?)
+    }
+}
+
+/// One record of a [`ChebyshevRecords`] array.
+#[derive(Debug, Clone, Copy)]
+pub struct ChebyshevRecord<'a> {
+    midpoint: f64,
+    radius: f64,
+    coefficients: &'a [f64],
+    n_coeffs: usize,
+    component_count: usize,
+}
+
+impl ChebyshevRecord<'_> {
+    /// Midpoint of the record, in TDB seconds since J2000.
+    pub fn midpoint(&self) -> f64 {
+        self.midpoint
+    }
+
+    /// Half-length of the record, in seconds.
+    pub fn radius(&self) -> f64 {
+        self.radius
+    }
+
+    /// The Chebyshev polynomial of component `index`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JplephemError::InvalidFormat`] if the component does not
+    /// exist in this record.
+    pub fn polynomial(&self, index: usize) -> Result<ChebyshevPolynomial> {
+        if index >= self.component_count {
+            return Err(JplephemError::InvalidFormat(format!(
+                "Component {index} out of range for a record of {} components",
+                self.component_count
+            )));
+        }
+        let start = index * self.n_coeffs;
+        Ok(ChebyshevPolynomial::new(
+            self.coefficients[start..start + self.n_coeffs].to_vec(),
+        ))
+    }
+
+    /// Map `et`, in TDB seconds since J2000, onto the polynomial's `[-1, 1]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the errors of [`normalize_time`].
+    pub fn normalized_time(&self, et: f64) -> Result<f64> {
+        normalize_time(et, self.midpoint, self.radius)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/jplephem/mod.rs
+++ b/src/jplephem/mod.rs
@@ -24,6 +24,7 @@
 //!
 //! - [`daf`] - Double Array File format reader (underlying binary container)
 //! - [`spk`] - Spacecraft Planet Kernel format reader
+//! - [`pck`] - Binary Planetary Constants Kernel format reader
 //! - [`kernel`] - High-level SpiceKernel API with named body access
 //! - [`chebyshev`] - Chebyshev polynomial interpolation
 //! - [`spk_type21`] - SPK Type 21 Modified Difference Array interpolation
@@ -46,5 +47,5 @@ mod tests;
 pub use self::chebyshev::{normalize_time, rescale_derivative, ChebyshevPolynomial};
 pub use self::errors::JplephemError;
 pub use self::kernel::{PlanetState, SpiceKernel, AU_KM, S_PER_DAY};
-pub use self::pck::PCK;
+pub use self::pck::{PckSegment, PCK};
 pub use self::spk::SPK;

--- a/src/jplephem/pck.rs
+++ b/src/jplephem/pck.rs
@@ -1,24 +1,555 @@
-//! Planetary Constants Kernel (PCK) format stub
+//! Binary Planetary Constants Kernel (PCK) reader
 //!
-//! PCK files contain rotation and orientation data for planets and moons.
-//! This is a placeholder for future implementation.
+//! A binary PCK — a `.bpc` file — is a DAF whose segments hold the orientation
+//! of a body-fixed frame rather than the position of a body. Each type 2
+//! segment stores Chebyshev coefficients for three Euler angles, in radians,
+//! that carry a reference frame (almost always J2000) into the body-fixed
+//! frame of a NAIF *frame class id*: 31006 for `MOON_PA_DE421`, 31008 for
+//! `MOON_PA_DE440`, 3000 for `ITRF93`.
+//!
+//! This is a port of python `jplephem/pck.py`. Only data type 2 is defined for
+//! binary PCK files, and only data type 2 is supported here; any other type
+//! reports [`JplephemError::UnsupportedDataType`].
+//!
+//! The angles are not pole right ascension, declination and prime meridian:
+//! they are the SPICE Euler angles of the rotation, and are turned into a
+//! matrix by [`crate::planetarylib::pck_frame::PckFrame`].
+//!
+//! # Example
+//!
+//! ```no_run
+//! use starfield::jplephem::pck::PCK;
+//!
+//! let pck = PCK::open("moon_pa_de421_1900-2050.bpc").unwrap();
+//! let segment = pck.segment_for(31006).unwrap();
+//! let (angles, rates) = segment.compute(2451545.0).unwrap();
+//! println!("{angles} rad, {rates} rad/day");
+//! ```
 
 use std::path::Path;
 use std::sync::Arc;
 
-use super::daf::DAF;
-use super::errors::Result;
+use nalgebra::Vector3;
+use once_cell::sync::OnceCell;
 
-/// Planetary Constants Kernel (PCK) file reader
+use super::calendar::calendar_date_from_float;
+use super::chebyshev::ChebyshevRecords;
+use super::daf::DAF;
+use super::errors::{JplephemError, Result};
+use super::kernel::S_PER_DAY;
+use super::names::get_target_name;
+use super::spk::{jd_to_seconds, seconds_to_jd};
+
+/// The only data type a binary PCK segment may use.
+const CHEBYSHEV_TYPE: i32 = 2;
+
+/// The frame class ids that NAIF's published binary PCK kernels carry.
+const FRAME_NAMES: [(i32, &str); 3] = [
+    (3000, "ITRF93"),
+    (31006, "MOON_PA_DE421"),
+    (31008, "MOON_PA_DE440"),
+];
+
+/// The name of a well-known NAIF frame class id.
+///
+/// Covers the frames the binary PCK kernels NAIF publishes orient: `ITRF93`
+/// (3000) and the lunar principal-axes frames `MOON_PA_DE421` (31006) and
+/// `MOON_PA_DE440` (31008). A text frame kernel is what names any other id.
+pub fn frame_name(frame_class_id: i32) -> Option<&'static str> {
+    FRAME_NAMES
+        .iter()
+        .find(|(id, _)| *id == frame_class_id)
+        .map(|(_, name)| *name)
+}
+
+/// A binary Planetary Constants Kernel (`.bpc`) file.
+///
+/// Open one with [`PCK::open`] or [`PCK::from_bytes`], then reach its
+/// orientation data through [`segments`](Self::segments) or
+/// [`segment_for`](Self::segment_for). Printing the kernel lists its segments,
+/// in the style of [`crate::jplephem::SPK`].
 pub struct PCK {
-    /// The underlying DAF file
+    /// The underlying DAF file.
     pub daf: Arc<DAF>,
+    /// Every segment found in the file, in file order.
+    segments: Vec<PckSegment>,
 }
 
 impl PCK {
-    /// Open a PCK file at the given path
+    /// Open a binary PCK file at the given path.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JplephemError::FileError`] if the file cannot be read and
+    /// [`JplephemError::InvalidFormat`] if it is not a DAF.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let daf = Arc::new(DAF::open(path)?);
-        Ok(PCK { daf })
+        Self::from_daf(Arc::new(DAF::open(path)?))
+    }
+
+    /// Read a binary PCK from an in-memory byte buffer.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JplephemError::InvalidFormat`] if the bytes are not a DAF.
+    pub fn from_bytes(data: &[u8]) -> Result<Self> {
+        Self::from_daf(Arc::new(DAF::from_bytes(data)?))
+    }
+
+    /// Build a kernel around an already-opened DAF.
+    fn from_daf(daf: Arc<DAF>) -> Result<Self> {
+        let mut segments = Vec::new();
+
+        for (name, values) in daf.summaries()?.iter() {
+            // A DAF/PCK summary is two doubles and five integers.
+            if values.len() < 7 {
+                return Err(JplephemError::InvalidFormat(format!(
+                    "A binary PCK summary needs 7 values, found {}",
+                    values.len()
+                )));
+            }
+
+            let start_second = values[0];
+            let end_second = values[1];
+
+            segments.push(PckSegment {
+                daf: Arc::clone(&daf),
+                source: String::from_utf8_lossy(name).trim_end().to_string(),
+                start_second,
+                end_second,
+                start_jd: seconds_to_jd(start_second),
+                end_jd: seconds_to_jd(end_second),
+                body: values[2] as i32,
+                frame: values[3] as i32,
+                data_type: values[4] as i32,
+                start_i: values[5] as usize,
+                end_i: values[6] as usize,
+                records: OnceCell::new(),
+            });
+        }
+
+        Ok(PCK { daf, segments })
+    }
+
+    /// Every segment in the file, in file order.
+    pub fn segments(&self) -> &[PckSegment] {
+        &self.segments
+    }
+
+    /// Take ownership of the segments, dropping the kernel wrapper.
+    ///
+    /// Each segment keeps its own reference to the underlying DAF, so the
+    /// segments stay usable once the [`PCK`] is gone.
+    pub fn into_segments(self) -> Vec<PckSegment> {
+        self.segments
+    }
+
+    /// The first segment whose frame class id is `body`, if there is one.
+    ///
+    /// The id is the NAIF frame class id the kernel orients, such as 31006 for
+    /// `MOON_PA_DE421`.
+    pub fn segment_for(&self, body: i32) -> Option<&PckSegment> {
+        self.segments.iter().find(|s| s.body == body)
+    }
+
+    /// Read the comment area of the underlying DAF file.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JplephemError::FileError`] if the comment records cannot be
+    /// read.
+    pub fn comments(&self) -> Result<String> {
+        self.daf.comments()
+    }
+}
+
+impl std::fmt::Display for PCK {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "File type {} with {} segments:",
+            self.daf.locidw,
+            self.segments.len()
+        )?;
+        for segment in &self.segments {
+            writeln!(f, "{segment}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for PCK {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
+/// One segment of a binary PCK file: the orientation of a single frame over a
+/// single stretch of time.
+pub struct PckSegment {
+    /// The file the coefficients are read from.
+    daf: Arc<DAF>,
+    /// Segment source label, such as `DE-0421LE-0421`.
+    pub source: String,
+    /// Start epoch, in TDB seconds since J2000.
+    pub start_second: f64,
+    /// End epoch, in TDB seconds since J2000.
+    pub end_second: f64,
+    /// NAIF frame class id of the body-fixed frame this segment orients.
+    pub body: i32,
+    /// NAIF id of the reference frame the angles rotate away from; 1 is J2000.
+    pub frame: i32,
+    /// Segment data type; only 2 is defined for binary PCK files.
+    pub data_type: i32,
+    /// Start index in the file, as a 1-indexed double-word address.
+    pub start_i: usize,
+    /// End index in the file, as a 1-indexed double-word address.
+    pub end_i: usize,
+    /// Start epoch, as a Julian date.
+    pub start_jd: f64,
+    /// End epoch, as a Julian date.
+    pub end_jd: f64,
+    /// Coefficients, read from the file the first time they are needed.
+    records: OnceCell<ChebyshevRecords>,
+}
+
+impl PckSegment {
+    /// The three Euler angles and their rates at TDB Julian date `tdb_jd`.
+    ///
+    /// Returns the angles in radians and their rates in radians per day. The
+    /// angles are the SPICE Euler angles of the rotation from the reference
+    /// frame to the body-fixed frame, in the order the kernel stores them.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JplephemError::UnsupportedDataType`] unless the segment is
+    /// type 2, and [`JplephemError::OutOfRangeError`] if `tdb_jd` lies outside
+    /// the span the segment covers.
+    pub fn compute(&self, tdb_jd: f64) -> Result<(Vector3<f64>, Vector3<f64>)> {
+        let et = jd_to_seconds(tdb_jd);
+
+        if et < self.start_second || et > self.end_second {
+            return Err(JplephemError::OutOfRangeError {
+                jd: tdb_jd,
+                start_jd: self.start_jd,
+                end_jd: self.end_jd,
+            });
+        }
+
+        let record = self.records()?.record_at(et)?;
+        let t = record.normalized_time(et)?;
+        // The Chebyshev variable spans the record's radius in seconds, so a
+        // derivative with respect to it becomes radians per day this way.
+        let rate_scale = S_PER_DAY / record.radius();
+
+        let mut angles = Vector3::zeros();
+        let mut rates = Vector3::zeros();
+        for i in 0..3 {
+            let polynomial = record.polynomial(i)?;
+            angles[i] = polynomial.evaluate(t);
+            rates[i] = polynomial.derivative(t) * rate_scale;
+        }
+
+        Ok((angles, rates))
+    }
+
+    /// The coefficients of this segment, read from the file on first use.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JplephemError::UnsupportedDataType`] unless the segment is
+    /// type 2, and [`JplephemError::InvalidFormat`] if the coefficient array
+    /// is malformed.
+    fn records(&self) -> Result<&ChebyshevRecords> {
+        if self.data_type != CHEBYSHEV_TYPE {
+            return Err(JplephemError::UnsupportedDataType(self.data_type));
+        }
+        self.records.get_or_try_init(|| {
+            let array = self.daf.read_array(self.start_i, self.end_i)?;
+            ChebyshevRecords::load(&array, 3)
+        })
+    }
+
+    /// A human-readable description of this segment.
+    ///
+    /// The verbose form adds the data type and the source label, matching the
+    /// description [`crate::jplephem::spk::Segment`] prints.
+    pub fn describe(&self, verbose: bool) -> String {
+        let start = calendar_date_from_float(self.start_jd);
+        let end = calendar_date_from_float(self.end_jd);
+        let body_name = frame_name(self.body)
+            .or_else(|| get_target_name(self.body))
+            .unwrap_or("Unknown");
+
+        let mut text = format!(
+            "{}-{:02}-{:02}..{}-{:02}-{:02}  frame={}  {} ({})",
+            start.0, start.1, start.2, end.0, end.1, end.2, self.frame, body_name, self.body
+        );
+
+        if verbose {
+            text.push_str(&format!(
+                "\n  data_type={} source={}",
+                self.data_type, self.source
+            ));
+        }
+        text
+    }
+}
+
+impl std::fmt::Display for PckSegment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.describe(false))
+    }
+}
+
+impl std::fmt::Debug for PckSegment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.describe(true))
+    }
+}
+
+/// Synthetic binary PCK files, shared by the tests of this module and of
+/// [`crate::planetarylib::pck_frame`].
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+
+    /// Frame class id of the lunar principal-axes frame of DE421.
+    pub const MOON_PA_DE421: i32 = 31006;
+
+    /// Build a DAF/PCK file in memory around one type 2 segment.
+    ///
+    /// `records` is one entry per record: its midpoint and radius in TDB
+    /// seconds since J2000, then the Chebyshev coefficients of each of the
+    /// three angles.
+    pub fn synthetic_pck(
+        body: i32,
+        data_type: i32,
+        records: &[(f64, f64, [Vec<f64>; 3])],
+    ) -> Result<Vec<u8>> {
+        let n_coeffs = records[0].2[0].len();
+        let record_size = 2 + 3 * n_coeffs;
+        let intlen = 2.0 * records[0].1;
+        let init = records[0].0 - records[0].1;
+
+        let mut array: Vec<f64> = Vec::new();
+        for (midpoint, radius, angles) in records {
+            array.push(*midpoint);
+            array.push(*radius);
+            for angle in angles {
+                assert_eq!(angle.len(), n_coeffs, "records must be the same size");
+                array.extend_from_slice(angle);
+            }
+        }
+        array.extend_from_slice(&[init, intlen, record_size as f64, records.len() as f64]);
+
+        // Records 1..=3 hold the header, the summary record and the name
+        // record; the coefficients start at the first double-word after them.
+        const RECORD_SIZE: usize = 1024;
+        let start_i = 3 * RECORD_SIZE / 8 + 1;
+        let end_i = start_i + array.len() - 1;
+
+        let mut file = vec![0u8; 3 * RECORD_SIZE];
+        file[0..8].copy_from_slice(b"DAF/PCK ");
+        file[8..12].copy_from_slice(&2u32.to_le_bytes()); // ND
+        file[12..16].copy_from_slice(&5u32.to_le_bytes()); // NI
+        file[16..76].copy_from_slice(format!("{:<60}", "SYNTHETIC").as_bytes());
+        file[76..80].copy_from_slice(&2u32.to_le_bytes()); // FWARD
+        file[80..84].copy_from_slice(&2u32.to_le_bytes()); // BWARD
+        file[84..88].copy_from_slice(&((end_i + 1) as u32).to_le_bytes()); // FREE
+
+        // Summary record: NEXT, PREV, NSUM, then the one summary itself.
+        let summary = RECORD_SIZE;
+        let put = |file: &mut Vec<u8>, at: usize, value: f64| {
+            file[at..at + 8].copy_from_slice(&value.to_le_bytes());
+        };
+        put(&mut file, summary, 0.0);
+        put(&mut file, summary + 8, 0.0);
+        put(&mut file, summary + 16, 1.0);
+        put(&mut file, summary + 24, records[0].0 - records[0].1);
+        put(
+            &mut file,
+            summary + 32,
+            records[records.len() - 1].0 + records[records.len() - 1].1,
+        );
+        // Five integers packed two to a double-word.
+        let ints = [body, 1, data_type, start_i as i32, end_i as i32];
+        for (i, value) in ints.iter().enumerate() {
+            let at = summary + 40 + (i / 2) * 8 + (i % 2) * 4;
+            file[at..at + 4].copy_from_slice(&value.to_le_bytes());
+        }
+
+        // Name record.
+        file[2 * RECORD_SIZE..2 * RECORD_SIZE + 40]
+            .copy_from_slice(format!("{:<40}", "SYNTHETIC PCK").as_bytes());
+
+        for value in &array {
+            file.extend_from_slice(&value.to_le_bytes());
+        }
+
+        Ok(file)
+    }
+
+    /// One day of coverage, centred on J2000, with easily checked angles.
+    pub fn one_day_pck(data_type: i32) -> Vec<u8> {
+        synthetic_pck(
+            MOON_PA_DE421,
+            data_type,
+            &[(
+                0.0,
+                S_PER_DAY / 2.0,
+                [
+                    vec![0.5, 0.25, 0.125],
+                    vec![1.0, 0.0, 0.0],
+                    vec![0.0, 2.0, 0.0],
+                ],
+            )],
+        )
+        .unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::{one_day_pck, synthetic_pck, MOON_PA_DE421};
+    use super::*;
+    use crate::jplephem::chebyshev::ChebyshevPolynomial;
+
+    #[test]
+    fn test_segment_metadata_is_parsed() {
+        let pck = PCK::from_bytes(&one_day_pck(2)).unwrap();
+        assert_eq!(pck.segments().len(), 1);
+
+        let segment = &pck.segments()[0];
+        assert_eq!(segment.body, MOON_PA_DE421);
+        assert_eq!(segment.frame, 1);
+        assert_eq!(segment.data_type, 2);
+        assert_eq!(segment.source, "SYNTHETIC PCK");
+        assert_eq!(segment.start_second, -S_PER_DAY / 2.0);
+        assert_eq!(segment.end_second, S_PER_DAY / 2.0);
+        assert!((segment.start_jd - 2451544.5).abs() < 1e-9);
+        assert!((segment.end_jd - 2451545.5).abs() < 1e-9);
+        assert!(pck.segment_for(MOON_PA_DE421).is_some());
+        assert!(pck.segment_for(3000).is_none());
+    }
+
+    #[test]
+    fn test_compute_matches_the_polynomials() {
+        let pck = PCK::from_bytes(&one_day_pck(2)).unwrap();
+        let segment = pck.segment_for(MOON_PA_DE421).unwrap();
+
+        // A quarter of a day past J2000 is halfway from the record's midpoint
+        // to its end, so the Chebyshev variable is exactly 1/2.
+        let tdb_jd = 2451545.25;
+        let s = 0.5;
+        let (angles, rates) = segment.compute(tdb_jd).unwrap();
+
+        let expected = [
+            ChebyshevPolynomial::new(vec![0.5, 0.25, 0.125]),
+            ChebyshevPolynomial::new(vec![1.0, 0.0, 0.0]),
+            ChebyshevPolynomial::new(vec![0.0, 2.0, 0.0]),
+        ];
+        for (i, polynomial) in expected.iter().enumerate() {
+            assert!((angles[i] - polynomial.evaluate(s)).abs() < 1e-12);
+            // The record spans half a day either side of its midpoint, so a
+            // derivative per unit of the variable is twice that per day.
+            assert!((rates[i] - polynomial.derivative(s) * 2.0).abs() < 1e-12);
+        }
+
+        // And the same values worked out by hand: T0 = 1, T1 = s, T2 = 2s²-1.
+        assert!((angles[0] - (0.5 + 0.25 * s + 0.125 * (2.0 * s * s - 1.0))).abs() < 1e-12);
+        assert!((angles[1] - 1.0).abs() < 1e-12);
+        assert!((angles[2] - 2.0 * s).abs() < 1e-12);
+        assert!((rates[0] - (0.25 + 0.125 * 4.0 * s) * 2.0).abs() < 1e-12);
+        assert_eq!(rates[1], 0.0);
+        assert!((rates[2] - 4.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_compute_at_the_ends_of_the_record() {
+        let pck = PCK::from_bytes(&one_day_pck(2)).unwrap();
+        let segment = pck.segment_for(MOON_PA_DE421).unwrap();
+
+        let (start, _) = segment.compute(2451544.5).unwrap();
+        let (end, _) = segment.compute(2451545.5).unwrap();
+        // Angle 2 is 2·T1(s), which runs from -2 to 2 across the record.
+        assert!((start[2] + 2.0).abs() < 1e-9);
+        assert!((end[2] - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_compute_picks_the_right_record() {
+        // Two consecutive one-day records, each holding a constant angle.
+        let bytes = synthetic_pck(
+            MOON_PA_DE421,
+            2,
+            &[
+                (
+                    0.0,
+                    S_PER_DAY / 2.0,
+                    [vec![7.0, 0.0], vec![0.0, 0.0], vec![0.0, 0.0]],
+                ),
+                (
+                    S_PER_DAY,
+                    S_PER_DAY / 2.0,
+                    [vec![9.0, 0.0], vec![0.0, 0.0], vec![0.0, 0.0]],
+                ),
+            ],
+        )
+        .unwrap();
+
+        let pck = PCK::from_bytes(&bytes).unwrap();
+        let segment = pck.segment_for(MOON_PA_DE421).unwrap();
+        assert_eq!(segment.compute(2451545.0).unwrap().0[0], 7.0);
+        assert_eq!(segment.compute(2451546.0).unwrap().0[0], 9.0);
+    }
+
+    #[test]
+    fn test_compute_outside_the_segment_is_an_error() {
+        let pck = PCK::from_bytes(&one_day_pck(2)).unwrap();
+        let segment = pck.segment_for(MOON_PA_DE421).unwrap();
+
+        assert!(matches!(
+            segment.compute(2451540.0),
+            Err(JplephemError::OutOfRangeError { .. })
+        ));
+        assert!(matches!(
+            segment.compute(2451550.0),
+            Err(JplephemError::OutOfRangeError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_other_data_types_are_unsupported() {
+        let pck = PCK::from_bytes(&one_day_pck(3)).unwrap();
+        let segment = pck.segment_for(MOON_PA_DE421).unwrap();
+        assert_eq!(segment.data_type, 3);
+        assert!(matches!(
+            segment.compute(2451545.0),
+            Err(JplephemError::UnsupportedDataType(3))
+        ));
+    }
+
+    #[test]
+    fn test_describe_and_display() {
+        let pck = PCK::from_bytes(&one_day_pck(2)).unwrap();
+        let text = format!("{pck}");
+        assert!(text.contains("DAF/PCK"));
+        assert!(text.contains("1 segments"));
+        assert!(text.contains("frame=1"));
+        assert!(text.contains("MOON_PA_DE421 (31006)"));
+        assert!(pck.segments()[0].describe(true).contains("data_type=2"));
+    }
+
+    #[test]
+    fn test_well_known_frame_names() {
+        assert_eq!(frame_name(31006), Some("MOON_PA_DE421"));
+        assert_eq!(frame_name(31008), Some("MOON_PA_DE440"));
+        assert_eq!(frame_name(3000), Some("ITRF93"));
+        assert_eq!(frame_name(301), None);
+    }
+
+    #[test]
+    fn test_from_bytes_rejects_a_non_daf() {
+        assert!(PCK::from_bytes(&[0u8; 16]).is_err());
     }
 }

--- a/src/jplephem/spk.rs
+++ b/src/jplephem/spk.rs
@@ -11,21 +11,11 @@ use std::sync::Arc;
 use nalgebra::Vector3;
 
 use super::calendar::calendar_date_from_float;
-use super::chebyshev::{normalize_time, rescale_derivative, ChebyshevPolynomial};
+use super::chebyshev::{rescale_derivative, ChebyshevRecords};
 use super::daf::DAF;
 use super::errors::{JplephemError, Result};
 use super::names::get_target_name;
 use super::spk_type21::Type21Data;
-
-/// Type 2 record coefficients: (midpoint, radius, x_coeffs, y_coeffs, z_coeffs)
-type Type2Coeffs = (f64, f64, Vec<f64>, Vec<f64>, Vec<f64>);
-/// Type 3 record coefficients: (midpoint, radius, (pos_xyz), (vel_xyz))
-type Type3Coeffs = (
-    f64,
-    f64,
-    (Vec<f64>, Vec<f64>, Vec<f64>),
-    (Vec<f64>, Vec<f64>, Vec<f64>),
-);
 
 /// J2000 epoch as Julian date
 const T0: f64 = 2451545.0;
@@ -86,12 +76,7 @@ pub struct Segment {
 enum SegmentData {
     /// Type 2/3 Chebyshev polynomial data
     Chebyshev {
-        init: f64,
-        intlen: f64,
-        coefficients: Vec<f64>,
-        /// (n_records, n_components, n_coeffs_per_component)
-        shape: (usize, usize, usize),
-        record_size: usize,
+        records: ChebyshevRecords,
         data_type: i32,
     },
     /// Type 21 Modified Difference Array data
@@ -234,75 +219,36 @@ impl Segment {
         let data = self.load_data()?;
 
         match data {
-            SegmentData::Chebyshev {
-                init,
-                intlen,
-                coefficients,
-                shape,
-                record_size,
-                data_type,
-            } => {
-                let record_index = Self::find_record_index(et, *init, *intlen, shape.0)?;
+            SegmentData::Chebyshev { records, data_type } => {
+                let record = records.record_at(et)?;
+                let t = record.normalized_time(et)?;
+                let radius = record.radius();
 
                 match data_type {
                     2 => {
-                        let (record_mid, record_radius, coeffs_x, coeffs_y, coeffs_z) =
-                            Self::get_record_coefficients_type2(
-                                coefficients,
-                                record_index,
-                                *record_size,
-                                shape.2,
-                            )?;
+                        let x = record.polynomial(0)?;
+                        let y = record.polynomial(1)?;
+                        let z = record.polynomial(2)?;
 
-                        let t = normalize_time(et, record_mid, record_radius)?;
-
-                        let poly_x = ChebyshevPolynomial::new(coeffs_x);
-                        let poly_y = ChebyshevPolynomial::new(coeffs_y);
-                        let poly_z = ChebyshevPolynomial::new(coeffs_z);
-
-                        let position = Vector3::new(
-                            poly_x.evaluate(t),
-                            poly_y.evaluate(t),
-                            poly_z.evaluate(t),
-                        );
-
+                        let position = Vector3::new(x.evaluate(t), y.evaluate(t), z.evaluate(t));
                         let velocity = Vector3::new(
-                            rescale_derivative(poly_x.derivative(t), record_radius)?,
-                            rescale_derivative(poly_y.derivative(t), record_radius)?,
-                            rescale_derivative(poly_z.derivative(t), record_radius)?,
+                            rescale_derivative(x.derivative(t), radius)?,
+                            rescale_derivative(y.derivative(t), radius)?,
+                            rescale_derivative(z.derivative(t), radius)?,
                         );
 
                         Ok((position, velocity))
                     }
                     3 => {
-                        let (record_mid, record_radius, pos_coeffs, vel_coeffs) =
-                            Self::get_record_coefficients_type3(
-                                coefficients,
-                                record_index,
-                                *record_size,
-                                shape.2,
-                            )?;
-
-                        let t = normalize_time(et, record_mid, record_radius)?;
-
-                        let poly_x = ChebyshevPolynomial::new(pos_coeffs.0);
-                        let poly_y = ChebyshevPolynomial::new(pos_coeffs.1);
-                        let poly_z = ChebyshevPolynomial::new(pos_coeffs.2);
-
-                        let poly_vx = ChebyshevPolynomial::new(vel_coeffs.0);
-                        let poly_vy = ChebyshevPolynomial::new(vel_coeffs.1);
-                        let poly_vz = ChebyshevPolynomial::new(vel_coeffs.2);
-
                         let position = Vector3::new(
-                            poly_x.evaluate(t),
-                            poly_y.evaluate(t),
-                            poly_z.evaluate(t),
+                            record.polynomial(0)?.evaluate(t),
+                            record.polynomial(1)?.evaluate(t),
+                            record.polynomial(2)?.evaluate(t),
                         );
-
                         let velocity = Vector3::new(
-                            rescale_derivative(poly_vx.evaluate(t), record_radius)?,
-                            rescale_derivative(poly_vy.evaluate(t), record_radius)?,
-                            rescale_derivative(poly_vz.evaluate(t), record_radius)?,
+                            rescale_derivative(record.polynomial(3)?.evaluate(t), radius)?,
+                            rescale_derivative(record.polynomial(4)?.evaluate(t), radius)?,
+                            rescale_derivative(record.polynomial(5)?.evaluate(t), radius)?,
                         );
 
                         Ok((position, velocity))
@@ -312,95 +258,6 @@ impl Segment {
             }
             SegmentData::Type21(type21_data) => type21_data.compute(et),
         }
-    }
-
-    fn find_record_index(et: f64, init: f64, intlen: f64, n_records: usize) -> Result<usize> {
-        let elapsed = et - init;
-        if elapsed < 0.0 {
-            return Err(JplephemError::OutOfRangeError {
-                jd: seconds_to_jd(et),
-                start_jd: seconds_to_jd(init),
-                end_jd: seconds_to_jd(init + intlen * n_records as f64),
-            });
-        }
-        let mut index = (elapsed / intlen).floor() as usize;
-        // Clamp to last record for times at the exact end of the range
-        if index >= n_records {
-            if index == n_records {
-                index = n_records - 1;
-            } else {
-                return Err(JplephemError::OutOfRangeError {
-                    jd: seconds_to_jd(et),
-                    start_jd: seconds_to_jd(init),
-                    end_jd: seconds_to_jd(init + intlen * n_records as f64),
-                });
-            }
-        }
-        Ok(index)
-    }
-
-    fn get_record_coefficients_type2(
-        coefficients: &[f64],
-        record_index: usize,
-        record_size: usize,
-        n_coeffs: usize,
-    ) -> Result<Type2Coeffs> {
-        let record_start = record_index * record_size;
-        if record_start + 2 + 3 * n_coeffs > coefficients.len() {
-            return Err(JplephemError::InvalidFormat(
-                "Record index out of bounds".to_string(),
-            ));
-        }
-
-        let record_mid = coefficients[record_start];
-        let record_radius = coefficients[record_start + 1];
-
-        let x_start = record_start + 2;
-        let y_start = x_start + n_coeffs;
-        let z_start = y_start + n_coeffs;
-
-        let coeffs_x = coefficients[x_start..x_start + n_coeffs].to_vec();
-        let coeffs_y = coefficients[y_start..y_start + n_coeffs].to_vec();
-        let coeffs_z = coefficients[z_start..z_start + n_coeffs].to_vec();
-
-        Ok((record_mid, record_radius, coeffs_x, coeffs_y, coeffs_z))
-    }
-
-    fn get_record_coefficients_type3(
-        coefficients: &[f64],
-        record_index: usize,
-        record_size: usize,
-        n_coeffs: usize,
-    ) -> Result<Type3Coeffs> {
-        let record_start = record_index * record_size;
-        if record_start + 2 + 6 * n_coeffs > coefficients.len() {
-            return Err(JplephemError::InvalidFormat(
-                "Record index out of bounds".to_string(),
-            ));
-        }
-
-        let record_mid = coefficients[record_start];
-        let record_radius = coefficients[record_start + 1];
-
-        let x_start = record_start + 2;
-        let y_start = x_start + n_coeffs;
-        let z_start = y_start + n_coeffs;
-        let vx_start = z_start + n_coeffs;
-        let vy_start = vx_start + n_coeffs;
-        let vz_start = vy_start + n_coeffs;
-
-        let pos = (
-            coefficients[x_start..x_start + n_coeffs].to_vec(),
-            coefficients[y_start..y_start + n_coeffs].to_vec(),
-            coefficients[z_start..z_start + n_coeffs].to_vec(),
-        );
-        let vel = (
-            coefficients[vx_start..vx_start + n_coeffs].to_vec(),
-            coefficients[vy_start..vy_start + n_coeffs].to_vec(),
-            coefficients[vz_start..vz_start + n_coeffs].to_vec(),
-        );
-
-        Ok((record_mid, record_radius, pos, vel))
     }
 
     fn load_data(&mut self) -> Result<&SegmentData> {
@@ -423,84 +280,16 @@ impl Segment {
     }
 
     fn load_data_type_2(&mut self, array: &[f64]) -> Result<&SegmentData> {
-        if array.len() < 4 {
-            return Err(JplephemError::InvalidFormat(
-                "Segment data too small for Type 2".to_string(),
-            ));
-        }
-
-        let n = array.len();
-        let init = array[n - 4];
-        let intlen = array[n - 3];
-        let rsize = array[n - 2] as usize;
-        let n_rec = array[n - 1] as usize;
-
-        if rsize < 5 {
-            return Err(JplephemError::InvalidFormat(format!(
-                "Invalid record size for Type 2: {rsize}"
-            )));
-        }
-
-        let n_coeffs = (rsize - 2) / 3;
-
-        let expected_size = n_rec * rsize + 4;
-        if array.len() != expected_size {
-            return Err(JplephemError::InvalidFormat(format!(
-                "Inconsistent array size: expected {expected_size}, got {}",
-                array.len()
-            )));
-        }
-
-        let coefficients = array[0..(n - 4)].to_vec();
-
         self.data = Some(SegmentData::Chebyshev {
-            init,
-            intlen,
-            coefficients,
-            shape: (n_rec, 3, n_coeffs),
-            record_size: rsize,
+            records: ChebyshevRecords::load(array, 3)?,
             data_type: self.data_type,
         });
         Ok(self.data.as_ref().unwrap())
     }
 
     fn load_data_type_3(&mut self, array: &[f64]) -> Result<&SegmentData> {
-        if array.len() < 4 {
-            return Err(JplephemError::InvalidFormat(
-                "Segment data too small for Type 3".to_string(),
-            ));
-        }
-
-        let n = array.len();
-        let init = array[n - 4];
-        let intlen = array[n - 3];
-        let rsize = array[n - 2] as usize;
-        let n_rec = array[n - 1] as usize;
-
-        if rsize < 8 {
-            return Err(JplephemError::InvalidFormat(format!(
-                "Invalid record size for Type 3: {rsize}"
-            )));
-        }
-
-        let n_coeffs = (rsize - 2) / 6;
-
-        let expected_size = n_rec * rsize + 4;
-        if array.len() != expected_size {
-            return Err(JplephemError::InvalidFormat(format!(
-                "Inconsistent array size: expected {expected_size}, got {}",
-                array.len()
-            )));
-        }
-
-        let coefficients = array[0..(n - 4)].to_vec();
-
         self.data = Some(SegmentData::Chebyshev {
-            init,
-            intlen,
-            coefficients,
-            shape: (n_rec, 6, n_coeffs),
-            record_size: rsize,
+            records: ChebyshevRecords::load(array, 6)?,
             data_type: self.data_type,
         });
         Ok(self.data.as_ref().unwrap())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,29 @@ impl Loader {
         Ok(constants)
     }
 
+    /// Open a binary PCK kernel, downloading it if necessary.
+    ///
+    /// Binary PCK kernels are the `.bpc` files that hold the orientation of a
+    /// body-fixed frame, such as `moon_pa_de421_1900-2050.bpc`. The file is
+    /// looked up in `data_dir` (if set) or in `~/.cache/starfield/`, and
+    /// downloaded from NAIF when it is not there.
+    ///
+    /// Hand the result to
+    /// [`PlanetaryConstants::read_binary`](planetarylib::PlanetaryConstants::read_binary)
+    /// to build frames from it.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// let loader = starfield::Loader::new();
+    /// let pck = loader.open_binary_pck("moon_pa_de421_1900-2050.bpc").unwrap();
+    /// assert!(pck.segment_for(31006).is_some());
+    /// ```
+    pub fn open_binary_pck(&self, filename: &str) -> Result<jplephem::pck::PCK> {
+        let path = data::download_or_cache(filename, self.data_dir.as_deref())?;
+        Ok(jplephem::pck::PCK::open(path)?)
+    }
+
     /// Ensure a data file is available locally, downloading if needed.
     ///
     /// Returns the local path without opening or parsing the file.

--- a/src/planetarylib/mod.rs
+++ b/src/planetarylib/mod.rs
@@ -13,6 +13,10 @@
 //! Both produce the same [`RotationalElements`] type, so code can start with
 //! the embedded table and switch to a downloaded kernel without changing.
 //!
+//! [`PlanetaryConstants`] also holds the segments of binary PCK (`.bpc`)
+//! kernels, read with [`PlanetaryConstants::read_binary`], and turns them into
+//! the body-fixed frames of [`pck_frame`].
+//!
 //! # Example
 //!
 //! ```
@@ -25,17 +29,38 @@
 //!
 //! Evaluating the elements at a given time — turning them into a rotation
 //! matrix — is the job of the body-fixed frames, which land separately.
+//!
+//! # Example: the lunar principal-axes frame
+//!
+//! ```no_run
+//! use starfield::framelib::Frame;
+//! use starfield::Loader;
+//!
+//! let loader = Loader::new();
+//! let mut pc = loader.open_text_pck("moon_080317.tf").unwrap();
+//! pc.read_binary(loader.open_binary_pck("moon_pa_de421_1900-2050.bpc").unwrap());
+//!
+//! let frame = pc.build_frame_named("MOON_PA_DE421").unwrap();
+//! let ts = loader.timescale();
+//! println!("{}", frame.rotation_at(&ts.tdb_jd(2451545.0)));
+//! ```
 
+pub mod pck_frame;
 #[cfg(all(test, feature = "python-tests"))]
 mod python_tests;
 pub mod text_pck;
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
+use nalgebra::Matrix3;
+
+pub use pck_frame::PckFrame;
 pub use text_pck::KernelValue;
 
+use crate::constants::ASEC2RAD;
+use crate::jplephem::pck::{PckSegment, PCK};
 use crate::{Result, StarfieldError};
 
 /// The IAU WGCCRE shape and orientation constants of one body.
@@ -231,6 +256,15 @@ fn coefficients(values: &[f64]) -> Option<[f64; 3]> {
 /// The magic numbers that open a NAIF text kernel.
 const TEXT_MAGIC_NUMBERS: [&str; 2] = ["KPL/FK", "KPL/PCK"];
 
+/// The error for a kernel variable that a frame needs and no kernel defines.
+fn missing(name: &str) -> StarfieldError {
+    StarfieldError::DataError(format!(
+        "unknown planetary constant {:?}; read a text kernel that defines it, \
+         such as moon_080317.tf, or add it to the variables map by hand",
+        name
+    ))
+}
+
 /// The variables read from one or more NAIF text kernels.
 ///
 /// This mirrors Skyfield's `PlanetaryConstants`: text kernels are read into
@@ -251,6 +285,10 @@ const TEXT_MAGIC_NUMBERS: [&str; 2] = ["KPL/FK", "KPL/PCK"];
 pub struct PlanetaryConstants {
     /// Every name assigned by the kernels read so far.
     pub variables: HashMap<String, KernelValue>,
+    /// Every binary PCK segment read so far, in the order they were read.
+    segments: Vec<Arc<PckSegment>>,
+    /// The last segment read for each frame class id.
+    segment_map: HashMap<i32, Arc<PckSegment>>,
 }
 
 impl PlanetaryConstants {
@@ -289,6 +327,194 @@ impl PlanetaryConstants {
     pub fn open_text<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
         let text = std::fs::read_to_string(path)?;
         self.read_text(&text)
+    }
+
+    /// Take the segments of an already-opened binary PCK kernel.
+    ///
+    /// Binary PCK kernels are the `.bpc` files that say how a body is oriented
+    /// on a given date; each of their segments is filed here under its NAIF
+    /// frame class id, ready for [`build_frame`](Self::build_frame). A later
+    /// kernel covering the same frame replaces an earlier one, as it does in
+    /// Skyfield's `PlanetaryConstants.read_binary`.
+    pub fn read_binary(&mut self, pck: PCK) {
+        for segment in pck.into_segments() {
+            let segment = Arc::new(segment);
+            self.segment_map.insert(segment.body, Arc::clone(&segment));
+            self.segments.push(segment);
+        }
+    }
+
+    /// Read a binary PCK kernel from a file.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StarfieldError::EphemerisError`] if the file cannot be read
+    /// or is not a DAF.
+    pub fn open_binary<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
+        self.read_binary(PCK::open(path)?);
+        Ok(())
+    }
+
+    /// Every binary PCK segment read so far, in the order they were read.
+    pub fn segments(&self) -> &[Arc<PckSegment>] {
+        &self.segments
+    }
+
+    /// Build the body-fixed frame that a kernel name stands for.
+    ///
+    /// The name is resolved through the `FRAME_<NAME>` variable of a text
+    /// kernel, so `moon_080317.tf` must have been read before
+    /// `build_frame_named("MOON_PA_DE421")` can work.
+    ///
+    /// # Errors
+    ///
+    /// Returns the errors of [`build_frame`](Self::build_frame), and
+    /// [`StarfieldError::DataError`] if no text kernel defines the name.
+    pub fn build_frame_named(&self, name: &str) -> Result<PckFrame> {
+        let integer = self.frame_integer(&format!("FRAME_{}", name))?;
+        self.build_frame(integer)
+    }
+
+    /// Build the body-fixed frame of a NAIF frame class id.
+    ///
+    /// Well-known ids are 31006 for `MOON_PA_DE421`, 31008 for
+    /// `MOON_PA_DE440` and 3000 for `ITRF93`. When the id names a text-kernel
+    /// *TK frame* — one defined by a fixed offset from another frame, the way
+    /// `MOON_ME` is defined relative to `MOON_PA_DE421` — the offset is folded
+    /// into the frame and the search moves on to the frame it is relative to.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StarfieldError::DataError`] if the variables that define the
+    /// frame are missing or malformed, and
+    /// [`StarfieldError::ObjectNotFound`] if no binary PCK segment has been
+    /// read for the frame.
+    pub fn build_frame(&self, integer: i32) -> Result<PckFrame> {
+        let center = self.frame_integer(&format!("FRAME_{}_CENTER", integer))?;
+
+        let mut frame_id = integer;
+        let mut matrix = None;
+
+        if let Some(spec) = self
+            .variables
+            .get(&format!("TKFRAME_{}_SPEC", integer))
+            .and_then(|v| v.as_string())
+        {
+            matrix = Some(self.tkframe_matrix(integer, spec)?);
+            let relative = self
+                .variables
+                .get(&format!("TKFRAME_{}_RELATIVE", integer))
+                .and_then(|v| v.as_string())
+                .ok_or_else(|| missing(&format!("TKFRAME_{}_RELATIVE", integer)))?
+                .to_string();
+            frame_id = self.frame_integer(&format!("FRAME_{}", relative))?;
+        }
+
+        let segment = self.segment_map.get(&frame_id).ok_or_else(|| {
+            StarfieldError::ObjectNotFound(format!(
+                "no binary PCK segment has been read for frame {}",
+                frame_id
+            ))
+        })?;
+
+        // Every binary PCK NAIF publishes gives its angles relative to J2000,
+        // and that is the only reference frame the rotation below assumes.
+        if segment.frame != 1 {
+            return Err(StarfieldError::DataError(format!(
+                "frame {} is defined relative to reference frame {}, but only \
+                 J2000 (1) is supported",
+                frame_id, segment.frame
+            )));
+        }
+
+        Ok(PckFrame::new(center, Arc::clone(segment), matrix))
+    }
+
+    /// The fixed rotation of a text-kernel TK frame.
+    ///
+    /// Handles the two specifications Skyfield handles: `ANGLES`, a sequence
+    /// of rotations about numbered axes, and `MATRIX`, nine numbers in row
+    /// order.
+    fn tkframe_matrix(&self, integer: i32, spec: &str) -> Result<Matrix3<f64>> {
+        match spec {
+            "ANGLES" => {
+                let angles = self.required_numbers(&format!("TKFRAME_{}_ANGLES", integer))?;
+                let axes = self.required_numbers(&format!("TKFRAME_{}_AXES", integer))?;
+                let units = self
+                    .variables
+                    .get(&format!("TKFRAME_{}_UNITS", integer))
+                    .and_then(|v| v.as_string())
+                    .ok_or_else(|| missing(&format!("TKFRAME_{}_UNITS", integer)))?;
+                let scale = match units {
+                    "ARCSECONDS" => ASEC2RAD,
+                    other => {
+                        return Err(StarfieldError::DataError(format!(
+                            "TKFRAME_{}_UNITS is {:?}, which is not supported",
+                            integer, other
+                        )))
+                    }
+                };
+
+                if angles.len() != axes.len() {
+                    return Err(StarfieldError::DataError(format!(
+                        "TKFRAME_{} has {} angles but {} axes",
+                        integer,
+                        angles.len(),
+                        axes.len()
+                    )));
+                }
+
+                let mut matrix = Matrix3::identity();
+                for (angle, axis) in angles.iter().zip(axes.iter()) {
+                    let rotation = match *axis as i32 {
+                        1 => pck_frame::rot_x,
+                        2 => pck_frame::rot_y,
+                        3 => pck_frame::rot_z,
+                        other => {
+                            return Err(StarfieldError::DataError(format!(
+                                "TKFRAME_{}_AXES names axis {}, which is not 1, 2 or 3",
+                                integer, other
+                            )))
+                        }
+                    };
+                    matrix = rotation(angle * scale) * matrix;
+                }
+                Ok(matrix)
+            }
+            "MATRIX" => {
+                let values = self.required_numbers(&format!("TKFRAME_{}_MATRIX", integer))?;
+                if values.len() != 9 {
+                    return Err(StarfieldError::DataError(format!(
+                        "TKFRAME_{}_MATRIX has {} values, not 9",
+                        integer,
+                        values.len()
+                    )));
+                }
+                Ok(Matrix3::from_row_slice(&values))
+            }
+            other => Err(StarfieldError::DataError(format!(
+                "TKFRAME_{}_SPEC is {:?}, which is not supported",
+                integer, other
+            ))),
+        }
+    }
+
+    /// A variable that must exist and must be a single integer.
+    fn frame_integer(&self, name: &str) -> Result<i32> {
+        let value = self
+            .variables
+            .get(name)
+            .and_then(|v| v.as_number())
+            .ok_or_else(|| missing(name))?;
+        Ok(value as i32)
+    }
+
+    /// A variable that must exist and must be numeric.
+    fn required_numbers(&self, name: &str) -> Result<Vec<f64>> {
+        self.variables
+            .get(name)
+            .and_then(|v| v.to_numbers())
+            .ok_or_else(|| missing(name))
     }
 
     /// Look up one kernel variable by name.

--- a/src/planetarylib/pck_frame.rs
+++ b/src/planetarylib/pck_frame.rs
@@ -1,0 +1,522 @@
+//! Body-fixed frames read from a binary PCK kernel.
+//!
+//! A binary PCK (`.bpc`) stores the orientation of a frame as Chebyshev
+//! coefficients for three Euler angles; see
+//! [`jplephem::pck`](crate::jplephem::pck). [`PckFrame`] turns those angles
+//! into the rotation matrix that carries a vector from the reference frame of
+//! the segment — J2000 in every kernel NAIF publishes — into the body-fixed
+//! frame, and implements [`Frame`] so it can be used wherever the inertial and
+//! Earth-fixed frames of [`framelib`](crate::framelib) are.
+//!
+//! Build one with
+//! [`PlanetaryConstants::build_frame_named`](crate::planetarylib::PlanetaryConstants::build_frame_named),
+//! which is the port of Skyfield's `planetarylib.PlanetaryConstants`.
+//!
+//! This is the most accurate body-fixed frame available for the Moon: the
+//! lunar principal-axes frames `MOON_PA_DE421` (frame class id 31006) and
+//! `MOON_PA_DE440` (31008) come from the same fits as the ephemerides
+//! themselves, where the IAU rotational elements of
+//! [`RotationalElements`](crate::planetarylib::RotationalElements) are a
+//! truncated series. `ITRF93` (3000) is likewise published as a binary PCK,
+//! though for the Earth [`ItrsFrame`](crate::framelib::ItrsFrame) is the
+//! frame to prefer.
+
+use std::sync::Arc;
+
+use nalgebra::{Matrix3, Vector3};
+
+use crate::framelib::Frame;
+use crate::jplephem::pck::PckSegment;
+use crate::time::Time;
+use crate::Result;
+
+/// A body-fixed frame whose orientation comes from a binary PCK segment.
+///
+/// The rotation is Skyfield's `rot_z(-W) · rot_x(-δ) · rot_z(-α)` on the three
+/// angles the segment stores. Those angles are the SPICE Euler angles of the
+/// rotation itself, not the right ascension and declination of a pole, so no
+/// quarter turn is folded in here; that difference is what separates this
+/// frame from one built out of IAU rotational elements.
+///
+/// `matrix`, when present, is the fixed offset of a text-kernel *TK frame*
+/// defined relative to the PCK frame — the way `MOON_ME` is defined relative
+/// to `MOON_PA_DE421` in `moon_080317.tf`. It is applied on the left, after
+/// the PCK rotation.
+#[derive(Debug, Clone)]
+pub struct PckFrame {
+    /// NAIF id of the body at the centre of the frame, such as 301.
+    center: i32,
+    /// The segment supplying the Euler angles.
+    segment: Arc<PckSegment>,
+    /// Fixed rotation applied after the segment's, for TK frames.
+    matrix: Option<Matrix3<f64>>,
+}
+
+impl PckFrame {
+    /// Build a frame around one binary PCK segment.
+    ///
+    /// `center` is the NAIF id of the body the frame is fixed to, and
+    /// `matrix`, if given, is the constant TK-frame offset applied on the left
+    /// of the segment's rotation.
+    pub fn new(center: i32, segment: Arc<PckSegment>, matrix: Option<Matrix3<f64>>) -> Self {
+        Self {
+            center,
+            segment,
+            matrix,
+        }
+    }
+
+    /// NAIF id of the body at the centre of the frame.
+    pub fn center(&self) -> i32 {
+        self.center
+    }
+
+    /// The segment the angles are read from.
+    pub fn segment(&self) -> &PckSegment {
+        &self.segment
+    }
+
+    /// The constant TK-frame offset, if this frame has one.
+    pub fn matrix(&self) -> Option<&Matrix3<f64>> {
+        self.matrix.as_ref()
+    }
+
+    /// The rotation from the segment's reference frame to this frame at `t`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StarfieldError::EphemerisError`](crate::StarfieldError) if
+    /// `t` lies outside the span the segment covers, or if the segment is not
+    /// a supported data type.
+    pub fn try_rotation_at(&self, t: &Time) -> Result<Matrix3<f64>> {
+        let (angles, _rates) = self.segment.compute(t.tdb())?;
+        Ok(self.assemble(&angles))
+    }
+
+    /// The rotation and its rate of change at `t`.
+    ///
+    /// The second matrix is the derivative of the first with respect to time,
+    /// in units of one day, so `dR/dt · r` is the velocity a fixed body-frame
+    /// vector `r` acquires from the body's rotation, per day. Ported from
+    /// Skyfield's `planetarylib.Frame.rotation_and_rate_at`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StarfieldError::EphemerisError`](crate::StarfieldError) if
+    /// `t` lies outside the span the segment covers, or if the segment is not
+    /// a supported data type.
+    pub fn rotation_and_rate_at(&self, t: &Time) -> Result<(Matrix3<f64>, Matrix3<f64>)> {
+        let (angles, rates) = self.segment.compute(t.tdb())?;
+        let (ra, dec, w) = (angles[0], angles[1], angles[2]);
+        let (ra_dot, dec_dot, w_dot) = (rates[0], rates[1], rates[2]);
+
+        let r = rot_z(-w) * rot_x(-dec) * rot_z(-ra);
+
+        let (sa, ca) = w.sin_cos();
+        let u = dec.cos();
+        let v = -dec.sin();
+
+        let domega0 = w_dot + u * ra_dot;
+        let domega1 = ca * dec_dot - sa * v * ra_dot;
+        let domega2 = sa * dec_dot + ca * v * ra_dot;
+
+        #[rustfmt::skip]
+        let drdt_rt = Matrix3::new(
+                 0.0,  domega0,  domega2,
+            -domega0,      0.0,  domega1,
+            -domega2, -domega1,      0.0,
+        );
+
+        let dr_dt = drdt_rt * r;
+
+        Ok(match self.matrix {
+            Some(m) => (m * r, m * dr_dt),
+            None => (r, dr_dt),
+        })
+    }
+
+    /// Assemble the rotation matrix from three Euler angles in radians.
+    fn assemble(&self, angles: &Vector3<f64>) -> Matrix3<f64> {
+        let r = rot_z(-angles[2]) * rot_x(-angles[1]) * rot_z(-angles[0]);
+        match self.matrix {
+            Some(m) => m * r,
+            None => r,
+        }
+    }
+}
+
+impl Frame for PckFrame {
+    /// The rotation from the segment's reference frame — J2000 in the kernels
+    /// NAIF publishes — to this body-fixed frame.
+    ///
+    /// The [`Frame`] trait cannot report an error, so an epoch the kernel does
+    /// not cover produces a matrix of `NaN`. Call
+    /// [`try_rotation_at`](Self::try_rotation_at) to see the error instead.
+    fn rotation_at(&self, t: &Time) -> Matrix3<f64> {
+        self.try_rotation_at(t)
+            .unwrap_or_else(|_| Matrix3::from_element(f64::NAN))
+    }
+}
+
+/// Rotation of `angle` radians about the x axis.
+///
+/// The same convention as Skyfield's `functions.rot_x`: the matrix rotates a
+/// vector counter-clockwise about the axis, as seen looking down the axis
+/// toward the origin.
+pub(crate) fn rot_x(angle: f64) -> Matrix3<f64> {
+    let (s, c) = angle.sin_cos();
+    #[rustfmt::skip]
+    let m = Matrix3::new(
+        1.0, 0.0, 0.0,
+        0.0,   c,  -s,
+        0.0,   s,   c,
+    );
+    m
+}
+
+/// Rotation of `angle` radians about the y axis, in the convention of
+/// Skyfield's `functions.rot_y`.
+pub(crate) fn rot_y(angle: f64) -> Matrix3<f64> {
+    let (s, c) = angle.sin_cos();
+    #[rustfmt::skip]
+    let m = Matrix3::new(
+          c, 0.0,   s,
+        0.0, 1.0, 0.0,
+         -s, 0.0,   c,
+    );
+    m
+}
+
+/// Rotation of `angle` radians about the z axis, in the convention of
+/// Skyfield's `functions.rot_z`.
+pub(crate) fn rot_z(angle: f64) -> Matrix3<f64> {
+    let (s, c) = angle.sin_cos();
+    #[rustfmt::skip]
+    let m = Matrix3::new(
+          c,  -s, 0.0,
+          s,   c, 0.0,
+        0.0, 0.0, 1.0,
+    );
+    m
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jplephem::pck::test_support;
+    use crate::planetarylib::PlanetaryConstants;
+    use nalgebra::{Rotation3, Vector3};
+
+    /// The sign convention of the `rot_*` helpers, checked before anything is
+    /// built on top of them.
+    ///
+    /// Skyfield's `functions.rot_z(theta)` is
+    /// `[[c, -s, 0], [s, c, 0], [0, 0, 1]]`, which is the active,
+    /// right-handed rotation: it carries the x axis a quarter turn toward the
+    /// y axis when `theta` is a quarter turn. nalgebra's
+    /// `Rotation3::from_axis_angle` is the independent witness.
+    #[test]
+    fn test_rotation_sign_convention_matches_skyfield() {
+        let angle = 0.3;
+        for (ours, axis) in [
+            (rot_x(angle), Vector3::x_axis()),
+            (rot_y(angle), Vector3::y_axis()),
+            (rot_z(angle), Vector3::z_axis()),
+        ] {
+            let theirs = *Rotation3::from_axis_angle(&axis, angle).matrix();
+            assert!(
+                (ours - theirs).abs().max() < 1e-15,
+                "rot about {axis:?} disagrees with nalgebra:\n{ours}\n{theirs}"
+            );
+        }
+
+        // Skyfield's literal matrices, spelled out.
+        let (s, c) = angle.sin_cos();
+        assert_eq!(
+            rot_z(angle),
+            Matrix3::new(c, -s, 0.0, s, c, 0.0, 0.0, 0.0, 1.0)
+        );
+        assert_eq!(
+            rot_x(angle),
+            Matrix3::new(1.0, 0.0, 0.0, 0.0, c, -s, 0.0, s, c)
+        );
+
+        // A quarter turn about z sends x̂ to ŷ.
+        let quarter = rot_z(std::f64::consts::FRAC_PI_2) * Vector3::x();
+        assert!((quarter - Vector3::y()).norm() < 1e-15);
+    }
+
+    /// The rotation matrices Skyfield produces for `MOON_PA_DE421` at three
+    /// epochs, from `moon_pa_de421_1900-2050.bpc` and `moon_080317.tf`:
+    ///
+    /// ```python
+    /// pc = PlanetaryConstants()
+    /// pc.read_text(load('moon_080317.tf'))
+    /// pc.read_binary(load('moon_pa_de421_1900-2050.bpc'))
+    /// pc.build_frame_named('MOON_PA_DE421').rotation_at(ts.tdb(y, m, d))
+    /// ```
+    ///
+    /// Each entry is a TDB Julian date and the nine elements of the matrix in
+    /// row order.
+    const MOON_PA_DE421_GOLDEN: [(f64, [f64; 9]); 3] = [
+        (
+            2451544.5,
+            [
+                0.850042543689892,
+                0.4719025905658242,
+                0.2339564466615154,
+                -0.5262425521270344,
+                0.7796926815587792,
+                0.3393347884530935,
+                -0.022281163525359693,
+                -0.41156684431686724,
+                0.9111071739433357,
+            ],
+        ),
+        (
+            2455362.5,
+            [
+                0.48606359354917644,
+                -0.7988143368227282,
+                -0.35445428240116666,
+                0.8735378827586621,
+                0.4561395395613729,
+                0.1699067033234794,
+                0.025956702632943758,
+                -0.3922147061689602,
+                0.9195074082644583,
+            ],
+        ),
+        (
+            2460735.5,
+            [
+                -0.9971502695940774,
+                0.06991210219677377,
+                0.028348506396042604,
+                -0.07544066971979335,
+                -0.925127101746052,
+                -0.37208675193720486,
+                0.00021260453350083338,
+                -0.37316503531464174,
+                0.9277649547261065,
+            ],
+        ),
+    ];
+
+    /// Skyfield's `MOON_ME_DE421` rotation at 2000-01-01 TDB: the same segment
+    /// seen through the TK-frame offset that `moon_080317.tf` defines.
+    const MOON_ME_DE421_GOLDEN: [f64; 9] = [
+        0.8502072337338002,
+        0.47148903601337244,
+        0.23419169205140472,
+        -0.5259625840805721,
+        0.7798486288034029,
+        0.33941048348679465,
+        -0.02260574825141532,
+        -0.41174531578711776,
+        0.9110185371732895,
+    ];
+
+    /// The angles Skyfield reads from the `MOON_PA_DE421` segment at
+    /// 2000-01-01 TDB, in radians.
+    const MOON_PA_DE421_ANGLES: [f64; 3] = [
+        -0.054084614394338155,
+        0.42483397988172855,
+        2564.1432197564877,
+    ];
+
+    /// Their rates at the same epoch, in radians per day.
+    const MOON_PA_DE421_RATES: [f64; 3] = [
+        -0.00013824229206887688,
+        4.2546358627903764e-05,
+        0.23011790298638823,
+    ];
+
+    /// The two kernels the ignored tests need, read from the data directory or
+    /// downloaded into it.
+    fn moon_constants() -> PlanetaryConstants {
+        let loader = crate::Loader::new();
+        let mut pc = loader.open_text_pck("moon_080317.tf").unwrap();
+        pc.read_binary(
+            loader
+                .open_binary_pck("moon_pa_de421_1900-2050.bpc")
+                .unwrap(),
+        );
+        pc
+    }
+
+    /// Compare a rotation with a golden matrix, element by element.
+    fn assert_matches(actual: &Matrix3<f64>, expected: &[f64; 9], tolerance: f64, label: &str) {
+        for row in 0..3 {
+            for column in 0..3 {
+                let want = expected[row * 3 + column];
+                let got = actual[(row, column)];
+                assert!(
+                    (got - want).abs() < tolerance,
+                    "{label}: element ({row}, {column}) is {got}, expected {want}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    #[ignore = "downloads moon_pa_de421_1900-2050.bpc and moon_080317.tf"]
+    fn test_moon_pa_de421_matches_skyfield() {
+        let pc = moon_constants();
+        let frame = pc.build_frame_named("MOON_PA_DE421").unwrap();
+        assert_eq!(frame.center(), 301);
+        assert!(frame.matrix().is_none());
+        assert_eq!(frame.segment().body, 31006);
+        assert_eq!(frame.segment().frame, 1);
+
+        let ts = crate::time::Timescale::default();
+        for (jd, expected) in MOON_PA_DE421_GOLDEN {
+            let t = ts.tdb_jd(jd);
+            assert_matches(&frame.rotation_at(&t), &expected, 1e-9, &format!("JD {jd}"));
+        }
+    }
+
+    #[test]
+    #[ignore = "downloads moon_pa_de421_1900-2050.bpc and moon_080317.tf"]
+    fn test_moon_pa_de421_angles_and_rates_match_skyfield() {
+        let pc = moon_constants();
+        let frame = pc.build_frame_named("MOON_PA_DE421").unwrap();
+        let ts = crate::time::Timescale::default();
+
+        let (angles, rates) = frame.segment().compute(2451544.5).unwrap();
+        for i in 0..3 {
+            assert!((angles[i] - MOON_PA_DE421_ANGLES[i]).abs() < 1e-9);
+            assert!((rates[i] - MOON_PA_DE421_RATES[i]).abs() < 1e-12);
+        }
+
+        let t = ts.tdb_jd(2451544.5);
+        let (rotation, rate) = frame.rotation_and_rate_at(&t).unwrap();
+        assert_matches(&rotation, &MOON_PA_DE421_GOLDEN[0].1, 1e-9, "rotation");
+
+        // The rate matrix must be the derivative of the rotation, so a central
+        // difference over a minute has to reproduce it.
+        let h = 1.0 / 1440.0;
+        let ahead = frame.try_rotation_at(&ts.tdb_jd(2451544.5 + h)).unwrap();
+        let behind = frame.try_rotation_at(&ts.tdb_jd(2451544.5 - h)).unwrap();
+        let numeric = (ahead - behind) / (2.0 * h);
+        assert!(
+            (rate - numeric).abs().max() < 1e-6,
+            "rate matrix disagrees with a central difference:\n{rate}\n{numeric}"
+        );
+    }
+
+    #[test]
+    #[ignore = "downloads moon_pa_de421_1900-2050.bpc and moon_080317.tf"]
+    fn test_moon_me_de421_applies_the_tk_offset() {
+        let pc = moon_constants();
+        let frame = pc.build_frame_named("MOON_ME_DE421").unwrap();
+
+        // MOON_ME_DE421 is frame 31007, a TK frame defined by three small
+        // rotations away from MOON_PA_DE421, which is the frame the kernel
+        // actually carries.
+        assert_eq!(frame.segment().body, 31006);
+        let matrix = frame.matrix().expect("the TK offset should be present");
+        assert!((matrix - Matrix3::identity()).abs().max() < 1e-3);
+
+        let t = crate::time::Timescale::default().tdb_jd(2451544.5);
+        assert_matches(
+            &frame.rotation_at(&t),
+            &MOON_ME_DE421_GOLDEN,
+            1e-9,
+            "MOON_ME_DE421",
+        );
+    }
+
+    #[test]
+    #[ignore = "downloads moon_pa_de421_1900-2050.bpc and moon_080317.tf"]
+    fn test_an_epoch_outside_the_kernel_is_an_error() {
+        let pc = moon_constants();
+        let frame = pc.build_frame_named("MOON_PA_DE421").unwrap();
+        let t = crate::time::Timescale::default().tdb_jd(2000000.5);
+
+        assert!(frame.try_rotation_at(&t).is_err());
+        assert!(frame.rotation_at(&t)[(0, 0)].is_nan());
+    }
+
+    #[test]
+    fn test_a_frame_built_from_a_synthetic_kernel() {
+        let pck = crate::jplephem::pck::PCK::from_bytes(&test_support::one_day_pck(2)).unwrap();
+        let mut pc = PlanetaryConstants::new();
+        pc.read_text(
+            "KPL/FK\n\\begindata\nFRAME_MOON_PA_DE421 = 31006\n\
+             FRAME_31006_CENTER = 301\n\\begintext\n",
+        )
+        .unwrap();
+        pc.read_binary(pck);
+        assert_eq!(pc.segments().len(), 1);
+
+        let frame = pc.build_frame_named("MOON_PA_DE421").unwrap();
+        assert_eq!(frame.center(), 301);
+
+        let t = crate::time::Timescale::default().tdb_jd(2451545.25);
+        let (angles, _) = frame.segment().compute(2451545.25).unwrap();
+        let expected = rot_z(-angles[2]) * rot_x(-angles[1]) * rot_z(-angles[0]);
+        assert!((frame.rotation_at(&t) - expected).abs().max() < 1e-15);
+        assert!((frame.rotation_at(&t).determinant() - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_a_tk_frame_folds_in_its_offset() {
+        let pck = crate::jplephem::pck::PCK::from_bytes(&test_support::one_day_pck(2)).unwrap();
+        let mut pc = PlanetaryConstants::new();
+        pc.read_text(
+            "KPL/FK\n\\begindata\n\
+             FRAME_MOON_PA_DE421 = 31006\n\
+             FRAME_31006_CENTER = 301\n\
+             FRAME_MOON_ME_DE421 = 31007\n\
+             FRAME_31007_CENTER = 301\n\
+             TKFRAME_31007_RELATIVE = 'MOON_PA_DE421'\n\
+             TKFRAME_31007_SPEC = 'ANGLES'\n\
+             TKFRAME_31007_ANGLES = ( 67.92, 78.56, 0.30 )\n\
+             TKFRAME_31007_AXES = ( 3, 2, 1 )\n\
+             TKFRAME_31007_UNITS = 'ARCSECONDS'\n\
+             \\begintext\n",
+        )
+        .unwrap();
+        pc.read_binary(pck);
+
+        let frame = pc.build_frame_named("MOON_ME_DE421").unwrap();
+        assert_eq!(frame.segment().body, 31006);
+
+        // The three angles are the ones moon_080317.tf gives, applied in the
+        // order z, y, x, each on the left of the last.
+        let scale = crate::constants::ASEC2RAD;
+        let expected = rot_x(0.30 * scale) * rot_y(78.56 * scale) * rot_z(67.92 * scale);
+        let matrix = frame.matrix().expect("the TK offset should be present");
+        assert!((matrix - expected).abs().max() < 1e-15);
+
+        let plain = pc.build_frame_named("MOON_PA_DE421").unwrap();
+        let t = crate::time::Timescale::default().tdb_jd(2451545.0);
+        assert!(
+            (frame.rotation_at(&t) - expected * plain.rotation_at(&t))
+                .abs()
+                .max()
+                < 1e-15
+        );
+    }
+
+    #[test]
+    fn test_a_frame_with_no_segment_is_an_error() {
+        let mut pc = PlanetaryConstants::new();
+        pc.read_text(
+            "KPL/FK\n\\begindata\nFRAME_MOON_PA_DE421 = 31006\n\
+             FRAME_31006_CENTER = 301\n\\begintext\n",
+        )
+        .unwrap();
+        assert!(pc.build_frame_named("MOON_PA_DE421").is_err());
+        assert!(pc.build_frame_named("NO_SUCH_FRAME").is_err());
+    }
+
+    #[test]
+    fn test_rotations_are_orthonormal() {
+        for m in [rot_x(1.1), rot_y(-0.4), rot_z(2.7)] {
+            assert!((m * m.transpose() - Matrix3::identity()).abs().max() < 1e-15);
+            assert!((m.determinant() - 1.0).abs() < 1e-15);
+        }
+    }
+}

--- a/src/planetarylib/python_tests.rs
+++ b/src/planetarylib/python_tests.rs
@@ -1,14 +1,24 @@
-//! Python comparison tests for the text kernel parser.
+//! Python comparison tests for the text kernel parser and the binary PCK
+//! frames.
 //!
 //! These compare [`PlanetaryConstants::read_text`] against Skyfield's
 //! `skyfield.planetarylib.PlanetaryConstants.read_text` on the checked-in
-//! excerpt of `pck00011.tpc`, so both parsers see exactly the same bytes.
+//! excerpt of `pck00011.tpc`, so both parsers see exactly the same bytes, and
+//! compare [`PckFrame`](crate::planetarylib::PckFrame) against Skyfield's
+//! `planetarylib.Frame` on the lunar principal-axes kernel. The kernel tests
+//! are `#[ignore]`d because they need a download; the same numbers are checked
+//! in as golden matrices in `pck_frame.rs`.
 
 #[cfg(test)]
 mod tests {
+    use crate::framelib::Frame;
     use crate::planetarylib::{KernelValue, PlanetaryConstants};
     use crate::pybridge::{PyRustBridge, PythonResult};
     use std::collections::HashMap;
+
+    /// The three epochs both implementations are asked about, as TDB Julian
+    /// dates: 2000-01-01, 2010-06-15 and 2025-03-01.
+    const EPOCHS: [f64; 3] = [2451544.5, 2455362.5, 2460735.5];
 
     /// The excerpt both parsers read, relative to the crate root.
     const EXCERPT_PATH: &str = "src/planetarylib/pck00011_excerpt.tpc";
@@ -123,5 +133,65 @@ rust.collect_string(json.dumps({{
         let parsed = unwrap_py_json(&bridge.run_py_to_json(&code).expect("Skyfield parse failed"));
         assert_eq!(parsed["scalar"].as_bool(), Some(false));
         assert_eq!(parsed["vector"].as_bool(), Some(true));
+    }
+
+    /// `PckFrame` reproduces Skyfield's `MOON_PA_DE421` rotation matrices.
+    ///
+    /// Both sides read the same two kernels from the data directory, so the
+    /// only thing under test is the interpolation and the assembly of the
+    /// matrix.
+    #[test]
+    #[ignore = "downloads moon_pa_de421_1900-2050.bpc and moon_080317.tf"]
+    fn test_moon_pa_frame_matches_skyfield() {
+        let loader = crate::Loader::new();
+        let text_path = loader.ensure_file("moon_080317.tf").unwrap();
+        let binary_path = loader.ensure_file("moon_pa_de421_1900-2050.bpc").unwrap();
+
+        let mut pc = PlanetaryConstants::new();
+        pc.open_text(&text_path).unwrap();
+        pc.open_binary(&binary_path).unwrap();
+        let frame = pc.build_frame_named("MOON_PA_DE421").unwrap();
+
+        let bridge = PyRustBridge::new().expect("Failed to create Python bridge");
+        let code = format!(
+            r#"
+import json
+from skyfield.api import load
+from skyfield.planetarylib import PlanetaryConstants
+
+ts = load.timescale()
+pc = PlanetaryConstants()
+pc.read_text(open('{text}', 'rb'))
+pc.read_binary(open('{binary}', 'rb'))
+frame = pc.build_frame_named('MOON_PA_DE421')
+
+out = []
+for jd in {epochs:?}:
+    out.append([float(x) for x in frame.rotation_at(ts.tdb_jd(jd)).flatten()])
+
+rust.collect_string(json.dumps(out))
+"#,
+            text = text_path.display(),
+            binary = binary_path.display(),
+            epochs = EPOCHS,
+        );
+
+        let parsed = unwrap_py_json(&bridge.run_py_to_json(&code).expect("Skyfield frame failed"));
+        let rows = parsed.as_array().expect("expected a JSON array");
+        assert_eq!(rows.len(), EPOCHS.len());
+
+        let ts = crate::time::Timescale::default();
+        for (jd, expected) in EPOCHS.iter().zip(rows) {
+            let rotation = frame.rotation_at(&ts.tdb_jd(*jd));
+            let expected = expected.as_array().expect("expected a JSON array");
+            for (i, want) in expected.iter().enumerate() {
+                let want = want.as_f64().expect("expected a number");
+                let got = rotation[(i / 3, i % 3)];
+                assert!(
+                    (got - want).abs() < 1e-9,
+                    "JD {jd}: element {i} is {got}, Skyfield says {want}"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

PR 8 of `docs/solar-system-bodies-plan.md` (#158): read binary PCK (`.bpc`) kernels and turn them into body-fixed frames.

- **`jplephem::pck`** — the 24-line stub is replaced by a port of python `jplephem/pck.py`. `PCK::open` / `PCK::from_bytes` parse the DAF summaries into `PckSegment { body, frame, data_type, start_jd, end_jd, … }`, and `PckSegment::compute(tdb_jd)` returns the three SPICE Euler angles in radians and their rates in radians per day. Data types other than 2 return `UnsupportedDataType`. Coefficients are read lazily, so a segment computes through `&self` and a frame can hold one behind an `Arc`. `Display`/`Debug`/`describe` follow `SPK`'s style, and `frame_name` knows 3000 = ITRF93, 31006 = MOON_PA_DE421, 31008 = MOON_PA_DE440.
- **Shared record reader** — the type 2/3 record layout moves out of `spk.rs` into `chebyshev::ChebyshevRecords`, which both SPK and PCK now use, so there is one copy of the array parsing, the record lookup and the coefficient slicing.
- **`PlanetaryConstants`** — `read_binary(PCK)` / `open_binary(path)` file segments by frame class id, and `build_frame(id)` / `build_frame_named(name)` mirror Skyfield's constructors, including TK frames specified by `ANGLES` (with `ARCSECONDS` units) or `MATRIX` and resolved through `TKFRAME_<id>_RELATIVE`.
- **`planetarylib::pck_frame::PckFrame`** — implements `framelib::Frame` as Skyfield's `rot_z(-W) · rot_x(-dec) · rot_z(-ra)` on the raw segment angles, with the TK offset applied on the left. `try_rotation_at` surfaces the out-of-range error the trait cannot; `rotation_at` yields `NaN` there. `rotation_and_rate_at` ports Skyfield's rate matrix, per day.
- **`Loader::open_binary_pck`** resolves `.bpc` files through the data dir like `open_text_pck`, and `resolve_url` learns `.tf` frame kernels via a new `NAIF_FK_SATELLITES_URL` (NAIF's `fk/satellites/` directory, where `moon_080317.tf` lives).
- **`examples/moon_pa_frame.rs`** downloads or reuses `moon_pa_de421_1900-2050.bpc` and `moon_080317.tf`, then prints the angles, rates and rotation of `MOON_PA_DE421` at three epochs, plus how far `MOON_ME_DE421` sits from it.

The sign convention was checked before anything was built on it: this crate's `rot_x`/`rot_z` match Skyfield's `functions.rot_x`/`rot_z` exactly, and a unit test asserts both the literal matrices and agreement with nalgebra's `Rotation3::from_axis_angle`.

## Test plan

- `cargo fmt --check`, `cargo clippy` clean for the touched files (the pre-existing warnings in `gaia_downloader.rs` / `iraf.rs` and the three `--all-targets` clippy errors in `catalogs`, `coordinates` and `sbdb` test code are untouched).
- `cargo test` — 666 passed, 0 failed, 23 ignored.
- `cargo test --doc` — 76 passed, 0 failed.
- `cargo test --features python-tests --lib` — 778 passed, 1 failed: the pre-existing `test_surface_brightness_at_matches_astropy_sersic2d_via_bridge`, which needs astropy in the local venv.
- Unit tests parse and interpolate a synthetic in-memory DAF/PCK built by a new `#[cfg(test)] test_support` module: record metadata, angles and rates against hand-checked Chebyshev values, record selection, both ends of a record, out-of-range and unsupported-type errors.
- Golden vectors: `MOON_PA_DE421` rotation matrices at 2000-01-01, 2010-06-15 and 2025-03-01 TDB, produced once from Skyfield, are checked in as constants and compared elementwise at 1e-9, together with the `MOON_ME_DE421` TK-frame matrix and the angles and rates at J2000. The kernel-reading tests are `#[ignore]`d; run locally with `--ignored` all five pass, including the live pybridge comparison against `PlanetaryConstants.build_frame_named('MOON_PA_DE421').rotation_at(t)`. No `.bpc` files are checked in.

Closes #158