### PR TITLE
Add Position::observe_star for catalog star places

### DIFF
--- a/examples/observe_star.rs
+++ b/examples/observe_star.rs
@@ -1,0 +1,65 @@
+//! Apparent place of a catalog star from two different observers
+//!
+//! `Position::observe_star` gives the direction to a catalog star from any
+//! barycentric observer, so star and planet directions come out in the same
+//! apparent frame. Sirius is shown from Earth and from Mars on the same date:
+//! the two differ mostly by the difference of the observers' aberration, a few
+//! arcseconds, which is what a star tracker at Mars has to allow for.
+//!
+//! Usage: cargo run --example observe_star
+
+use starfield::catalogs::StarData;
+use starfield::jplephem::kernel::SpiceKernel;
+use starfield::jplephem_ext::SpiceKernelExt;
+use starfield::{ProperMotion, Timescale};
+
+fn main() {
+    let mut kernel = match SpiceKernel::open("test_data/de421.bsp") {
+        Ok(k) => k,
+        Err(e) => {
+            eprintln!("Could not open test_data/de421.bsp: {e}");
+            return;
+        }
+    };
+
+    let ts = Timescale::default();
+    let t = ts.utc((2024, 1, 1, 0, 0, 0.0));
+
+    // Sirius (HIP 32349), Hipparcos astrometry at epoch J2000.0.
+    let sirius = StarData::new(32349, 101.2874, -16.7161, -1.46, None);
+    let pm = ProperMotion::new(-546.01, -1223.07);
+    let parallax_mas = 379.21;
+
+    println!("Apparent place of Sirius on 2024-01-01 00:00 UTC");
+    println!("================================================\n");
+    println!(
+        "Catalog (J2000): RA {:>12.6}°  Dec {:>12.6}°",
+        sirius.ra_deg(),
+        sirius.dec_deg()
+    );
+
+    let mut places = Vec::new();
+    for body in ["earth", "mars"] {
+        let observer = kernel.at(body, &t).expect("body missing from DE421");
+        let apparent = observer
+            .observe_star(&sirius, Some(&pm), Some(parallax_mas), &t)
+            .apparent(&mut kernel, &t)
+            .expect("apparent place");
+
+        let (ra_hours, dec_deg, distance_au) = apparent.radec(None);
+        let speed_km_s = observer.velocity.norm() * 149_597_870.7 / 86_400.0;
+
+        println!(
+            "\nFrom {body:<6} (barycentric speed {speed_km_s:.2} km/s)\n  \
+             RA {:>12.6}°  Dec {:>12.6}°  distance {:.0} AU",
+            ra_hours * 15.0,
+            dec_deg,
+            distance_au
+        );
+        places.push(apparent);
+    }
+
+    let separation_arcsec = places[0].separation_from(&places[1]).to_degrees() * 3600.0;
+    println!("\nEarth vs Mars apparent direction: {separation_arcsec:.2}″");
+    println!("(aberration difference plus the small parallax of a 2.6 pc star)");
+}

--- a/src/positions/mod.rs
+++ b/src/positions/mod.rs
@@ -22,6 +22,7 @@
 pub mod angular_size;
 pub mod ecliptic;
 pub mod illumination;
+pub mod stars;
 
 #[cfg(all(test, feature = "python-tests"))]
 mod python_tests;

--- a/src/positions/stars.rs
+++ b/src/positions/stars.rs
@@ -1,0 +1,288 @@
+//! Apparent places of catalog stars for an arbitrary observer
+//!
+//! Port of Skyfield's `Star._observe_from_bcrs()` in the shape the catalog
+//! types of this crate use: a [`StarData`] row, an optional
+//! [`ProperMotion`], and an optional parallax.  The observer is any
+//! barycentric [`Position`] — a planet from an SPK kernel, a ground site
+//! from `toposlib`, or a spacecraft — so a star direction can be obtained in
+//! the same frame, and with the same aberration, as a planet observed from
+//! that observer.
+//!
+//! The returned position is [`PositionKind::Astrometric`] with
+//! `observer_barycentric` populated, so it flows through the ordinary
+//! [`Position::apparent`] pipeline:
+//!
+//! ```ignore
+//! let mars = kernel.at("mars", &t)?;
+//! let star = StarData::new(32349, 101.2874, -16.7161, -1.46, None);
+//! let pm = ProperMotion::new(-546.01, -1223.07);
+//! let apparent = mars
+//!     .observe_star(&star, Some(&pm), Some(379.21), &t)
+//!     .apparent(&mut kernel, &t)?;
+//! ```
+//!
+//! An observer moving with Mars picks up roughly 17″ of stellar aberration
+//! (Mars's ~24 km/s orbital speed divided by the speed of light), exactly as
+//! the planets observed from the same position do.
+
+use crate::catalogs::StarData;
+use crate::framelib::inertial::ProperMotion;
+use crate::positions::{Position, PositionKind};
+use crate::starlib::Star;
+use crate::time::Time;
+
+/// Target id given to catalog stars.
+///
+/// Stars have no NAIF body id.  This crate labels every star position with
+/// the sentinel `-1`, which is outside the range of ephemeris body ids that
+/// [`Position::observe`] can produce and is the value
+/// [`Star::observe_from`](crate::starlib::Star::observe_from) has always
+/// used.  Consumers that need to tell stars apart from solar-system targets
+/// should compare `position.target` against this constant.
+pub const STAR_TARGET_ID: i32 = -1;
+
+impl Position {
+    /// Astrometric direction from this observer to a catalog star.
+    ///
+    /// The catalog position in `star` is taken to refer to epoch J2000.0
+    /// (the ICRS reference epoch).  It is carried forward to `epoch` with the
+    /// supplied proper motion, placed at the distance implied by
+    /// `parallax_mas`, and differenced against this observer's barycentric
+    /// position — so both proper motion and annual parallax are applied.
+    /// A star with no parallax is placed at one gigaparsec, following
+    /// Skyfield, which makes the parallax term vanish without special-casing
+    /// it.
+    ///
+    /// # Arguments
+    /// * `star` — catalog row supplying ICRS right ascension and declination
+    /// * `pm` — proper motion in mas/yr (`pmra` already includes cos δ);
+    ///   `None` means the star is treated as fixed
+    /// * `parallax_mas` — parallax in milliarcseconds; `None` or a
+    ///   non-positive value places the star at one gigaparsec
+    /// * `epoch` — the time of observation
+    ///
+    /// `StarData` carries no radial velocity, so the Doppler factor that
+    /// Skyfield folds into the space motion is 1.  For a star with a known
+    /// radial velocity, build a [`Star`](crate::starlib::Star) directly and
+    /// call [`Star::observe_from`](crate::starlib::Star::observe_from), which
+    /// takes `radial_km_per_s` and accepts a non-J2000 catalog epoch through
+    /// [`Star::with_epoch`](crate::starlib::Star::with_epoch).
+    ///
+    /// # Panics
+    /// Panics if this position is not [`PositionKind::Barycentric`], because
+    /// proper motion and parallax are only meaningful against a barycentric
+    /// observer.
+    pub fn observe_star(
+        &self,
+        star: &StarData,
+        pm: Option<&ProperMotion>,
+        parallax_mas: Option<f64>,
+        epoch: &Time,
+    ) -> Position {
+        assert_eq!(
+            self.kind,
+            PositionKind::Barycentric,
+            "observe_star() requires a Barycentric position"
+        );
+
+        let pm = pm.copied().unwrap_or(ProperMotion::ZERO);
+        let star = Star::new(
+            star.ra_deg(),
+            star.dec_deg(),
+            pm.pmra,
+            pm.pmdec,
+            parallax_mas.unwrap_or(0.0),
+            0.0,
+        );
+        star.observe_from(self, epoch)
+    }
+}
+
+#[cfg(all(test, feature = "python-tests"))]
+mod python_tests;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::C_AUDAY;
+    use crate::jplephem::kernel::SpiceKernel;
+    use crate::jplephem_ext::SpiceKernelExt;
+    use crate::time::Timescale;
+    use nalgebra::Vector3;
+
+    /// Radians in one arcsecond
+    const ARCSEC: f64 = std::f64::consts::PI / 180.0 / 3600.0;
+
+    fn de421_kernel() -> SpiceKernel {
+        SpiceKernel::open("test_data/de421.bsp").expect("Failed to open DE421")
+    }
+
+    /// Sirius, from the Hipparcos entries embedded in `catalogs::hipparcos`.
+    fn sirius() -> (StarData, ProperMotion, f64) {
+        (
+            StarData::new(32349, 101.2874, -16.7161, -1.46, None),
+            ProperMotion::new(-546.01, -1223.07),
+            379.21,
+        )
+    }
+
+    #[test]
+    fn test_observe_star_is_astrometric() {
+        let mut kernel = de421_kernel();
+        let ts = Timescale::default();
+        let t = ts.tdb_jd(2451545.0);
+        let earth = kernel.at("earth", &t).unwrap();
+
+        let (star, pm, plx) = sirius();
+        let astro = earth.observe_star(&star, Some(&pm), Some(plx), &t);
+
+        assert_eq!(astro.kind, PositionKind::Astrometric);
+        assert_eq!(astro.target, STAR_TARGET_ID);
+        assert_eq!(astro.center, 399);
+        assert!(astro.observer_barycentric.is_some());
+        assert!(astro.light_time > 0.0);
+        // Distance to Sirius is 2.64 pc = 5.4e5 AU
+        assert!(
+            astro.distance() > 4.0e5 && astro.distance() < 7.0e5,
+            "Sirius distance {} AU",
+            astro.distance()
+        );
+        assert!((astro.light_time - astro.distance() / C_AUDAY).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_observe_star_apparent_pipeline() {
+        let mut kernel = de421_kernel();
+        let ts = Timescale::default();
+        let t = ts.tdb_jd(2451545.0);
+        let earth = kernel.at("earth", &t).unwrap();
+
+        let (star, pm, plx) = sirius();
+        let apparent = earth
+            .observe_star(&star, Some(&pm), Some(plx), &t)
+            .apparent(&mut kernel, &t)
+            .unwrap();
+
+        assert_eq!(apparent.kind, PositionKind::Apparent);
+        let (ra_h, dec_d, _) = apparent.radec(None);
+        // Sirius: 6h45m, -16.7 degrees, shifted at most ~20" by aberration
+        assert!((ra_h - 101.2874 / 15.0).abs() < 0.01, "RA {ra_h} h");
+        assert!((dec_d + 16.7161).abs() < 0.01, "Dec {dec_d} deg");
+    }
+
+    #[test]
+    fn test_zero_motion_returns_catalog_direction() {
+        let mut kernel = de421_kernel();
+        let ts = Timescale::default();
+        let t = ts.tdb_jd(2451545.0);
+        let earth = kernel.at("earth", &t).unwrap();
+
+        // No proper motion, no parallax: the star sits at one gigaparsec and
+        // the astrometric direction is the catalog direction, to well under a
+        // microarcsecond, whatever the observer does.
+        let star = StarData::new(1, 123.456, -45.678, 5.0, None);
+        let astro = earth.observe_star(&star, None, None, &t);
+        let (ra_h, dec_d, _) = astro.radec(None);
+
+        assert!(
+            (ra_h * 15.0 - 123.456).abs() < 1e-9,
+            "RA {} deg",
+            ra_h * 15.0
+        );
+        assert!((dec_d + 45.678).abs() < 1e-9, "Dec {dec_d} deg");
+    }
+
+    /// A star seen from Mars is aberrated by |v|/c relative to the same star
+    /// seen from a motionless observer at the solar system barycenter.
+    #[test]
+    fn test_aberration_from_mars_matches_v_over_c() {
+        let mut kernel = de421_kernel();
+        let ts = Timescale::default();
+        let t = ts.tdb_jd(2451545.0);
+
+        let mars = kernel.at("mars", &t).unwrap();
+        let ssb = Position::barycentric(Vector3::zeros(), Vector3::zeros(), 0);
+
+        // Zero parallax keeps the two observers' geometric parallax out of
+        // the comparison, leaving aberration alone.
+        let star = StarData::new(1, 30.0, 20.0, 5.0, None);
+
+        let from_mars = mars
+            .observe_star(&star, None, None, &t)
+            .apparent(&mut kernel, &t)
+            .unwrap();
+        let from_ssb = ssb
+            .observe_star(&star, None, None, &t)
+            .apparent(&mut kernel, &t)
+            .unwrap();
+
+        let measured = from_mars.separation_from(&from_ssb);
+
+        // Expected: (v/c) sin(theta) between Mars's velocity and the star.
+        let speed_au_day = mars.velocity.norm();
+        let cos_theta = mars
+            .velocity
+            .normalize()
+            .dot(&from_ssb.position.normalize());
+        let expected = speed_au_day / C_AUDAY * (1.0 - cos_theta * cos_theta).sqrt();
+
+        // Mars's orbital speed runs from 21.97 km/s at aphelion to 26.50 km/s
+        // at perihelion, so its full aberration constant v/c is 15.1"–18.2".
+        let speed_km_s = speed_au_day * crate::constants::AU_KM / crate::constants::DAY_S;
+        assert!(
+            (21.9..26.6).contains(&speed_km_s),
+            "Mars barycentric speed {speed_km_s} km/s"
+        );
+        let v_over_c_arcsec = speed_au_day / C_AUDAY / ARCSEC;
+        assert!(
+            (15.0..18.3).contains(&v_over_c_arcsec),
+            "Mars v/c = {v_over_c_arcsec} arcsec"
+        );
+        println!(
+            "Mars aberration: measured {:.4}\" expected {:.4}\" (v/c = {v_over_c_arcsec:.3}\")",
+            measured / ARCSEC,
+            expected / ARCSEC
+        );
+        assert!(
+            (measured - expected).abs() < 0.02 * expected,
+            "aberration: measured {} arcsec, expected {} arcsec",
+            measured / ARCSEC,
+            expected / ARCSEC
+        );
+    }
+
+    #[test]
+    fn test_proper_motion_moves_the_star() {
+        let mut kernel = de421_kernel();
+        let ts = Timescale::default();
+        let t0 = ts.tdb_jd(2451545.0);
+        let t1 = ts.tdb_jd(2451545.0 + 50.0 * 365.25);
+
+        let earth0 = kernel.at("earth", &t0).unwrap();
+        let earth1 = kernel.at("earth", &t1).unwrap();
+
+        let (star, pm, plx) = sirius();
+        let a0 = earth0.observe_star(&star, Some(&pm), Some(plx), &t0);
+        let a1 = earth1.observe_star(&star, Some(&pm), Some(plx), &t1);
+
+        // Sirius moves 1.34"/yr, so 67" in 50 years; parallax adds < 0.8".
+        let moved = a0.separation_from(&a1) / ARCSEC;
+        assert!(
+            (60.0..75.0).contains(&moved),
+            "Sirius moved {moved} arcsec in 50 years"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "observe_star() requires a Barycentric position")]
+    fn test_observe_star_rejects_astrometric_observer() {
+        let mut kernel = de421_kernel();
+        let ts = Timescale::default();
+        let t = ts.tdb_jd(2451545.0);
+        let earth = kernel.at("earth", &t).unwrap();
+        let mars = earth.observe("mars", &mut kernel, &t).unwrap();
+
+        let (star, pm, plx) = sirius();
+        let _ = mars.observe_star(&star, Some(&pm), Some(plx), &t);
+    }
+}

--- a/src/positions/stars/python_tests.rs
+++ b/src/positions/stars/python_tests.rs
@@ -1,0 +1,169 @@
+//! Python comparison tests for `Position::observe_star`
+//!
+//! Checks the apparent places of twenty Hipparcos stars against Skyfield's
+//! `observer.at(t).observe(star).apparent().radec()`, for an Earth observer
+//! and for an observer riding Mars — the case the Rust method exists for,
+//! where the observer's velocity contributes ~17″ of aberration.
+
+#[cfg(test)]
+mod tests {
+    use crate::catalogs::StarData;
+    use crate::framelib::inertial::ProperMotion;
+    use crate::jplephem_ext::SpiceKernelExt;
+    use crate::pybridge::bridge::PyRustBridge;
+    use crate::pybridge::test_utils::{de421_kernel, parse_f64_list};
+    use crate::time::Timescale;
+
+    /// Twenty Hipparcos stars: (HIP, RA°, Dec°, pmRA mas/yr, pmDec mas/yr,
+    /// parallax mas), ICRS at epoch J2000.0.
+    ///
+    /// The astrometry is the published Hipparcos solution rounded to the
+    /// precision printed in the usual bright-star tables; six of the rows are
+    /// the entries already embedded in `catalogs::hipparcos`. The comparison
+    /// below feeds identical numbers to Rust and to Skyfield, so what is under
+    /// test is the propagation and the light-time/aberration/deflection
+    /// pipeline, not the catalog values themselves.
+    const STARS: [(u64, f64, f64, f64, f64, f64); 20] = [
+        (32349, 101.2874, -16.7161, -546.01, -1223.07, 379.21), // Sirius
+        (91262, 279.2347, 38.7837, 200.94, 286.23, 130.23),     // Vega
+        (27989, 88.7929, 7.4070, 26.40, 9.56, 5.95),            // Betelgeuse
+        (26727, 85.1897, -1.9426, 3.19, 2.03, 3.99),            // Alnitak
+        (26311, 84.0534, -1.2019, 1.49, -1.06, 2.43),           // Alnilam
+        (25930, 83.0016, -0.2991, 0.92, -1.20, 3.56),           // Mintaka
+        (24608, 79.1723, 45.9980, 75.52, -427.11, 77.29),       // Capella
+        (24436, 78.6345, -8.2017, 1.87, -0.56, 4.22),           // Rigel
+        (37279, 114.8255, 5.2250, -716.57, -1034.58, 285.93),   // Procyon
+        (69673, 213.9153, 19.1824, -1093.45, -1999.40, 88.85),  // Arcturus
+        (71683, 219.9021, -60.8340, -3678.19, 481.84, 742.12),  // Alpha Cen A
+        (87937, 269.4521, 4.6934, -798.71, 10337.77, 549.01),   // Barnard's Star
+        (11767, 37.9529, 89.2641, 44.22, -11.74, 7.54),         // Polaris
+        (65474, 201.2983, -11.1613, -42.50, -31.73, 12.44),     // Spica
+        (80763, 247.3519, -26.4320, -10.16, -23.21, 5.40),      // Antares
+        (97649, 297.6958, 8.8683, 536.82, 385.54, 194.44),      // Altair
+        (21421, 68.9802, 16.5093, 63.45, -188.94, 50.09),       // Aldebaran
+        (30438, 95.9880, -52.6957, 19.93, 23.24, 10.43),        // Canopus
+        (49669, 152.0930, 11.9672, -249.40, 4.91, 42.09),       // Regulus
+        (102098, 310.3580, 45.2803, 1.56, 1.55, 1.01),          // Deneb
+    ];
+
+    /// Render `STARS` as a Python list of tuples.
+    fn python_star_table() -> String {
+        STARS
+            .iter()
+            .map(|(_, ra, dec, pmra, pmdec, plx)| {
+                format!("    ({ra:?}, {dec:?}, {pmra:?}, {pmdec:?}, {plx:?}),")
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Skyfield apparent RA/Dec in degrees for every star in `STARS`, in
+    /// order, at each of the given TDB Julian dates, as seen from `body`.
+    fn skyfield_apparent(body: &str, jds: &[f64]) -> Vec<f64> {
+        let bridge = PyRustBridge::new().expect("Failed to create Python bridge");
+        let code = format!(
+            r#"
+from skyfield.api import load, load_file, Star
+
+ts = load.timescale()
+eph = load_file('test_data/de421.bsp')
+rows = [
+{table}
+]
+out = []
+for jd in [{jds}]:
+    t = ts.tdb_jd(jd)
+    observer = eph['{body}'].at(t)
+    for ra, dec, pmra, pmdec, plx in rows:
+        star = Star(ra_hours=ra / 15.0, dec_degrees=dec,
+                    ra_mas_per_year=pmra, dec_mas_per_year=pmdec,
+                    parallax_mas=plx)
+        apparent = observer.observe(star).apparent()
+        ra_a, dec_a, _ = apparent.radec()
+        out.append(ra_a._degrees)
+        out.append(dec_a.degrees)
+rust.collect_string(','.join(repr(v) for v in out))
+"#,
+            table = python_star_table(),
+            jds = jds
+                .iter()
+                .map(|jd| format!("{jd:?}"))
+                .collect::<Vec<_>>()
+                .join(", "),
+            body = body,
+        );
+        let result = bridge.run_py_to_json(&code).expect("Skyfield run failed");
+        parse_f64_list(&result)
+    }
+
+    /// Angular separation of two RA/Dec pairs (degrees in, mas out).
+    fn separation_mas(ra1: f64, dec1: f64, ra2: f64, dec2: f64) -> f64 {
+        let d_dec = dec2 - dec1;
+        let mut d_ra = ra2 - ra1;
+        if d_ra > 180.0 {
+            d_ra -= 360.0;
+        } else if d_ra < -180.0 {
+            d_ra += 360.0;
+        }
+        let d_ra = d_ra * dec1.to_radians().cos();
+        (d_ra * d_ra + d_dec * d_dec).sqrt() * 3_600_000.0
+    }
+
+    /// Compare `Position::observe_star(...).apparent()` with Skyfield for the
+    /// twenty stars, from `body`, at every epoch in `jds`. Returns the worst
+    /// separation in milliarcseconds.
+    fn max_error_mas(body: &str, jds: &[f64]) -> f64 {
+        let python = skyfield_apparent(body, jds);
+        assert_eq!(python.len(), 2 * STARS.len() * jds.len());
+
+        let mut kernel = de421_kernel();
+        let ts = Timescale::default();
+        let mut worst = 0.0f64;
+        let mut index = 0;
+
+        for &jd in jds {
+            let t = ts.tdb_jd(jd);
+            let observer = kernel.at(body, &t).unwrap();
+            for &(hip, ra, dec, pmra, pmdec, plx) in STARS.iter() {
+                let star = StarData::new(hip, ra, dec, 0.0, None);
+                let pm = ProperMotion::new(pmra, pmdec);
+                let apparent = observer
+                    .observe_star(&star, Some(&pm), Some(plx), &t)
+                    .apparent(&mut kernel, &t)
+                    .unwrap();
+                let (ra_h, dec_deg, _) = apparent.radec(None);
+
+                let error = separation_mas(ra_h * 15.0, dec_deg, python[index], python[index + 1]);
+                assert!(
+                    error < 1.0,
+                    "HIP {hip} at JD {jd} from {body}: {error:.4} mas \
+                     (rust {ra_deg:.9} {dec_deg:.9}, skyfield {py_ra:.9} {py_dec:.9})",
+                    ra_deg = ra_h * 15.0,
+                    py_ra = python[index],
+                    py_dec = python[index + 1],
+                );
+                worst = worst.max(error);
+                index += 2;
+            }
+        }
+        worst
+    }
+
+    /// Twenty Hipparcos stars from Earth at two epochs, under 1 mas.
+    #[test]
+    fn test_observe_star_matches_skyfield_from_earth() {
+        // J2000.0 and 2025-01-01, both inside the DE421 span.
+        let worst = max_error_mas("earth", &[2451545.0, 2460676.5]);
+        println!("observe_star from Earth: max error {worst:.6} mas");
+        assert!(worst < 1.0, "max error {worst} mas");
+    }
+
+    /// The same stars from Mars, where the observer's velocity supplies a
+    /// different ~17″ aberration than Earth's.
+    #[test]
+    fn test_observe_star_matches_skyfield_from_mars() {
+        let worst = max_error_mas("mars", &[2451545.0]);
+        println!("observe_star from Mars: max error {worst:.6} mas");
+        assert!(worst < 1.0, "max error {worst} mas");
+    }
+}

--- a/src/positions/stars/python_tests.rs
+++ b/src/positions/stars/python_tests.rs
@@ -82,7 +82,9 @@ for jd in [{jds}]:
         ra_a, dec_a, _ = apparent.radec()
         out.append(ra_a._degrees)
         out.append(dec_a.degrees)
-rust.collect_string(','.join(repr(v) for v in out))
+# float() first: NumPy 2 reprs a scalar as np.float64(...), which the
+# Rust side cannot parse.
+rust.collect_string(','.join(repr(float(v)) for v in out))
 "#,
             table = python_star_table(),
             jds = jds

--- a/src/starlib/mod.rs
+++ b/src/starlib/mod.rs
@@ -148,7 +148,13 @@ impl Star {
         let distance = vector.norm();
         let light_time = distance / C_AUDAY;
 
-        Position::astrometric(vector, velocity, observer, -1, light_time)
+        Position::astrometric(
+            vector,
+            velocity,
+            observer,
+            crate::positions::stars::STAR_TARGET_ID,
+            light_time,
+        )
     }
 
     /// Compute the ICRS position and velocity vectors from catalog parameters.


### PR DESCRIPTION
## Summary

`Position::observe` handles ephemeris bodies by name; catalog stars had no
equivalent, so an observer away from Earth could not get star directions in the
same apparent frame as the planets it was looking at. This adds
`Position::observe_star`, a port of Skyfield's `Star._observe_from_bcrs` in the
shape this crate's catalog types use.

```rust
let mars = kernel.at("mars", &t)?;
let apparent = mars
    .observe_star(&star, Some(&pm), Some(parallax_mas), &t)
    .apparent(&mut kernel, &t)?;
```

- `src/positions/stars.rs` — `observe_star(&StarData, Option<&ProperMotion>, Option<f64>, &Time)`.
  The catalog place is taken at J2000.0, carried to the observation epoch by
  the proper motion, and placed at the distance implied by the parallax (one
  gigaparsec when there is none, as Skyfield does), then differenced against
  the observer's barycentric position. The result is `Astrometric` with
  `observer_barycentric` populated — mandatory, since `apparent()` asserts on
  it — so aberration and deflection come out consistent with a planet observed
  from the same position: ~17 arcsec of aberration for an observer riding Mars.
- `STAR_TARGET_ID = -1` documents the sentinel target id the crate has been
  using for stars; `starlib::Star::observe_from` now refers to the constant
  instead of a literal.
- `StarData` carries no radial velocity, so the Doppler factor is 1; the doc
  comment points at `starlib::Star` for stars with a known radial velocity or a
  non-J2000 catalog epoch.
- `examples/observe_star.rs` — Sirius from Earth and from Mars on the same date
  (37.3 arcsec apart, almost all of it the difference of the two aberrations).

## Test plan

`cargo fmt`, `cargo clippy --all-targets` (no new lints), `cargo test`:
683 passed, 0 failed, 23 ignored.

New tests:

- `src/positions/stars/python_tests.rs` — twenty Hipparcos stars against
  Skyfield `observer.at(t).observe(star).apparent().radec()`, asserted under
  1 mas per star:
  - from Earth at JD 2451545.0 and 2460676.5 — **max error 0.000008 mas**
  - from Mars at JD 2451545.0 — **max error 0.000002 mas**
- `test_aberration_from_mars_matches_v_over_c` — a star seen from Mars vs from
  a motionless observer at the SSB, compared with (v/c)·sin(theta): measured
  14.4716 arcsec against 14.4128 expected, within 2% (Mars's full v/c at J2000
  is 18.105 arcsec; its speed there is 26.3 km/s, near perihelion, against the
  24.1 km/s mean).
- `test_zero_motion_returns_catalog_direction` — no proper motion and no
  parallax reproduces the catalog RA/Dec to under 1e-9 degrees.
- Plus astrometric-shape, apparent-pipeline, 50-year proper motion, and
  wrong-observer-kind tests.

`cargo test --features python-tests`: 797 passed, 1 failed — the pre-existing
astropy Sersic comparison, untouched by this branch.

Closes #166
