### PR TITLE
Add spacecraft and Kepler orbit barycentric observers

### DIFF
--- a/examples/mars_orbiter.rs
+++ b/examples/mars_orbiter.rs
@@ -1,0 +1,99 @@
+//! An observer on a Mars orbit
+//!
+//! Builds a circular 17 000 km orbit about Mars, turns it into a barycentric
+//! observer with `KeplerOrbit::barycentric_at`, and observes Earth from it —
+//! the geometry a Mars-orbiting camera needs. The apparent direction differs
+//! from a Mars-centre observer by the orbit radius over the range, ~47″ at the
+//! 0.5 AU close approach of 2003.
+//!
+//! `Position::from_spk_target` does the same job for a spacecraft that has a
+//! real SPK kernel, addressed by its (negative) NAIF id.
+//!
+//! Usage: cargo run --example mars_orbiter
+
+use nalgebra::Vector3;
+use starfield::constants::{AU_KM, DAY_S, GM_KM3_S2_TO_AU3_D2, GM_MARS};
+use starfield::jplephem::kernel::SpiceKernel;
+use starfield::jplephem_ext::SpiceKernelExt;
+use starfield::keplerlib::KeplerOrbit;
+use starfield::magnitudelib::planetary_magnitude;
+use starfield::positions::Position;
+use starfield::Timescale;
+
+const ORBIT_RADIUS_KM: f64 = 17_000.0;
+
+fn main() {
+    let mut kernel = match SpiceKernel::open("test_data/de421.bsp") {
+        Ok(k) => k,
+        Err(e) => {
+            eprintln!("Could not open test_data/de421.bsp: {e}");
+            return;
+        }
+    };
+
+    let ts = Timescale::default();
+    // 2003-10-02, shortly after the closest Mars opposition in 60 000 years.
+    let t = ts.tdb_jd(2452923.0);
+
+    let mars = kernel.at("mars", &t).expect("Mars missing from DE421");
+    let earth = kernel.at("earth", &t).expect("Earth missing from DE421");
+
+    // Place the orbiter a quarter turn from the Mars-Earth line, so its whole
+    // offset shows as a shift in the apparent direction of Earth.
+    let to_earth = (earth.position - mars.position).normalize();
+    let radial = to_earth.cross(&Vector3::z()).normalize();
+    let along_track = to_earth.cross(&radial).normalize();
+
+    let radius_au = ORBIT_RADIUS_KM / AU_KM;
+    let mu = GM_MARS * GM_KM3_S2_TO_AU3_D2;
+    let speed = (mu / radius_au).sqrt();
+
+    let orbit = KeplerOrbit::new(
+        radial * radius_au,
+        along_track * speed,
+        &t,
+        mu,
+        Some(499),
+        Some("Mars orbiter"),
+    );
+
+    let period_hours = 2.0 * std::f64::consts::PI * (radius_au.powi(3) / mu).sqrt() * 24.0;
+    println!("Circular Mars orbit");
+    println!("===================\n");
+    println!(
+        "radius {ORBIT_RADIUS_KM:.0} km, speed {:.3} km/s, period {period_hours:.2} h\n",
+        speed * AU_KM / DAY_S
+    );
+
+    let orbiter = orbit
+        .barycentric_at(&mut kernel, "mars", &t)
+        .expect("orbiter state");
+
+    for (label, observer) in [("Mars centre", &mars), ("orbiter", &orbiter)] {
+        let astrometric = observer
+            .observe("earth", &mut kernel, &t)
+            .expect("observe Earth");
+        let apparent = astrometric.apparent(&mut kernel, &t).expect("apparent");
+        let (ra_hours, dec_deg, distance) = apparent.radec(None);
+        let magnitude = planetary_magnitude(&astrometric, &t).expect("magnitude");
+
+        println!(
+            "Earth from {label:<12} RA {:>11.6}°  Dec {:>11.6}°  range {distance:.5} AU  V {magnitude:.2}",
+            ra_hours * 15.0,
+            dec_deg
+        );
+    }
+
+    let from_mars = mars.observe("earth", &mut kernel, &t).unwrap();
+    let from_orbiter = orbiter.observe("earth", &mut kernel, &t).unwrap();
+    let offset_arcsec = from_orbiter.separation_from(&from_mars).to_degrees() * 3600.0;
+    let expected = radius_au / from_mars.distance() * (180.0 / std::f64::consts::PI) * 3600.0;
+    println!("\nOffset from the Mars-centre direction: {offset_arcsec:.2}″ (radius/range = {expected:.2}″)");
+
+    // A flown mission would come from its own kernel instead; DE421 has no
+    // spacecraft, so this reports that nothing reaches NAIF id -74 (MRO).
+    match Position::from_spk_target(&mut kernel, -74, &t) {
+        Ok(p) => println!("\nMRO from the kernel: {p}"),
+        Err(e) => println!("\nPosition::from_spk_target(-74): {e}"),
+    }
+}

--- a/src/constants/mod.rs
+++ b/src/constants/mod.rs
@@ -42,6 +42,37 @@ pub const GS: f64 = 1.327_124_400_179_87e+20;
 /// Solar GM in km^3/s^2 (Pitjeva 2005)
 pub const GM_SUN: f64 = 132_712_440_042.0;
 
+// Planetary gravitational parameters
+//
+// GM of each planetary system (barycenter), plus the Earth, Moon and Mars
+// bodies themselves, in km^3/s^2. Values are the JPL DE440 constants
+// (Park, Folkner, Williams & Boggs 2021, AJ 161, 105, Table 4), which are the
+// same set the DE440 header carries in AU^3/day^2; multiply by
+// [`GM_KM3_S2_TO_AU3_D2`] for that form. Use the body GM, not the system GM,
+// for an orbit close enough to the planet that its moons do not matter.
+/// GM of the Mercury system in km^3/s^2 (DE440)
+pub const GM_MERCURY: f64 = 22_031.868_551;
+/// GM of the Venus system in km^3/s^2 (DE440)
+pub const GM_VENUS: f64 = 324_858.592;
+/// GM of the Earth in km^3/s^2 (DE440)
+pub const GM_EARTH: f64 = 398_600.435_507;
+/// GM of the Moon in km^3/s^2 (DE440)
+pub const GM_MOON: f64 = 4_902.800_118;
+/// GM of the Mars system in km^3/s^2 (DE440)
+pub const GM_MARS_SYSTEM: f64 = 42_828.375_816;
+/// GM of Mars itself in km^3/s^2 (DE440); Phobos and Deimos add 1e-4 km^3/s^2
+pub const GM_MARS: f64 = 42_828.375_214;
+/// GM of the Jupiter system in km^3/s^2 (DE440)
+pub const GM_JUPITER: f64 = 126_712_764.1;
+/// GM of the Saturn system in km^3/s^2 (DE440)
+pub const GM_SATURN: f64 = 37_940_584.841_8;
+/// GM of the Uranus system in km^3/s^2 (DE440)
+pub const GM_URANUS: f64 = 5_794_556.4;
+/// GM of the Neptune system in km^3/s^2 (DE440)
+pub const GM_NEPTUNE: f64 = 6_836_527.100_58;
+/// GM of the Pluto system in km^3/s^2 (DE440)
+pub const GM_PLUTO: f64 = 975.5;
+
 // Earth constants
 /// Earth's angular velocity in radians/s
 pub const EARTH_ANGVEL: f64 = 7.292_115_0e-5;
@@ -53,6 +84,8 @@ pub const IERS_2010_INVERSE_EARTH_FLATTENING: f64 = 298.25642;
 // Derived constants
 /// Speed of light in AU/day
 pub const C_AUDAY: f64 = C * DAY_S / AU_M;
+/// Factor converting a gravitational parameter from km^3/s^2 to AU^3/day^2
+pub const GM_KM3_S2_TO_AU3_D2: f64 = DAY_S * DAY_S / (AU_KM * AU_KM * AU_KM);
 
 // Calendar constants
 /// First day of Gregorian calendar in Julian day number (1582-10-15)

--- a/src/jplephem/spk.rs
+++ b/src/jplephem/spk.rs
@@ -32,6 +32,14 @@ pub fn jd_to_seconds(jd: f64) -> f64 {
     (jd - T0) * S_PER_DAY
 }
 
+/// SPK data types this reader can evaluate: Chebyshev position (2), Chebyshev
+/// position and velocity (3), and extended modified difference arrays (21).
+///
+/// Segments of any other type are skipped when a file is parsed, so a body
+/// carried only by such segments is not reachable; `Position::from_spk_target`
+/// reports that as [`JplephemError::UnsupportedDataType`].
+pub const SUPPORTED_DATA_TYPES: [i32; 3] = [2, 3, 21];
+
 /// Spacecraft Planet Kernel (SPK) file reader
 pub struct SPK {
     /// The underlying DAF file
@@ -135,7 +143,7 @@ impl SPK {
             if start_i == 0 || end_i < start_i {
                 continue;
             }
-            if data_type != 2 && data_type != 3 && data_type != 21 {
+            if !SUPPORTED_DATA_TYPES.contains(&data_type) {
                 continue;
             }
 

--- a/src/keplerlib/mod.rs
+++ b/src/keplerlib/mod.rs
@@ -33,12 +33,9 @@ use nalgebra::{Matrix3, Vector3};
 
 #[cfg(test)]
 use crate::constants::GM_SUN;
-use crate::constants::{AU_KM, DAY_S, DEG2RAD};
+use crate::constants::{DEG2RAD, GM_KM3_S2_TO_AU3_D2 as CONVERT_GM};
 use crate::positions::Position;
 use crate::time::Time;
-
-/// Convert GM from km³/s² to AU³/day²
-const CONVERT_GM: f64 = DAY_S * DAY_S / (AU_KM * AU_KM * AU_KM);
 
 /// A two-body Keplerian orbit
 ///
@@ -226,7 +223,59 @@ impl KeplerOrbit {
 
         Position::barycentric(pos, vel, self.center)
     }
+
+    /// Barycentric state of the body on this orbit at `t`.
+    ///
+    /// Adds the orbit's position and velocity relative to its central body —
+    /// [`KeplerOrbit::at`] — to that body's state from `kernel`, giving a
+    /// position relative to the solar system barycenter with the velocity that
+    /// [`Position::observe`] and [`Position::apparent`] need for light-time
+    /// and aberration. This is how a spacecraft on a Kepler orbit about
+    /// another planet becomes an observer.
+    ///
+    /// # Arguments
+    /// * `kernel` — the SPK supplying the central body's barycentric state
+    /// * `center` — kernel name (or NAIF id as a string) of the central body,
+    ///   which must be the body whose GM this orbit was built with and whose
+    ///   id is in [`KeplerOrbit::center`]
+    /// * `t` — the epoch
+    ///
+    /// The orbit's `mu_au3_d2` is the central body's GM, not the Sun's, for
+    /// anything but a heliocentric orbit; the planetary values are in
+    /// [`crate::constants`] (`GM_MARS`, `GM_EARTH`, …) in km³/s², which is
+    /// what [`KeplerOrbit::from_periapsis`] and
+    /// [`KeplerOrbit::from_mean_anomaly`] take.
+    ///
+    /// The returned position is [`crate::positions::PositionKind::Barycentric`]
+    /// with `target` set to the sentinel [`KEPLER_TARGET_ID`], since a body
+    /// defined by orbital elements has no NAIF id of its own.
+    pub fn barycentric_at(
+        &self,
+        kernel: &mut crate::jplephem::kernel::SpiceKernel,
+        center: &str,
+        t: &Time,
+    ) -> crate::jplephem::errors::Result<Position> {
+        use crate::jplephem_ext::SpiceKernelExt;
+
+        let center_state = kernel.at(center, t)?;
+        let relative = self.at(t);
+
+        Ok(Position::barycentric(
+            center_state.position + relative.position,
+            center_state.velocity + relative.velocity,
+            KEPLER_TARGET_ID,
+        ))
+    }
 }
+
+/// Target id given to a body whose position comes from a [`KeplerOrbit`].
+///
+/// Elements-defined bodies — comets, asteroids, a spacecraft on a modelled
+/// orbit — have no NAIF body id. `-1000001` is outside the range NAIF assigns
+/// to spacecraft (-1 … -999999), so it cannot be confused with an SPK target,
+/// and outside the range of planetary ids, so `magnitudelib` treats it as an
+/// unsupported body rather than mistaking it for a planet.
+pub const KEPLER_TARGET_ID: i32 = -1_000_001;
 
 impl std::fmt::Display for KeplerOrbit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -842,5 +891,171 @@ mod tests {
         let orbit = comet_orbit(1.0, 0.5, 0.0, 0.0, 0.0, &epoch, GM_SUN, Some("1P/Halley"));
         let s = format!("{orbit}");
         assert!(s.contains("Halley"));
+    }
+
+    // --- Barycentric observer on an orbit about another planet ---
+
+    /// 2003-10-02, when Mars is 0.498 AU from Earth.
+    const CLOSE_APPROACH_TDB: f64 = 2452923.0;
+
+    /// Radius of the circular Mars orbit used below, in km.
+    const ORBIT_RADIUS_KM: f64 = 17_000.0;
+
+    fn de421_kernel() -> crate::jplephem::kernel::SpiceKernel {
+        crate::jplephem::kernel::SpiceKernel::open("test_data/de421.bsp")
+            .expect("Failed to open DE421")
+    }
+
+    /// A circular orbit of `ORBIT_RADIUS_KM` about Mars whose position at
+    /// `epoch` is perpendicular to the Mars → Earth direction, so the whole
+    /// offset shows up as a shift in the apparent direction of Earth.
+    fn perpendicular_mars_orbit(
+        kernel: &mut crate::jplephem::kernel::SpiceKernel,
+        epoch: &Time,
+    ) -> KeplerOrbit {
+        use crate::jplephem_ext::SpiceKernelExt;
+
+        let mars = kernel.at("mars", epoch).unwrap();
+        let earth = kernel.at("earth", epoch).unwrap();
+        let to_earth = (earth.position - mars.position).normalize();
+
+        // Two unit vectors perpendicular to the line of sight.
+        let radial = to_earth.cross(&Vector3::z()).normalize();
+        let along_track = to_earth.cross(&radial).normalize();
+
+        let radius_au = ORBIT_RADIUS_KM / crate::constants::AU_KM;
+        let mu = crate::constants::GM_MARS * CONVERT_GM;
+        let speed = (mu / radius_au).sqrt();
+
+        KeplerOrbit::new(
+            radial * radius_au,
+            along_track * speed,
+            epoch,
+            mu,
+            Some(499),
+            Some("Mars orbiter"),
+        )
+    }
+
+    /// A 17 000 km orbit about Mars shifts the apparent direction of Earth by
+    /// the orbit radius over the range: 47″ at the 0.498 AU close approach of
+    /// 2003 (46.9″ at exactly 0.5 AU).
+    #[test]
+    fn test_orbiter_parallax_matches_radius_over_range() {
+        use crate::jplephem_ext::SpiceKernelExt;
+
+        let mut kernel = de421_kernel();
+        let t = ts().tdb_jd(CLOSE_APPROACH_TDB);
+
+        let orbit = perpendicular_mars_orbit(&mut kernel, &t);
+        let orbiter = orbit.barycentric_at(&mut kernel, "mars", &t).unwrap();
+        let mars = kernel.at("mars", &t).unwrap();
+
+        let from_orbiter = orbiter.observe("earth", &mut kernel, &t).unwrap();
+        let from_mars = mars.observe("earth", &mut kernel, &t).unwrap();
+
+        let range_au = from_mars.distance();
+        let expected = ORBIT_RADIUS_KM / crate::constants::AU_KM / range_au;
+        let measured = from_orbiter.separation_from(&from_mars);
+
+        let arcsec = 180.0 / PI * 3600.0;
+        println!(
+            "Mars-Earth range {range_au:.4} AU: measured {:.3}\", expected {:.3}\"",
+            measured * arcsec,
+            expected * arcsec
+        );
+        assert!(
+            (range_au - 0.5).abs() < 0.01,
+            "range {range_au} AU is not the intended close approach"
+        );
+        assert!(
+            (measured - expected).abs() < 0.02 * expected,
+            "measured {}\" vs expected {}\"",
+            measured * arcsec,
+            expected * arcsec
+        );
+    }
+
+    /// The orbiter's state is its central body's plus the orbit's own, and
+    /// the velocity is present — that is what aberration needs.
+    #[test]
+    fn test_barycentric_at_adds_center_state() {
+        use crate::jplephem_ext::SpiceKernelExt;
+
+        let mut kernel = de421_kernel();
+        let t = ts().tdb_jd(CLOSE_APPROACH_TDB);
+
+        let orbit = perpendicular_mars_orbit(&mut kernel, &t);
+        let orbiter = orbit.barycentric_at(&mut kernel, "mars", &t).unwrap();
+        let mars = kernel.at("mars", &t).unwrap();
+        let relative = orbit.at(&t);
+
+        assert_eq!(orbiter.kind, crate::positions::PositionKind::Barycentric);
+        assert_eq!(orbiter.center, 0);
+        assert_eq!(orbiter.target, KEPLER_TARGET_ID);
+        assert_relative_eq!(
+            (orbiter.position - mars.position - relative.position).norm(),
+            0.0,
+            epsilon = 1e-15
+        );
+        assert_relative_eq!(
+            (orbiter.velocity - mars.velocity - relative.velocity).norm(),
+            0.0,
+            epsilon = 1e-15
+        );
+
+        // Circular orbit speed about Mars: 17 000 km radius gives 1.59 km/s.
+        let speed_km_s =
+            relative.velocity.norm() * crate::constants::AU_KM / crate::constants::DAY_S;
+        assert_relative_eq!(speed_km_s, 1.587, epsilon = 0.01);
+
+        // The offset from Mars is the orbit radius.
+        let offset_km = relative.position.norm() * crate::constants::AU_KM;
+        assert_relative_eq!(offset_km, ORBIT_RADIUS_KM, epsilon = 1e-6);
+    }
+
+    /// `observe` and `planetary_magnitude` both work from the orbiter, which
+    /// needs `observer_barycentric` to be populated.
+    #[test]
+    fn test_orbiter_observes_and_has_magnitude() {
+        let mut kernel = de421_kernel();
+        let t = ts().tdb_jd(CLOSE_APPROACH_TDB);
+
+        let orbit = perpendicular_mars_orbit(&mut kernel, &t);
+        let orbiter = orbit.barycentric_at(&mut kernel, "mars", &t).unwrap();
+
+        let earth = orbiter.observe("earth", &mut kernel, &t).unwrap();
+        assert!(earth.observer_barycentric.is_some());
+        let apparent = earth.apparent(&mut kernel, &t).unwrap();
+        assert_eq!(apparent.kind, crate::positions::PositionKind::Apparent);
+
+        // Earth from Mars at 0.5 AU near opposition is around magnitude -2.
+        let magnitude = crate::magnitudelib::planetary_magnitude(&earth, &t).unwrap();
+        assert!(
+            (-4.0..0.0).contains(&magnitude),
+            "Earth from Mars magnitude {magnitude}"
+        );
+    }
+
+    /// A Kepler orbit about Mars must use Mars's GM, not the Sun's.
+    #[test]
+    fn test_orbit_period_follows_the_center_gm() {
+        let mut kernel = de421_kernel();
+        let t = ts().tdb_jd(CLOSE_APPROACH_TDB);
+        let orbit = perpendicular_mars_orbit(&mut kernel, &t);
+
+        // Circular period 2*PI*sqrt(r^3/mu): 17 000 km about Mars is 18.69 h.
+        let radius_au = ORBIT_RADIUS_KM / crate::constants::AU_KM;
+        let period_days = 2.0 * PI * (radius_au.powi(3) / orbit.mu_au3_d2).sqrt();
+        assert_relative_eq!(period_days * 24.0, 18.69, epsilon = 0.01);
+
+        // Half a period later the orbiter is on the other side of Mars.
+        let half = ts().tdb_jd(CLOSE_APPROACH_TDB + period_days / 2.0);
+        let opposite = orbit.at(&half);
+        assert_relative_eq!(
+            (opposite.position + orbit.at(&t).position).norm(),
+            0.0,
+            epsilon = 1e-10
+        );
     }
 }

--- a/src/positions/mod.rs
+++ b/src/positions/mod.rs
@@ -22,6 +22,7 @@
 pub mod angular_size;
 pub mod ecliptic;
 pub mod illumination;
+pub mod spacecraft;
 pub mod stars;
 
 #[cfg(all(test, feature = "python-tests"))]

--- a/src/positions/spacecraft.rs
+++ b/src/positions/spacecraft.rs
@@ -1,0 +1,227 @@
+//! Barycentric observers from spacecraft SPK segments
+//!
+//! [`Position::from_spk_target`] resolves any SPK target id — including the
+//! negative ids NAIF assigns to spacecraft — to a barycentric position and
+//! velocity, so a spacecraft with its own kernel can be an observer just like
+//! a planet from `SpiceKernelExt::at`:
+//!
+//! ```ignore
+//! let mut kernel = SpiceKernel::open("mro_psp.bsp")?;
+//! let mro = Position::from_spk_target(&mut kernel, -74, &t)?;
+//! let earth = mro.observe("earth", &mut kernel, &t)?.apparent(&mut kernel, &t)?;
+//! ```
+//!
+//! # Supported segment types
+//!
+//! This crate's SPK reader implements data types 2, 3 and 21 (Chebyshev
+//! position, Chebyshev position and velocity, and extended modified difference
+//! arrays). Reconstructed spacecraft trajectories are commonly type 1 or
+//! type 13; a target whose only segments are of another type reports
+//! [`JplephemError::UnsupportedDataType`] rather than looking like a missing
+//! body. For a spacecraft whose kernel is unsupported — or one that has no
+//! kernel at all, because the trajectory is a study rather than a flown
+//! mission — model the orbit with
+//! [`KeplerOrbit::barycentric_at`](crate::keplerlib::KeplerOrbit::barycentric_at)
+//! instead.
+
+use crate::constants::{AU_KM, DAY_S};
+use crate::jplephem::errors::{JplephemError, Result};
+use crate::jplephem::kernel::SpiceKernel;
+use crate::jplephem::spk::jd_to_seconds;
+use crate::positions::Position;
+use crate::time::Time;
+
+/// SPK data types this crate's reader can evaluate.
+const SUPPORTED_DATA_TYPES: [i32; 3] = [2, 3, 21];
+
+impl Position {
+    /// Barycentric state of an SPK target id at `t`.
+    ///
+    /// Resolves the chain of segments from the solar system barycenter to
+    /// `target_id` exactly as `SpiceKernelExt::at` does for a named body, and
+    /// returns a [`crate::positions::PositionKind::Barycentric`] position in
+    /// AU and AU/day with `target` set to the requested id. Negative ids are
+    /// spacecraft; positive ids are the usual bodies, so
+    /// `from_spk_target(kernel, 399, t)` is `kernel.at("earth", t)`.
+    ///
+    /// # Errors
+    /// * [`JplephemError::UnsupportedDataType`] if the kernel holds segments
+    ///   for this target but of a data type the reader does not implement
+    ///   (see the module documentation)
+    /// * [`JplephemError::Other`] if no chain of segments reaches the target
+    /// * an out-of-range error if the segments do not cover `t`
+    pub fn from_spk_target(kernel: &mut SpiceKernel, target_id: i32, t: &Time) -> Result<Position> {
+        let chain = match kernel.get(&target_id.to_string()) {
+            Ok(vf) => vf.chain,
+            // A target with only unsupported segments is dropped when the file
+            // is parsed and so looks unreachable; say what actually happened.
+            Err(err) => return Err(unsupported_data_type(kernel, target_id).unwrap_or(err)),
+        };
+
+        let (position_km, velocity_km_s) =
+            kernel.compute_chain_pub(&chain, jd_to_seconds(t.tdb()))?;
+
+        Ok(Position::barycentric(
+            position_km / AU_KM,
+            velocity_km_s * DAY_S / AU_KM,
+            target_id,
+        ))
+    }
+}
+
+/// The unsupported data type of a segment for `target_id`, if that is why the
+/// target could not be resolved.
+fn unsupported_data_type(kernel: &SpiceKernel, target_id: i32) -> Option<JplephemError> {
+    let daf = &kernel.spk().daf;
+    let summaries = daf.summaries().ok()?;
+
+    for (_, values) in summaries {
+        if values.len() < (daf.nd + daf.ni) as usize {
+            continue;
+        }
+        let target = values[2] as i32;
+        let data_type = values[5] as i32;
+        if target == target_id && !SUPPORTED_DATA_TYPES.contains(&data_type) {
+            return Some(JplephemError::UnsupportedDataType(data_type));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jplephem_ext::SpiceKernelExt;
+    use crate::time::Timescale;
+
+    fn de421_kernel() -> SpiceKernel {
+        SpiceKernel::open("test_data/de421.bsp").expect("Failed to open DE421")
+    }
+
+    /// A DAF/SPK file in memory holding one segment of the given data type.
+    ///
+    /// Only the header, summary and name records are written: a segment of an
+    /// unsupported type is rejected before its data array is ever read.
+    fn synthetic_spk(target: i32, center: i32, data_type: i32) -> Vec<u8> {
+        const RECORD_SIZE: usize = 1024;
+        let start_i = 3 * RECORD_SIZE / 8 + 1;
+        let end_i = start_i + 7;
+
+        let mut file = vec![0u8; 3 * RECORD_SIZE + 64];
+        file[0..8].copy_from_slice(b"DAF/SPK ");
+        file[8..12].copy_from_slice(&2u32.to_le_bytes()); // ND
+        file[12..16].copy_from_slice(&6u32.to_le_bytes()); // NI
+        file[16..76].copy_from_slice(format!("{:<60}", "SYNTHETIC").as_bytes());
+        file[76..80].copy_from_slice(&2u32.to_le_bytes()); // FWARD
+        file[80..84].copy_from_slice(&2u32.to_le_bytes()); // BWARD
+        file[84..88].copy_from_slice(&((end_i + 1) as u32).to_le_bytes()); // FREE
+
+        let summary = RECORD_SIZE;
+        let mut put = |at: usize, value: f64| {
+            file[at..at + 8].copy_from_slice(&value.to_le_bytes());
+        };
+        put(summary, 0.0); // NEXT
+        put(summary + 8, 0.0); // PREV
+        put(summary + 16, 1.0); // NSUM
+        put(summary + 24, -1.0e9); // segment start, TDB seconds
+        put(summary + 32, 1.0e9); // segment end, TDB seconds
+
+        // Six integers packed two to a double-word.
+        let ints = [target, center, 1, data_type, start_i as i32, end_i as i32];
+        for (i, value) in ints.iter().enumerate() {
+            let at = summary + 40 + (i / 2) * 8 + (i % 2) * 4;
+            file[at..at + 4].copy_from_slice(&value.to_le_bytes());
+        }
+
+        file[2 * RECORD_SIZE..2 * RECORD_SIZE + 40]
+            .copy_from_slice(format!("{:<40}", "SYNTHETIC SPK").as_bytes());
+
+        file
+    }
+
+    #[test]
+    fn test_from_spk_target_earth_matches_named_lookup() {
+        let mut kernel = de421_kernel();
+        let ts = Timescale::default();
+        let t = ts.tdb_jd(2451545.0);
+
+        let by_name = kernel.at("earth", &t).unwrap();
+        let by_id = Position::from_spk_target(&mut kernel, 399, &t).unwrap();
+
+        assert_eq!(by_id.target, 399);
+        assert_eq!(by_id.center, 0);
+        assert_eq!(by_id.kind, crate::positions::PositionKind::Barycentric);
+        assert!((by_id.position - by_name.position).norm() < 1e-15);
+        assert!((by_id.velocity - by_name.velocity).norm() < 1e-15);
+    }
+
+    #[test]
+    fn test_from_spk_target_moon_matches_named_lookup() {
+        let mut kernel = de421_kernel();
+        let ts = Timescale::default();
+        let t = ts.tdb_jd(2451545.0);
+
+        let by_name = kernel.at("moon", &t).unwrap();
+        let by_id = Position::from_spk_target(&mut kernel, 301, &t).unwrap();
+
+        assert!((by_id.position - by_name.position).norm() < 1e-15);
+        assert!((by_id.velocity - by_name.velocity).norm() < 1e-15);
+    }
+
+    #[test]
+    fn test_from_spk_target_missing_body() {
+        let mut kernel = de421_kernel();
+        let ts = Timescale::default();
+        let t = ts.tdb_jd(2451545.0);
+
+        // -74 is Mars Reconnaissance Orbiter; DE421 has no spacecraft.
+        let err = Position::from_spk_target(&mut kernel, -74, &t).unwrap_err();
+        assert!(
+            matches!(err, JplephemError::Other(ref m) if m.contains("No path from SSB")),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_from_spk_target_unsupported_data_type() {
+        let ts = Timescale::default();
+        let t = ts.tdb_jd(2451545.0);
+
+        // Type 1 (modified difference arrays) is the usual reconstructed
+        // spacecraft trajectory, and is not implemented.
+        let bytes = synthetic_spk(-74, 4, 1);
+        let mut kernel = SpiceKernel::from_bytes(&bytes).unwrap();
+        let err = Position::from_spk_target(&mut kernel, -74, &t).unwrap_err();
+        assert!(
+            matches!(err, JplephemError::UnsupportedDataType(1)),
+            "unexpected error: {err}"
+        );
+
+        // Type 13 (Hermite interpolation) likewise.
+        let bytes = synthetic_spk(-74, 4, 13);
+        let mut kernel = SpiceKernel::from_bytes(&bytes).unwrap();
+        let err = Position::from_spk_target(&mut kernel, -74, &t).unwrap_err();
+        assert!(
+            matches!(err, JplephemError::UnsupportedDataType(13)),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_from_spk_target_observes_and_apparent() {
+        let mut kernel = de421_kernel();
+        let ts = Timescale::default();
+        let t = ts.tdb_jd(2451545.0);
+
+        let mars = Position::from_spk_target(&mut kernel, 499, &t).unwrap();
+        let earth = mars
+            .observe("earth", &mut kernel, &t)
+            .unwrap()
+            .apparent(&mut kernel, &t)
+            .unwrap();
+
+        assert_eq!(earth.target, 399);
+        assert!(earth.observer_barycentric.is_some());
+        assert!(earth.distance() > 0.3 && earth.distance() < 2.7);
+    }
+}

--- a/src/positions/spacecraft.rs
+++ b/src/positions/spacecraft.rs
@@ -27,12 +27,9 @@
 use crate::constants::{AU_KM, DAY_S};
 use crate::jplephem::errors::{JplephemError, Result};
 use crate::jplephem::kernel::SpiceKernel;
-use crate::jplephem::spk::jd_to_seconds;
+use crate::jplephem::spk::{jd_to_seconds, SUPPORTED_DATA_TYPES};
 use crate::positions::Position;
 use crate::time::Time;
-
-/// SPK data types this crate's reader can evaluate.
-const SUPPORTED_DATA_TYPES: [i32; 3] = [2, 3, 21];
 
 impl Position {
     /// Barycentric state of an SPK target id at `t`.


### PR DESCRIPTION
## Summary

Observers were either barycentric bodies from `SpiceKernelExt::at` or ground
sites from `toposlib`. This adds the missing case — a spacecraft — by both
routes: a modelled orbit, and a real SPK kernel.

- `KeplerOrbit::barycentric_at(kernel, center, t)` adds the central body's
  barycentric state to the orbit's own position **and velocity**
  (`KeplerOrbit::at` already returns both, relative to the centre), giving a
  `Barycentric` position whose velocity makes light-time and aberration come
  out right. `target` is the documented sentinel `KEPLER_TARGET_ID` (-1000001,
  outside NAIF's -1…-999999 spacecraft range), since an elements-defined body
  has no NAIF id.
- `Position::from_spk_target(kernel, target_id, t)` in
  `src/positions/spacecraft.rs` resolves any SPK target id — negative ids are
  spacecraft — to a barycentric state through the same SSB chain the named
  lookup uses. Only SPK types 2, 3 and 21 are implemented; reconstructed
  spacecraft trajectories are commonly type 1 or 13, and those now report
  `UnsupportedDataType` instead of looking like a missing body (segments of an
  unsupported type are dropped at parse time, so the target would otherwise
  appear unreachable). The limitation is documented on the module and the
  method, pointing at `barycentric_at` as the alternative.
- No change was needed to how `KeplerOrbit` handles GM: it already stores
  `mu_au3_d2` and takes `gm_km3_s2` + a `center` id in its constructors, so a
  body orbiting Mars just gets Mars's GM. What was missing were the values —
  `constants` gains `GM_MERCURY`, `GM_VENUS`, `GM_EARTH`, `GM_MOON`,
  `GM_MARS`, `GM_MARS_SYSTEM`, `GM_JUPITER`, `GM_SATURN`, `GM_URANUS`,
  `GM_NEPTUNE`, `GM_PLUTO` in km³/s² (JPL DE440, Park et al. 2021, AJ 161,
  105), matching `GM_SUN`'s existing units, plus `GM_KM3_S2_TO_AU3_D2`;
  keplerlib's private copy of that conversion is replaced by the shared one.
- `examples/mars_orbiter.rs` — a 17 000 km circular orbit about Mars observing
  Earth, with the magnitude, the offset from a Mars-centre observer, and what
  `from_spk_target` says about a spacecraft DE421 does not carry.

### Correction to the issue text

The issue asks for "~55″ at 0.5 AU". That is wrong: 17 000 km at 0.5 AU
subtends 17000 / (0.5 × 1.496e8) = 2.27e-4 rad = **46.9″** (55″ corresponds to
0.43 AU). The test asserts the value computed from the actual range at the
chosen epoch, within 2 %.

## Test plan

`cargo fmt`, `cargo clippy --all-targets` (no new lints), `cargo test`:
686 passed, 0 failed, 23 ignored. `cargo test --features python-tests`:
798 passed, 1 failed — the pre-existing astropy Sérsic comparison, untouched
by this branch.

New tests:

- `test_orbiter_parallax_matches_radius_over_range` — an observer on the
  17 000 km orbit, placed a quarter turn from the Mars-Earth line, observing
  Earth at the 2003-10-02 close approach: Mars-Earth range **0.4980 AU**,
  **measured 47.066″, expected 47.066″** (radius/range), asserted within 2 %.
- `test_barycentric_at_adds_center_state` — the state is exactly the centre's
  plus the orbit's, to 1e-15 AU and AU/day; the offset is 17 000 km and the
  circular speed 1.587 km/s.
- `test_orbiter_observes_and_has_magnitude` — `observe`, `apparent` and
  `magnitudelib::planetary_magnitude` all succeed from the orbiter
  (`observer_barycentric` populated); Earth from Mars comes out at V −1.92.
- `test_orbit_period_follows_the_center_gm` — 18.69 h for 17 000 km about
  Mars, and half a period later the orbiter is diametrically opposite; a
  heliocentric GM would give neither.
- `from_spk_target(399)` and `(301)` equal `kernel.at("earth")` and
  `at("moon")` to 1e-15; `(-74)` on DE421 reports no path to the body; a
  synthetic in-memory DAF/SPK with a single type-1 (and type-13) segment
  reports `UnsupportedDataType(1)` / `UnsupportedDataType(13)`.

Closes #167
