### PR TITLE
Angular size and occultation geometry

### DIFF
--- a/examples/apparent_disk.rs
+++ b/examples/apparent_disk.rs
@@ -1,0 +1,159 @@
+//! The Earth and the Moon as resolved discs, seen from Mars.
+//!
+//! Prints the angular diameter and the projected ellipse of both bodies at the
+//! epoch of the HiRISE Earth-and-Moon portrait, 2007 October 3, then flies an
+//! observer once around Mars on a 17 000 km circular orbit and finds the
+//! interval in which Mars hides the Earth from it.
+//!
+//! Run with `cargo run --example apparent_disk`.
+
+use nalgebra::Vector3;
+
+use starfield::constants::{AU_KM, DAY_S};
+use starfield::framelib::Frame;
+use starfield::jplephem::SpiceKernel;
+use starfield::jplephem_ext::SpiceKernelExt;
+use starfield::planetarylib::occult::{occultation, Occultation};
+use starfield::planetarylib::{IauFrame, PlanetaryConstants};
+use starfield::planetlib::Body;
+use starfield::positions::Position;
+use starfield::searchlib::{find_discrete, DEFAULT_NUM, EPSILON_DISCRETE};
+use starfield::time::{Time, Timescale};
+
+/// Radians to arcseconds.
+const RAD2ASEC: f64 = 206_264.806_247_096_36;
+
+/// Gravitational parameter of Mars, km³/s², from DE440.
+const GM_MARS: f64 = 42_828.375_214;
+
+/// Radius of the circular orbit the observer flies, in km.
+const ORBIT_RADIUS_KM: f64 = 17_000.0;
+
+fn main() {
+    let mut kernel = SpiceKernel::open("test_data/de421.bsp").expect("test_data/de421.bsp");
+    let ts = Timescale::default();
+    let t = ts.utc((2007, 10, 3, 8, 30, 0.0));
+
+    println!("Seen from Mars on 2007 October 3 at 08:30 UTC\n");
+
+    let mars = kernel.at("mars", &t).unwrap();
+    let earth = mars.observe("earth", &mut kernel, &t).unwrap();
+    let moon = mars.observe("moon", &mut kernel, &t).unwrap();
+
+    // The Earth is best served by the ITRS; the Moon by its IAU elements.
+    let earth_frame = PlanetaryConstants::new().frame_for(399).unwrap();
+    let moon_frame = IauFrame::from_body(Body::Moon);
+    report("Earth", &earth, Body::Earth, earth_frame.as_ref(), &t);
+    report("Moon", &moon, Body::Moon, &moon_frame, &t);
+
+    let state = occultation(
+        &moon,
+        &earth,
+        Body::Moon.radii_km()[0],
+        Body::Earth.radii_km()[0],
+    );
+    println!("\nThe Moon hidden by the Earth, seen from Mars: {}", state);
+
+    occultation_from_mars_orbit(&mut kernel, &ts, &t);
+}
+
+/// Print the apparent size and shape of one body.
+fn report(name: &str, position: &Position, body: Body, frame: &dyn Frame, t: &Time) {
+    let radii = body.radii_km();
+    let diameter = 2.0 * position.angular_semi_diameter(radii) * RAD2ASEC;
+    let (major, minor, pa) = position.apparent_ellipse(frame, radii, t);
+
+    println!("{name}");
+    println!("  distance          {:.6} AU", position.distance());
+    println!("  angular diameter  {:.3} arcseconds", diameter);
+    println!(
+        "  apparent ellipse  {:.3} × {:.3} arcseconds, axis ratio {:.5}",
+        2.0 * major * RAD2ASEC,
+        2.0 * minor * RAD2ASEC,
+        minor / major
+    );
+    println!("  major axis at     {:.2}° east of north", pa.to_degrees());
+}
+
+/// Fly one orbit about Mars and find when Mars hides the Earth.
+fn occultation_from_mars_orbit(kernel: &mut SpiceKernel, ts: &Timescale, t: &Time) {
+    let mars = kernel.at("mars", t).unwrap();
+    let earth = mars.observe("earth", kernel, t).unwrap();
+
+    // An orbit plane containing the direction to the Earth, so the observer
+    // passes behind Mars once per revolution.
+    let toward_earth = earth.position.normalize();
+    let across = toward_earth.cross(&Vector3::z()).normalize();
+    let period_days = std::f64::consts::TAU * (ORBIT_RADIUS_KM.powi(3) / GM_MARS).sqrt() / DAY_S;
+    let epoch_tt = t.tt();
+
+    let state = |kernel: &mut SpiceKernel, t: &Time| -> Occultation {
+        let phase = std::f64::consts::TAU * (t.tt() - epoch_tt) / period_days;
+        let radius_au = ORBIT_RADIUS_KM / AU_KM;
+        let speed = std::f64::consts::TAU * radius_au / period_days;
+        let (sin, cos) = phase.sin_cos();
+
+        let mars = kernel.at("mars", t).unwrap();
+        let observer = Position::barycentric(
+            mars.position + radius_au * (cos * toward_earth + sin * across),
+            mars.velocity + speed * (-sin * toward_earth + cos * across),
+            -1,
+        );
+        let earth = observer.observe("earth", kernel, t).unwrap();
+        let mars = observer.observe("mars", kernel, t).unwrap();
+        occultation(
+            &earth,
+            &mars,
+            Body::Earth.radii_km()[0],
+            Body::Mars.radii_km()[0],
+        )
+    };
+
+    let mut sample = |jd: &[f64]| -> Vec<i64> {
+        jd.iter()
+            .map(|&jd| {
+                let t = ts.tt_jd(jd, None);
+                match state(kernel, &t) {
+                    Occultation::None => 0,
+                    Occultation::Partial => 1,
+                    Occultation::Full => 2,
+                }
+            })
+            .collect()
+    };
+
+    let events = find_discrete(
+        epoch_tt,
+        epoch_tt + period_days,
+        &mut sample,
+        0.005,
+        EPSILON_DISCRETE,
+        DEFAULT_NUM,
+    );
+
+    println!(
+        "\nFrom a {:.0} km circular Mars orbit of {:.0} s, over one revolution:",
+        ORBIT_RADIUS_KM,
+        period_days * DAY_S
+    );
+    for (jd, value) in &events {
+        let label = match value {
+            0 => "clear of the limb",
+            1 => "partly hidden",
+            _ => "wholly hidden",
+        };
+        println!(
+            "  {}  {}",
+            ts.tt_jd(*jd, None).utc_iso('T', 0).unwrap(),
+            label
+        );
+    }
+    if events.len() == 4 {
+        println!(
+            "  total occultation lasted {:.1} s, partial phases {:.2} s and {:.2} s",
+            (events[2].0 - events[1].0) * DAY_S,
+            (events[1].0 - events[0].0) * DAY_S,
+            (events[3].0 - events[2].0) * DAY_S,
+        );
+    }
+}

--- a/src/planetarylib/mod.rs
+++ b/src/planetarylib/mod.rs
@@ -49,6 +49,7 @@
 //! ```
 
 pub mod iau_frame;
+pub mod occult;
 pub mod pck_frame;
 #[cfg(all(test, feature = "python-tests"))]
 mod python_tests;

--- a/src/planetarylib/occult.rs
+++ b/src/planetarylib/occult.rs
@@ -1,0 +1,387 @@
+//! Is one body hidden behind another?
+//!
+//! [`occultation`] answers that question for two bodies seen from one place —
+//! from a Mars orbiter the Earth is regularly hidden behind Mars, and the Moon
+//! behind the Earth — and reports whether the target is fully hidden, partly
+//! hidden, or clear of the occulting body.
+//!
+//! [`eclipselib`](crate::eclipselib) covers the Sun, the Earth and the Moon
+//! and works with shadow cones and penumbrae. This is the other half of the
+//! same geometry: two discs on the sky and the question of which is in front.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use starfield::jplephem::SpiceKernel;
+//! use starfield::jplephem_ext::SpiceKernelExt;
+//! use starfield::planetarylib::occult::{occultation, Occultation};
+//! use starfield::planetlib::Body;
+//! use starfield::time::Timescale;
+//!
+//! let mut kernel = SpiceKernel::open("test_data/de421.bsp").unwrap();
+//! let t = Timescale::default().utc((2007, 10, 3, 8, 30, 0.0));
+//!
+//! // Both targets are observed from the same place at the same moment.
+//! let mars = kernel.at("mars", &t).unwrap();
+//! let earth = mars.observe("earth", &mut kernel, &t).unwrap();
+//! let moon = mars.observe("moon", &mut kernel, &t).unwrap();
+//!
+//! let state = occultation(
+//!     &moon,
+//!     &earth,
+//!     Body::Moon.radii_km()[0],
+//!     Body::Earth.radii_km()[0],
+//! );
+//! assert_eq!(state, Occultation::None);
+//! ```
+
+use crate::positions::Position;
+
+/// How much of a target one body hides from an observer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Occultation {
+    /// The whole target is visible.
+    None,
+    /// Part of the target is hidden.
+    Partial,
+    /// The whole target is hidden.
+    Full,
+}
+
+impl std::fmt::Display for Occultation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Occultation::None => write!(f, "None"),
+            Occultation::Partial => write!(f, "Partial"),
+            Occultation::Full => write!(f, "Full"),
+        }
+    }
+}
+
+/// Whether `occulter` hides `target` from the observer both are seen from.
+///
+/// Both positions must be of the same observer at the same moment — the
+/// astrometric or apparent positions that
+/// [`Position::observe`](crate::positions::Position::observe) and
+/// [`Position::apparent`](crate::positions::Position::apparent) return, or any
+/// other pair of vectors that run from one observer to the two bodies. Nothing
+/// checks that; a pair from two different observers gives a meaningless
+/// answer.
+///
+/// Both bodies are treated as spheres of the given radii, which is what the
+/// question is worth: the flattening of an oblate planet moves a limb by a
+/// fraction of a percent of its radius, while an occultation is decided by the
+/// difference between two angles that are usually far further apart than that.
+/// Use [`Body::radii_km`](crate::planetlib::Body::radii_km) and take the
+/// equatorial radius for the conservative answer.
+///
+/// The test is the obvious one on three angles — the separation `s` of the two
+/// bodies on the sky and their angular radii `rₜ` and `rₒ`:
+///
+/// ```text
+/// s ≥ rₜ + rₒ   →  None
+/// s ≤ rₒ − rₜ   →  Full
+/// otherwise     →  Partial
+/// ```
+///
+/// with one further condition: the occulter must be the nearer of the two, or
+/// the result is [`Occultation::None`] however close the two discs are, since
+/// then it is the target that passes in front.
+///
+/// An annular occultation — a nearer, smaller disc entirely inside a farther,
+/// larger one — is reported as [`Occultation::Partial`], which is what the
+/// middle case of the test above gives when `rₒ < rₜ`. Part of the target is
+/// hidden and part is not, so `Partial` is the truth; a caller who cares about
+/// the distinction can compare the two angular radii itself.
+///
+/// # Deviation from the proposed signature
+///
+/// Issue #170 proposes a leading `observer: &Position` argument. It carries no
+/// information this function uses: the positions of the target and of the
+/// occulter are already relative to the observer, and the epoch that would
+/// come with it is already baked into them. It is left out rather than
+/// accepted and ignored.
+///
+/// # Example
+///
+/// ```
+/// use nalgebra::Vector3;
+/// use starfield::planetarylib::occult::{occultation, Occultation};
+/// use starfield::positions::Position;
+///
+/// // A body one AU away, right behind a body 0.5 AU away that is large
+/// // enough to cover it.
+/// let target = Position::barycentric(Vector3::new(1.0, 0.0, 0.0), Vector3::zeros(), 0);
+/// let occulter = Position::barycentric(Vector3::new(0.5, 0.0, 0.0), Vector3::zeros(), 0);
+/// assert_eq!(occultation(&target, &occulter, 6378.0, 6378.0), Occultation::Full);
+///
+/// // Swap them and the near body is the one in front of the far one.
+/// assert_eq!(occultation(&occulter, &target, 6378.0, 6378.0), Occultation::None);
+/// ```
+pub fn occultation(
+    target: &Position,
+    occulter: &Position,
+    target_radius_km: f64,
+    occulter_radius_km: f64,
+) -> Occultation {
+    let target_distance = target.distance();
+    let occulter_distance = occulter.distance();
+
+    if occulter_distance >= target_distance {
+        return Occultation::None;
+    }
+
+    let target_radius = target.angular_semi_diameter([target_radius_km; 3]);
+    let occulter_radius = occulter.angular_semi_diameter([occulter_radius_km; 3]);
+    let separation = target.separation_from(occulter);
+
+    if separation >= target_radius + occulter_radius {
+        Occultation::None
+    } else if separation <= occulter_radius - target_radius {
+        Occultation::Full
+    } else {
+        Occultation::Partial
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::{AU_KM, DAY_S};
+    use crate::jplephem::kernel::SpiceKernel;
+    use crate::jplephem_ext::SpiceKernelExt;
+    use crate::planetlib::Body;
+    use crate::positions::PositionKind;
+    use crate::searchlib::{find_discrete, DEFAULT_NUM, EPSILON_DISCRETE};
+    use crate::time::{Time, Timescale};
+    use nalgebra::Vector3;
+
+    /// A position relative to the observer, which is all `occultation` reads.
+    fn seen_from_here(position: Vector3<f64>) -> Position {
+        Position {
+            position,
+            velocity: Vector3::zeros(),
+            kind: PositionKind::Astrometric,
+            center: 0,
+            target: 0,
+            light_time: 0.0,
+            observer_barycentric: None,
+        }
+    }
+
+    /// A body at `distance_au` whose direction is `angle` radians off the x
+    /// axis, in the xy plane.
+    fn at_angle(distance_au: f64, angle: f64) -> Position {
+        seen_from_here(Vector3::new(angle.cos(), angle.sin(), 0.0) * distance_au)
+    }
+
+    #[test]
+    fn test_a_target_clear_of_the_occulter_is_not_occulted() {
+        // Two degrees apart, discs of a few arcminutes each.
+        let target = at_angle(1.0, 0.0);
+        let occulter = at_angle(0.5, 2f64.to_radians());
+        assert_eq!(
+            occultation(&target, &occulter, 6378.0, 3396.0),
+            Occultation::None
+        );
+    }
+
+    #[test]
+    fn test_a_grazing_target_is_partly_occulted() {
+        let target = at_angle(1.0, 0.0);
+        let target_radius = target.angular_semi_diameter([6378.0; 3]);
+
+        // Put the occulter's centre one target radius outside its own limb, so
+        // the two discs overlap by half the target.
+        let occulter_distance = 0.5;
+        let occulter_radius = (3396.0 / (occulter_distance * AU_KM)).asin();
+        let occulter = at_angle(occulter_distance, occulter_radius);
+        assert!(target_radius < occulter_radius);
+        assert_eq!(
+            occultation(&target, &occulter, 6378.0, 3396.0),
+            Occultation::Partial
+        );
+    }
+
+    #[test]
+    fn test_a_target_behind_the_occulter_is_fully_occulted() {
+        let target = at_angle(1.0, 0.0);
+        let target_radius = target.angular_semi_diameter([6378.0; 3]);
+        let occulter_distance = 0.5;
+        let occulter_radius = (3396.0 / (occulter_distance * AU_KM)).asin();
+        // Inside the occulting disc by more than the target's own radius, but
+        // not at its centre.
+        let occulter = at_angle(occulter_distance, 0.5 * (occulter_radius - target_radius));
+        assert_eq!(
+            occultation(&target, &occulter, 6378.0, 3396.0),
+            Occultation::Full
+        );
+    }
+
+    #[test]
+    fn test_an_occulter_behind_the_target_occults_nothing() {
+        // Exactly the same line of sight, but the "occulter" is the far body.
+        let target = at_angle(0.5, 0.0);
+        let occulter = at_angle(1.0, 0.0);
+        assert_eq!(
+            occultation(&target, &occulter, 3396.0, 6378.0),
+            Occultation::None
+        );
+        // Equal distances are not an occultation either.
+        assert_eq!(
+            occultation(&target, &at_angle(0.5, 0.0), 3396.0, 6378.0),
+            Occultation::None
+        );
+    }
+
+    #[test]
+    fn test_an_annular_occultation_is_partial() {
+        // A near, small disc entirely inside a far, large one.
+        let target = at_angle(1.0, 0.0);
+        let occulter = at_angle(0.5, 0.0);
+        let target_radius = target.angular_semi_diameter([70000.0; 3]);
+        let occulter_radius = occulter.angular_semi_diameter([1737.4; 3]);
+        assert!(occulter_radius < target_radius);
+        assert_eq!(
+            occultation(&target, &occulter, 70000.0, 1737.4),
+            Occultation::Partial
+        );
+    }
+
+    /// Gravitational parameter of Mars, km³/s², from DE440.
+    const GM_MARS: f64 = 42_828.375_214;
+
+    /// Radius of the circular orbit the observer flies, in km.
+    const ORBIT_RADIUS_KM: f64 = 17_000.0;
+
+    /// One observer on a circular Mars orbit, and the state of the Earth
+    /// behind Mars as seen from it.
+    struct MarsOrbiter {
+        kernel: SpiceKernel,
+        /// Toward the Earth at the epoch: the orbit plane contains it, so the
+        /// observer is bound to pass behind Mars once per revolution.
+        toward_earth: Vector3<f64>,
+        /// The second axis of the orbit plane.
+        across: Vector3<f64>,
+        /// TT Julian date at which the observer is between Mars and the Earth.
+        epoch_tt: f64,
+        /// Orbital period in days.
+        period_days: f64,
+        ts: Timescale,
+    }
+
+    impl MarsOrbiter {
+        fn new() -> Self {
+            let mut kernel = SpiceKernel::open("test_data/de421.bsp").expect("test_data/de421.bsp");
+            let ts = Timescale::default();
+            let t = ts.utc((2007, 10, 3, 8, 30, 0.0));
+
+            let mars = kernel.at("mars", &t).unwrap();
+            let earth = mars.observe("earth", &mut kernel, &t).unwrap();
+            let toward_earth = earth.position.normalize();
+            let across = toward_earth.cross(&Vector3::z()).normalize();
+
+            let seconds = std::f64::consts::TAU * (ORBIT_RADIUS_KM.powi(3) / GM_MARS).sqrt();
+
+            MarsOrbiter {
+                kernel,
+                toward_earth,
+                across,
+                epoch_tt: t.tt(),
+                period_days: seconds / DAY_S,
+                ts,
+            }
+        }
+
+        /// The barycentric state of the observer at `t`.
+        ///
+        /// Mars from the ephemeris plus a circular offset that starts on the
+        /// Earth-facing side and swings behind Mars half a revolution later.
+        fn observer(&mut self, t: &Time) -> Position {
+            let phase = std::f64::consts::TAU * (t.tt() - self.epoch_tt) / self.period_days;
+            let radius_au = ORBIT_RADIUS_KM / AU_KM;
+            let speed = std::f64::consts::TAU * radius_au / self.period_days;
+            let (sin, cos) = phase.sin_cos();
+
+            let mars = self.kernel.at("mars", t).unwrap();
+            Position::barycentric(
+                mars.position + radius_au * (cos * self.toward_earth + sin * self.across),
+                mars.velocity + speed * (-sin * self.toward_earth + cos * self.across),
+                -1,
+            )
+        }
+
+        /// The state of the Earth's occultation by Mars at `t`.
+        fn state(&mut self, t: &Time) -> Occultation {
+            let observer = self.observer(t);
+            let earth = observer.observe("earth", &mut self.kernel, t).unwrap();
+            let mars = observer.observe("mars", &mut self.kernel, t).unwrap();
+            occultation(
+                &earth,
+                &mars,
+                Body::Earth.radii_km()[0],
+                Body::Mars.radii_km()[0],
+            )
+        }
+    }
+
+    #[test]
+    fn test_mars_occults_the_earth_once_per_orbit() {
+        let mut orbiter = MarsOrbiter::new();
+        let start = orbiter.epoch_tt;
+        let end = start + orbiter.period_days;
+
+        // At the epoch the observer is between Mars and the Earth.
+        let t0 = orbiter.ts.tt_jd(start, None);
+        assert_eq!(orbiter.state(&t0), Occultation::None);
+
+        let mut sample = |jd: &[f64]| -> Vec<i64> {
+            jd.iter()
+                .map(|&jd| {
+                    let t = orbiter.ts.tt_jd(jd, None);
+                    match orbiter.state(&t) {
+                        Occultation::None => 0,
+                        Occultation::Partial => 1,
+                        Occultation::Full => 2,
+                    }
+                })
+                .collect()
+        };
+
+        let events = find_discrete(
+            start,
+            end,
+            &mut sample,
+            0.005,
+            EPSILON_DISCRETE,
+            DEFAULT_NUM,
+        );
+
+        let values: Vec<i64> = events.iter().map(|&(_, v)| v).collect();
+        assert_eq!(
+            values,
+            vec![1, 2, 1, 0],
+            "one ingress and one egress per orbit, got {:?}",
+            events
+        );
+
+        // The total occultation runs from the second event to the third.
+        let full_seconds = (events[2].0 - events[1].0) * DAY_S;
+        // The observer moves at a constant angular rate about Mars, so the
+        // Earth is wholly hidden while the angle from the anti-Earth direction
+        // is less than the difference of the two angular radii.
+        let mars_radius = (Body::Mars.radii_km()[0] / ORBIT_RADIUS_KM).asin();
+        let earth_radius = 18.50 / 2.0 / 206_264.806_247_096_36;
+        let expected = 2.0 * (mars_radius - earth_radius) / std::f64::consts::TAU
+            * orbiter.period_days
+            * DAY_S;
+        assert!(
+            (full_seconds - expected).abs() < 0.05 * expected,
+            "total occultation lasted {full_seconds} s, expected about {expected} s"
+        );
+
+        // Halfway between ingress and egress the Earth is behind Mars.
+        let middle = orbiter.ts.tt_jd(0.5 * (events[1].0 + events[2].0), None);
+        assert_eq!(orbiter.state(&middle), Occultation::Full);
+    }
+}

--- a/src/positions/angular_size.rs
+++ b/src/positions/angular_size.rs
@@ -1,0 +1,561 @@
+//! Apparent angular size of a resolved body.
+//!
+//! Two methods on [`Position`], both answering "how big does the target look
+//! from here?":
+//!
+//! * [`Position::angular_semi_diameter`] treats the body as a sphere of its
+//!   largest equatorial radius, which is what an ephemeris table means by
+//!   "angular diameter";
+//! * [`Position::apparent_ellipse`] projects the real triaxial ellipsoid onto
+//!   the sky and returns the outline the observer would resolve, which for an
+//!   oblate planet such as Jupiter is visibly flattened.
+//!
+//! Radii come from [`planetarylib`](crate::planetarylib) — either
+//! [`Body::radii_km`](crate::planetlib::Body::radii_km) or
+//! [`PlanetaryConstants::radii`](crate::planetarylib::PlanetaryConstants::radii)
+//! — and the orientation of the ellipsoid from any
+//! [`Frame`](crate::framelib::Frame), in practice the body-fixed frame that
+//! [`PlanetaryConstants::frame_for`](crate::planetarylib::PlanetaryConstants::frame_for)
+//! returns.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use starfield::jplephem::SpiceKernel;
+//! use starfield::jplephem_ext::SpiceKernelExt;
+//! use starfield::planetlib::Body;
+//! use starfield::time::Timescale;
+//!
+//! let mut kernel = SpiceKernel::open("test_data/de421.bsp").unwrap();
+//! let ts = Timescale::default();
+//! let t = ts.utc((2007, 10, 3, 8, 30, 0.0));
+//!
+//! let mars = kernel.at("mars", &t).unwrap();
+//! let earth = mars.observe("earth", &mut kernel, &t).unwrap();
+//! let arcsec = earth.angular_semi_diameter(Body::Earth.radii_km()).to_degrees() * 7200.0;
+//! println!("Earth is {:.2} arcseconds across, seen from Mars", arcsec);
+//! ```
+
+use nalgebra::Vector3;
+
+use crate::constants::AU_KM;
+use crate::framelib::Frame;
+use crate::positions::Position;
+use crate::time::Time;
+
+/// Relative spread of the two eigenvalues below which the projected outline
+/// counts as a circle and its position angle as zero. A few times the machine
+/// epsilon: an ellipse this round is one part in 10¹⁵ from a circle, so its
+/// axes are rounding error rather than geometry.
+const CIRCLE_TOLERANCE: f64 = 8.0 * f64::EPSILON;
+
+impl Position {
+    /// The angular radius of the body, in radians, taken as a sphere.
+    ///
+    /// `asin(a / d)`, where `a` is the larger of the two equatorial radii of
+    /// `radii_km` and `d` the distance from the observer to the body, taken
+    /// from [`position`](Position::position). Doubling the result gives the
+    /// angular diameter that ephemeris tables quote.
+    ///
+    /// An observer inside the body — `a` greater than `d` — gets a quarter
+    /// turn rather than a NaN, and so does a body at zero distance.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use nalgebra::Vector3;
+    /// use starfield::planetlib::Body;
+    /// use starfield::positions::Position;
+    ///
+    /// // One AU away, the Earth is 17.59 arcseconds across.
+    /// let p = Position::barycentric(Vector3::new(1.0, 0.0, 0.0), Vector3::zeros(), 399);
+    /// let arcsec = p.angular_semi_diameter(Body::Earth.radii_km()).to_degrees() * 7200.0;
+    /// assert!((arcsec - 17.59).abs() < 0.01);
+    /// ```
+    pub fn angular_semi_diameter(&self, radii_km: [f64; 3]) -> f64 {
+        let distance_km = self.position.norm() * AU_KM;
+        semi_angle(radii_km[0].max(radii_km[1]), distance_km)
+    }
+
+    /// The outline of the body's ellipsoid as projected onto the sky.
+    ///
+    /// Returns `(semi_major, semi_minor, position_angle)`: the two angular
+    /// semi-axes in radians, and the position angle of the major axis in
+    /// radians east of celestial north, folded into `[0, π)` because the axis
+    /// of an ellipse has no head or tail.
+    ///
+    /// `frame` is the body-fixed frame the radii are given in — the one
+    /// [`PlanetaryConstants::frame_for`](crate::planetarylib::PlanetaryConstants::frame_for)
+    /// returns — and is evaluated at the light-time-corrected epoch
+    /// `t − self.light_time`, since what the observer sees is the orientation
+    /// the body had when the light left it.
+    ///
+    /// # The projection
+    ///
+    /// The body is the ellipsoid `xᵀ A x = 1` in body-fixed coordinates, with
+    /// `A = diag(1/a², 1/b², 1/c²)` for `radii_km = [a, b, c]`. Rotate into a
+    /// frame whose first two axes `u`, `v` span the sky plane (east and north)
+    /// and whose third axis `n` is the line of sight, using the orthogonal
+    /// matrix `C` whose rows are those three vectors written in body-fixed
+    /// coordinates. In that frame the ellipsoid is `yᵀ B y = 1` with
+    /// `B = C A Cᵀ`, which splits into blocks
+    ///
+    /// ```text
+    /// B = ⎡ B₁₁  b₁₂ ⎤     B₁₁ is 2×2, b₁₂ is 2×1, b₂₂ is a scalar.
+    ///     ⎣ b₁₂ᵀ b₂₂ ⎦
+    /// ```
+    ///
+    /// The observer is far enough away that the projection is orthographic, so
+    /// the outline is the shadow the solid `yᵀ B y ≤ 1` casts along `n`: a
+    /// sky-plane point `p` lies inside the outline exactly when some `y₃`
+    /// satisfies
+    ///
+    /// ```text
+    /// pᵀ B₁₁ p + 2 y₃ b₁₂ᵀ p + b₂₂ y₃² ≤ 1.
+    /// ```
+    ///
+    /// The left side is a quadratic in `y₃`, minimised at
+    /// `y₃ = −(b₁₂ᵀ p) / b₂₂`, where it takes the value
+    /// `pᵀ (B₁₁ − b₁₂ b₁₂ᵀ / b₂₂) p`. The outline is therefore the conic
+    /// `pᵀ S p = 1` whose matrix
+    ///
+    /// ```text
+    /// S = B₁₁ − b₁₂ b₁₂ᵀ / b₂₂
+    /// ```
+    ///
+    /// is the Schur complement of `b₂₂` in `B`. `S` is symmetric and positive
+    /// definite; its eigenvectors give the directions of the projected axes,
+    /// and the semi-axis along an eigenvector of eigenvalue `λ` is `1/√λ`, so
+    /// the smaller eigenvalue belongs to the major axis. Each semi-axis is
+    /// then turned into an angle the way [`angular_semi_diameter`] turns a
+    /// radius into one.
+    ///
+    /// Nothing here assumes `a = b`: a triaxial body is projected exactly, and
+    /// a sphere gives two equal axes and a position angle of zero.
+    ///
+    /// [`angular_semi_diameter`]: Position::angular_semi_diameter
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use nalgebra::Vector3;
+    /// use starfield::framelib::ICRS;
+    /// use starfield::planetlib::Body;
+    /// use starfield::positions::Position;
+    /// use starfield::time::Timescale;
+    ///
+    /// let t = Timescale::default().tdb_jd(2451545.0);
+    /// // Five AU away along the x axis, so for a body whose pole is the ICRF
+    /// // z axis the line of sight lies in its equatorial plane.
+    /// let p = Position::barycentric(Vector3::new(5.0, 0.0, 0.0), Vector3::zeros(), 599);
+    /// let (major, minor, pa) = p.apparent_ellipse(&ICRS, Body::Jupiter.radii_km(), &t);
+    /// assert!((minor / major - (1.0 - Body::Jupiter.flattening())).abs() < 1e-6);
+    /// // The pole is projected north, so the equator runs east and west.
+    /// assert!((pa.to_degrees() - 90.0).abs() < 1e-9);
+    /// ```
+    pub fn apparent_ellipse(
+        &self,
+        frame: &dyn Frame,
+        radii_km: [f64; 3],
+        t: &Time,
+    ) -> (f64, f64, f64) {
+        let distance_km = self.position.norm() * AU_KM;
+        let (east, north, line_of_sight) = sky_basis(&self.position);
+
+        // The body-fixed orientation at the moment the light left the body.
+        let rotation = frame.rotation_at(&(t.clone() - self.light_time));
+        let u = rotation * east;
+        let v = rotation * north;
+        let n = rotation * line_of_sight;
+
+        // B = C A Cᵀ, one entry at a time; A is diagonal, so `quadratic` is
+        // all the linear algebra the Schur complement needs.
+        let b11 = quadratic(&u, &u, radii_km);
+        let b12 = quadratic(&u, &v, radii_km);
+        let b13 = quadratic(&u, &n, radii_km);
+        let b22 = quadratic(&v, &v, radii_km);
+        let b23 = quadratic(&v, &n, radii_km);
+        let b33 = quadratic(&n, &n, radii_km);
+
+        let s11 = b11 - b13 * b13 / b33;
+        let s12 = b12 - b13 * b23 / b33;
+        let s22 = b22 - b23 * b23 / b33;
+
+        // Eigenvalues of the symmetric 2×2 conic matrix, smaller one first.
+        let mean = 0.5 * (s11 + s22);
+        let half_difference = 0.5 * (s11 - s22);
+        let radius = half_difference.hypot(s12);
+        let semi_major_km = 1.0 / (mean - radius).sqrt();
+        let semi_minor_km = 1.0 / (mean + radius).sqrt();
+
+        // Eigenvector of the smaller eigenvalue, in (east, north) components.
+        // Both rows of `S − λI` give the same direction; the longer of the two
+        // is the numerically safe one. When the two eigenvalues differ by no
+        // more than rounding the outline is a circle, its axes are arbitrary,
+        // and the eigenvector is noise: report a position angle of zero
+        // rather than that noise.
+        let lambda = mean - radius;
+        let (first, second) = ((s12, lambda - s11), (lambda - s22, s12));
+        let (east_part, north_part) = if first.0.hypot(first.1) >= second.0.hypot(second.1) {
+            first
+        } else {
+            second
+        };
+        let position_angle = if radius <= CIRCLE_TOLERANCE * mean {
+            0.0
+        } else {
+            east_part.atan2(north_part).rem_euclid(std::f64::consts::PI)
+        };
+
+        (
+            semi_angle(semi_major_km, distance_km),
+            semi_angle(semi_minor_km, distance_km),
+            position_angle,
+        )
+    }
+}
+
+/// The angle a radius subtends at a distance, saturating at a quarter turn.
+fn semi_angle(radius_km: f64, distance_km: f64) -> f64 {
+    if distance_km <= 0.0 {
+        return std::f64::consts::FRAC_PI_2;
+    }
+    (radius_km / distance_km).min(1.0).asin()
+}
+
+/// `wᵀ A z` for the diagonal ellipsoid matrix `A = diag(1/a², 1/b², 1/c²)`.
+fn quadratic(w: &Vector3<f64>, z: &Vector3<f64>, radii_km: [f64; 3]) -> f64 {
+    w.x * z.x / (radii_km[0] * radii_km[0])
+        + w.y * z.y / (radii_km[1] * radii_km[1])
+        + w.z * z.z / (radii_km[2] * radii_km[2])
+}
+
+/// The right-handed sky triad `(east, north, line_of_sight)` at a direction.
+///
+/// East is `ẑ × r̂`, the direction of increasing right ascension, and north
+/// completes the triad as `r̂ × east`. A target exactly at a celestial pole
+/// leaves east undefined; there the x axis stands in for the pole, so the
+/// triad is still orthonormal and the position angle is merely arbitrary, as
+/// it must be.
+fn sky_basis(position: &Vector3<f64>) -> (Vector3<f64>, Vector3<f64>, Vector3<f64>) {
+    let line_of_sight = position.normalize();
+    let mut east = Vector3::z().cross(&line_of_sight);
+    if east.norm() < 1e-12 {
+        east = Vector3::x().cross(&line_of_sight);
+    }
+    let east = east.normalize();
+    let north = line_of_sight.cross(&east);
+    (east, north, line_of_sight)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::framelib::ICRS;
+    use crate::jplephem::kernel::SpiceKernel;
+    use crate::jplephem_ext::SpiceKernelExt;
+    use crate::planetarylib::pck_frame::{rot_x, rot_z};
+    use crate::planetarylib::PlanetaryConstants;
+    use crate::planetlib::Body;
+    use crate::time::Timescale;
+    use nalgebra::Matrix3;
+
+    /// Radians to arcseconds.
+    const RAD2ASEC: f64 = 206_264.806_247_096_36;
+
+    /// A body-fixed frame that never moves, for tests that place the line of
+    /// sight exactly on a body's equator or pole.
+    struct FixedFrame(Matrix3<f64>);
+
+    impl Frame for FixedFrame {
+        fn rotation_at(&self, _t: &Time) -> Matrix3<f64> {
+            self.0
+        }
+    }
+
+    fn t_j2000() -> Time {
+        Timescale::default().tdb_jd(2451545.0)
+    }
+
+    /// The epoch of the HiRISE Earth-and-Moon portrait, 2007 October 3 at
+    /// 08:30 UTC, when Mars was 0.9507 AU from the Earth.
+    fn hirise_epoch() -> Time {
+        Timescale::default().utc((2007, 10, 3, 8, 30, 0.0))
+    }
+
+    /// The epoch of the earlier Earth-and-Moon portrait, the one the Mars
+    /// Orbiter Camera of Mars Global Surveyor took on 2003 May 8 at 13:00 UTC
+    /// from 0.9304 AU.
+    fn moc_epoch() -> Time {
+        Timescale::default().utc((2003, 5, 8, 13, 0, 0.0))
+    }
+
+    fn at_distance(au: f64, direction: Vector3<f64>) -> Position {
+        Position::barycentric(direction.normalize() * au, Vector3::zeros(), 0)
+    }
+
+    fn de421() -> SpiceKernel {
+        SpiceKernel::open("test_data/de421.bsp").expect("test_data/de421.bsp")
+    }
+
+    #[test]
+    fn test_semi_diameter_is_asin_of_the_ratio() {
+        let p = at_distance(1.0, Vector3::x());
+        let expected = (6378.1366 / AU_KM).asin();
+        assert!((p.angular_semi_diameter(Body::Earth.radii_km()) - expected).abs() < 1e-18);
+    }
+
+    #[test]
+    fn test_semi_diameter_uses_the_larger_equatorial_radius() {
+        let p = at_distance(1.0, Vector3::x());
+        let flat = p.angular_semi_diameter([100.0, 200.0, 10.0]);
+        let round = p.angular_semi_diameter([200.0, 200.0, 200.0]);
+        assert_eq!(flat, round);
+    }
+
+    #[test]
+    fn test_semi_diameter_saturates_inside_the_body() {
+        let inside = at_distance(1e-9, Vector3::x());
+        assert_eq!(
+            inside.angular_semi_diameter(Body::Earth.radii_km()),
+            std::f64::consts::FRAC_PI_2
+        );
+        let nowhere = Position::barycentric(Vector3::zeros(), Vector3::zeros(), 0);
+        assert_eq!(
+            nowhere.angular_semi_diameter(Body::Earth.radii_km()),
+            std::f64::consts::FRAC_PI_2
+        );
+    }
+
+    #[test]
+    fn test_a_sphere_projects_to_a_circle() {
+        // An arbitrary line of sight and an arbitrary body orientation: a
+        // sphere has no orientation to reveal.
+        let p = at_distance(0.5, Vector3::new(0.3, -0.7, 0.4));
+        let frame = FixedFrame(rot_z(0.7) * rot_x(-0.3));
+        let (major, minor, pa) = p.apparent_ellipse(&frame, [1737.4; 3], &t_j2000());
+        assert!((major - minor).abs() < 1e-15);
+        assert!((major - p.angular_semi_diameter([1737.4; 3])).abs() < 1e-15);
+        // A circle has no major axis to report an angle for.
+        assert_eq!(pa, 0.0);
+    }
+
+    #[test]
+    fn test_pole_on_view_of_an_oblate_body_is_a_circle() {
+        // Line of sight along the body's pole: the outline is the equator.
+        let p = at_distance(5.0, Vector3::z());
+        let radii = Body::Jupiter.radii_km();
+        let (major, minor, _) = p.apparent_ellipse(&ICRS, radii, &t_j2000());
+        assert!((major - minor).abs() < 1e-15);
+        assert!((major - p.angular_semi_diameter(radii)).abs() < 1e-15);
+    }
+
+    #[test]
+    fn test_jupiter_equator_on_reproduces_its_flattening() {
+        // Line of sight in the body's equatorial plane, so the polar axis is
+        // projected at its full length.
+        let p = at_distance(5.0, Vector3::x());
+        let radii = Body::Jupiter.radii_km();
+        let (major, minor, pa) = p.apparent_ellipse(&ICRS, radii, &t_j2000());
+
+        let flattening = (radii[0] - radii[2]) / radii[0];
+        assert!(
+            (flattening - 0.06487).abs() < 5e-6,
+            "flattening {flattening}"
+        );
+        assert!(
+            (minor / major - (1.0 - flattening)).abs() < 1e-6,
+            "ratio {} against {}",
+            minor / major,
+            1.0 - flattening
+        );
+        // The major axis is the equator, which runs east and west on the sky.
+        assert!((pa - std::f64::consts::FRAC_PI_2).abs() < 1e-12, "pa {pa}");
+        assert!((major - p.angular_semi_diameter(radii)).abs() < 1e-15);
+    }
+
+    #[test]
+    fn test_a_tilted_pole_tilts_the_ellipse() {
+        // Turn the body 30° about the line of sight: the pole is projected at
+        // position angle 30°, so the equator lies at 120°.
+        let p = at_distance(5.0, Vector3::x());
+        let frame = FixedFrame(rot_x(30f64.to_radians()));
+        let (_, _, pa) = p.apparent_ellipse(&frame, Body::Jupiter.radii_km(), &t_j2000());
+        assert!(
+            (pa.to_degrees() - 120.0).abs() < 1e-9,
+            "position angle {} degrees",
+            pa.to_degrees()
+        );
+    }
+
+    #[test]
+    fn test_a_triaxial_body_seen_down_its_long_axis() {
+        // Radii 3, 2, 1 along body x, y, z seen along body x: the outline has
+        // semi-axes 2 and 1.
+        let p = at_distance(1.0, Vector3::x());
+        let (major, minor, _) = p.apparent_ellipse(&ICRS, [3.0, 2.0, 1.0], &t_j2000());
+        assert!((major - (2.0f64 / AU_KM).asin()).abs() < 1e-18);
+        assert!((minor - (1.0f64 / AU_KM).asin()).abs() < 1e-18);
+    }
+
+    /// The published 18.90″ and 5.14″ belong to this epoch, not to the 2007
+    /// HiRISE one: Mars was 0.9304 AU from the Earth when the Mars Orbiter
+    /// Camera took its Earth-and-Moon portrait, against 0.9507 AU four years
+    /// later, and the difference is a fifth of an arcsecond on the Earth.
+    #[test]
+    fn test_earth_and_moon_from_mars_at_the_moc_epoch() {
+        let mut kernel = de421();
+        let t = moc_epoch();
+        let mars = kernel.at("mars", &t).unwrap();
+
+        let earth = mars.observe("earth", &mut kernel, &t).unwrap();
+        let earth_diameter = 2.0 * earth.angular_semi_diameter(Body::Earth.radii_km()) * RAD2ASEC;
+        assert!(
+            (earth_diameter - 18.90).abs() < 0.02,
+            "the Earth is {earth_diameter} arcseconds across, expected 18.90"
+        );
+
+        let moon = mars.observe("moon", &mut kernel, &t).unwrap();
+        let moon_diameter = 2.0 * moon.angular_semi_diameter(Body::Moon.radii_km()) * RAD2ASEC;
+        assert!(
+            (moon_diameter - 5.14).abs() < 0.02,
+            "the Moon is {moon_diameter} arcseconds across, expected 5.14"
+        );
+    }
+
+    #[test]
+    fn test_earth_and_moon_from_mars_at_the_hirise_epoch() {
+        let mut kernel = de421();
+        let t = hirise_epoch();
+        let mars = kernel.at("mars", &t).unwrap();
+
+        let earth = mars.observe("earth", &mut kernel, &t).unwrap();
+        let earth_diameter = 2.0 * earth.angular_semi_diameter(Body::Earth.radii_km()) * RAD2ASEC;
+        assert!(
+            (earth_diameter - 18.50).abs() < 0.02,
+            "the Earth is {earth_diameter} arcseconds across, expected 18.50"
+        );
+
+        let moon = mars.observe("moon", &mut kernel, &t).unwrap();
+        let moon_diameter = 2.0 * moon.angular_semi_diameter(Body::Moon.radii_km()) * RAD2ASEC;
+        assert!(
+            (moon_diameter - 5.05).abs() < 0.02,
+            "the Moon is {moon_diameter} arcseconds across, expected 5.05"
+        );
+    }
+
+    #[test]
+    fn test_the_earths_apparent_ellipse_from_mars_is_barely_flattened() {
+        let mut kernel = de421();
+        let t = hirise_epoch();
+        let mars = kernel.at("mars", &t).unwrap();
+        let earth = mars.observe("earth", &mut kernel, &t).unwrap();
+
+        let radii = Body::Earth.radii_km();
+        let frame = PlanetaryConstants::new().frame_for(399).unwrap();
+        let (major, minor, pa) = earth.apparent_ellipse(frame.as_ref(), radii, &t);
+
+        // The projected major axis of an oblate body is its equatorial radius,
+        // whatever the line of sight.
+        assert!((2.0 * major * RAD2ASEC - 18.50).abs() < 0.02);
+        // The polar axis is foreshortened by between nothing and the full
+        // flattening; the Earth's pole is well off the line of sight here.
+        let ratio = minor / major;
+        assert!(
+            (radii[2] / radii[0]..=1.0).contains(&ratio),
+            "axis ratio {ratio}"
+        );
+        assert!((ratio - 0.99718).abs() < 1e-5, "axis ratio {ratio}");
+        // The Earth's pole is within a degree of celestial north from Mars, so
+        // the equator — the major axis — runs east and west.
+        assert!((pa.to_degrees() - 90.0).abs() < 1.0, "position angle {pa}");
+    }
+
+    /// The projection of an oblate spheroid has a closed form: seen from a
+    /// direction that makes an angle `φ` with the equatorial plane, the
+    /// outline has semi-axes `a` and `√(c² cos²φ + a² sin²φ)`. The general
+    /// Schur-complement projection must reproduce it at every `φ`.
+    #[test]
+    fn test_an_oblate_body_matches_the_closed_form() {
+        let radii = Body::Jupiter.radii_km();
+        let (a, c) = (radii[0], radii[2]);
+        let distance_au = 5.0;
+
+        for degrees in [0.0f64, 7.5, 23.0, 45.0, 66.0, 90.0] {
+            let phi = degrees.to_radians();
+            // A line of sight at latitude φ above the body's equator.
+            let p = at_distance(distance_au, Vector3::new(phi.cos(), 0.0, phi.sin()));
+            let (major, minor, _) = p.apparent_ellipse(&ICRS, radii, &t_j2000());
+
+            let distance_km = distance_au * AU_KM;
+            let expected_minor =
+                ((c * phi.cos()).powi(2) + (a * phi.sin()).powi(2)).sqrt() / distance_km;
+            assert!(
+                (major.sin() - a / distance_km).abs() < 1e-18,
+                "semi-major at {degrees}°"
+            );
+            assert!(
+                (minor.sin() - expected_minor).abs() < 1e-15,
+                "semi-minor at {degrees}°: {} against {}",
+                minor.sin(),
+                expected_minor
+            );
+        }
+    }
+}
+
+#[cfg(all(test, feature = "python-tests"))]
+mod python_tests {
+    use crate::jplephem::SpiceKernel;
+    use crate::jplephem_ext::SpiceKernelExt;
+    use crate::planetlib::Body;
+    use crate::pybridge::{PyRustBridge, PythonResult};
+    use crate::time::Timescale;
+
+    /// Skyfield has no angular diameter of its own, so it supplies the
+    /// light-time-corrected distance and the same `asin` is taken on both
+    /// sides. Agreement to a microarcsecond means the geometry agrees.
+    #[test]
+    fn test_angular_diameter_matches_skyfield() {
+        let bridge = PyRustBridge::new().expect("Python bridge");
+        let python = bridge
+            .run_py_to_json(
+                r#"
+from numpy import arcsin
+from skyfield.api import load
+import json
+
+ts = load.timescale()
+eph = load('de421.bsp')
+t = ts.utc(2003, 5, 8, 13, 0, 0)
+
+mars = eph['mars'].at(t)
+out = {}
+for name, radius_km in (('earth', 6378.1366), ('moon', 1737.4)):
+    distance_km = mars.observe(eph[name]).distance().km
+    out[name] = float(2.0 * arcsin(radius_km / distance_km))
+
+rust.collect_string(json.dumps(out))
+"#,
+            )
+            .expect("Skyfield angular diameter");
+
+        let inner = match PythonResult::try_from(python.as_str()).expect("Python result") {
+            PythonResult::String(s) => s,
+            other => panic!("expected a string, got {:?}", other),
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&inner).expect("JSON");
+
+        let mut kernel = SpiceKernel::open("test_data/de421.bsp").unwrap();
+        let t = Timescale::default().utc((2003, 5, 8, 13, 0, 0.0));
+        let mars = kernel.at("mars", &t).unwrap();
+
+        for (name, body) in [("earth", Body::Earth), ("moon", Body::Moon)] {
+            let target = mars.observe(name, &mut kernel, &t).unwrap();
+            let rust = 2.0 * target.angular_semi_diameter(body.radii_km());
+            let skyfield = parsed[name].as_f64().unwrap();
+            let arcsec = (rust - skyfield).abs().to_degrees() * 3600.0;
+            assert!(arcsec < 1e-6, "{name}: {rust} against {skyfield}");
+        }
+    }
+}

--- a/src/positions/mod.rs
+++ b/src/positions/mod.rs
@@ -19,6 +19,7 @@
 //! let (ra, dec, dist) = mars_apparent.radec(None);
 //! ```
 
+pub mod angular_size;
 pub mod ecliptic;
 
 #[cfg(all(test, feature = "python-tests"))]


### PR DESCRIPTION
## Summary

PR 10 of `docs/solar-system-bodies-plan.md`: how big a resolved body looks, and whether another body is in the way.

**`Position::angular_semi_diameter(radii_km)`** — `asin(a / d)` on the larger equatorial radius, radians. Saturates at a quarter turn for an observer inside the body rather than returning NaN.

**`Position::apparent_ellipse(frame, radii_km, t) -> (semi_major, semi_minor, position_angle)`** — the projected outline of the triaxial ellipsoid, angular semi-axes in radians and the position angle of the major axis east of celestial north, folded into `[0, π)`. The body-fixed `frame` is evaluated at `t − self.light_time`, the orientation the body had when the light left it.

The projection is done properly rather than by the oblate special case. With the ellipsoid `xᵀ A x = 1`, `A = diag(1/a², 1/b², 1/c²)`, rotate into the frame whose axes are east, north and the line of sight: `B = C A Cᵀ`. A sky-plane point `p` is inside the orthographic silhouette exactly when some `y₃` satisfies `pᵀB₁₁p + 2y₃b₁₂ᵀp + b₂₂y₃² ≤ 1`; minimising the quadratic over `y₃` leaves `pᵀ(B₁₁ − b₁₂b₁₂ᵀ/b₂₂)p ≤ 1`, so the outline is the conic whose matrix is the **Schur complement of `b₂₂` in `B`**. Its eigenvalues give the semi-axes as `1/√λ` (smaller eigenvalue ↔ major axis) and its eigenvectors the position angle. The derivation is in the doc comment. Triaxial bodies are handled exactly; a sphere returns equal axes and a position angle of zero.

**`planetarylib::occult::{Occultation, occultation}`** — `None` / `Partial` / `Full` from the separation of the two discs against their angular radii, with the occulter required to be the *nearer* body (otherwise `None`: the target is in front). Annular is `Partial` by that test, and the doc says so.

### Signature change against issue #170

Dropped the leading `observer: &Position`:

```rust
pub fn occultation(target: &Position, occulter: &Position,
                   target_radius_km: f64, occulter_radius_km: f64) -> Occultation
```

`target` and `occulter` are already positions *relative to* the observer, so the observer argument carried no information the function used, and the epoch it would have brought along is already baked into them. Left out rather than accepted and ignored. The doc comment records both the requirement (same observer, same moment) and the deviation.

### The 18.90″ acceptance value belongs to a different epoch

Issue #165 asks for Earth 18.90″ and Moon 5.14″ from Mars on 2007-10-03, "HiRISE release values". Those numbers are from the *Mars Global Surveyor* Mars Orbiter Camera portrait of **2003-05-08**, when Mars was 0.9304 AU from the Earth; on 2007-10-03 it was 0.9507 AU and the true values are 18.50″ and 5.05″. Both epochs are now tested: the MOC one against the published 18.90″/5.14″ (computed 18.903″ and 5.135″, both inside the required 0.02″), the HiRISE one against 18.50″/5.05″. The 2007 caption's own "142 million km" agrees with the computed 1.4222e8 km, so the ephemeris is not at fault.

`examples/apparent_disk.rs` prints both discs and their ellipses at the HiRISE epoch, then flies an observer once round a 17 000 km circular Mars orbit and reports the occultation:

```
Earth
  distance          0.950708 AU
  angular diameter  18.500 arcseconds
  apparent ellipse  18.500 × 18.448 arcseconds, axis ratio 0.99718
  major axis at     90.05° east of north
Moon
  angular diameter  5.053 arcseconds
The Moon hidden by the Earth, seen from Mars: None

From a 17000 km circular Mars orbit of 67296 s, over one revolution:
  2007-10-03T17:14:24Z  partly hidden
  2007-10-03T17:14:25Z  wholly hidden
  2007-10-03T18:26:09Z  partly hidden
  2007-10-03T18:26:10Z  clear of the limb
  total occultation lasted 4303.9 s, partial phases 0.96 s and 0.96 s
```

## Test plan

- `cargo fmt`, `cargo clippy --all-targets` (only the three pre-existing `approx_constant` errors in `catalogs`/`coordinates`/`sbdb` test code remain; nothing from these files), `cargo test`: **695 passed, 0 failed, 23 ignored**, plus 84 doc tests.
- `cargo test --features python-tests`: **808 passed, 1 failed** — the pre-existing astropy Sérsic comparison, unrelated.
- New tests, all in-crate and network-free:
  - `angular_semi_diameter` equals `asin(a/d)`, uses the larger equatorial radius, saturates inside the body.
  - Jupiter viewed exactly equator-on: minor/major = 1 − 0.06487 (IAU 2015 flattening) to 1e-6, major axis at 90°, semi-major equal to `angular_semi_diameter`.
  - Pole-on oblate view and a sphere: two equal axes, equal to `angular_semi_diameter`.
  - Tilting the frame 30° about the line of sight moves the major axis to 120°.
  - A triaxial body seen down its long axis projects semi-axes 2 and 1 from radii 3, 2, 1.
  - The general projection reproduces the closed form `√(c²cos²φ + a²sin²φ)` for an oblate spheroid at six view angles, to 1e-15.
  - Earth and Moon from Mars at both epochs, DE421, tolerance 0.02″.
  - Skyfield comparison (`python-tests`): the same angular diameters through Skyfield's light-time-corrected distance agree to under a microarcsecond.
  - Occultation: none, grazing/partial, full, occulter-behind-target (and equal distances), annular-is-partial.
  - `find_discrete` over one Mars orbit finds exactly one ingress and one egress: total occultation 4303.9 s against the analytic `(rₒ − rₜ)T/π` = 4307 s, partial phases 0.96 s each. Runs in under a tenth of a second, so it is not `#[ignore]`d.

Closes #165
Closes #170
