### PR TITLE
frame_for picks the lunar principal-axes frame

### DIFF
--- a/src/planetarylib/mod.rs
+++ b/src/planetarylib/mod.rs
@@ -262,6 +262,13 @@ fn coefficients(values: &[f64]) -> Option<[f64; 3]> {
 /// The NAIF code of the Earth, the one body served by a frame of its own.
 const EARTH: i32 = 399;
 
+/// The NAIF code of the Moon.
+const MOON: i32 = 301;
+
+/// The frame class ids of the lunar principal-axes frames, best first:
+/// `MOON_PA_DE440` then `MOON_PA_DE421`.
+const MOON_PA_FRAMES: [i32; 2] = [31008, 31006];
+
 /// The magic numbers that open a NAIF text kernel.
 const TEXT_MAGIC_NUMBERS: [&str; 2] = ["KPL/FK", "KPL/PCK"];
 
@@ -571,20 +578,31 @@ impl PlanetaryConstants {
 
     /// The body-fixed frame of a body, choosing the best available source.
     ///
-    /// The Earth gets [`ItrsFrame`], whose IERS-grade rotation is orders of
-    /// magnitude better than the IAU polynomials — those are about 0.06° out
-    /// at present — while every other body gets an [`IauFrame`] built from the
-    /// kernels read so far. This is the one place the choice is made, so
-    /// callers need not know the rule.
+    /// Three rules, and this is the one place they are applied, so callers
+    /// need not know them:
     ///
-    /// Once binary PCK support lands, a body with a loaded high-accuracy
-    /// segment — the Moon with a `moon_pa_*.bpc` kernel, say — will be served
-    /// from that segment instead, and only this method will change.
+    /// * the Earth gets [`ItrsFrame`], whose IERS-grade rotation is orders of
+    ///   magnitude better than the IAU polynomials — those are about 0.06° out
+    ///   at present;
+    /// * the Moon gets a [`PckFrame`] on its principal-axes frame when a
+    ///   binary PCK for one has been read — `MOON_PA_DE440` (frame class id
+    ///   31008) in preference to `MOON_PA_DE421` (31006) — because those come
+    ///   from the same fits as the ephemerides where the IAU elements are a
+    ///   truncated series;
+    /// * every other body, and the Moon without such a kernel, gets an
+    ///   [`IauFrame`] built from the kernels read so far.
+    ///
+    /// The lunar frame is taken straight from the segment, so no frame kernel
+    /// need be read for it; `moon_080317.tf` is needed only to reach the
+    /// frames by name through [`build_frame_named`](Self::build_frame_named)
+    /// or to fold in the `MOON_ME` offset.
     ///
     /// # Errors
     ///
     /// Returns [`StarfieldError::DataError`] if the kernels read so far define
-    /// no rotational elements for `body`.
+    /// no rotational elements for `body`, or if a lunar principal-axes segment
+    /// has been read that is relative to something other than J2000, which is
+    /// the only reference frame the rotation assumes.
     ///
     /// # Example
     ///
@@ -606,7 +624,32 @@ impl PlanetaryConstants {
         if body == EARTH {
             return Ok(Box::new(ItrsFrame));
         }
+        if body == MOON {
+            if let Some(frame) = self.moon_principal_axes()? {
+                return Ok(Box::new(frame));
+            }
+        }
         Ok(Box::new(IauFrame::new(body, self)?))
+    }
+
+    /// The lunar principal-axes frame of the best binary PCK read so far, or
+    /// `None` if none has been.
+    fn moon_principal_axes(&self) -> Result<Option<PckFrame>> {
+        for id in MOON_PA_FRAMES {
+            let Some(segment) = self.segment_map.get(&id) else {
+                continue;
+            };
+            if segment.frame != 1 {
+                return Err(StarfieldError::DataError(format!(
+                    "the lunar principal-axes segment for frame {} is defined \
+                     relative to reference frame {}, but only J2000 (1) is \
+                     supported",
+                    id, segment.frame
+                )));
+            }
+            return Ok(Some(PckFrame::new(MOON, Arc::clone(segment), None)));
+        }
+        Ok(None)
     }
 
     /// A variable read as a polynomial of up to three terms.

--- a/src/planetarylib/pck_frame.rs
+++ b/src/planetarylib/pck_frame.rs
@@ -10,7 +10,10 @@
 //!
 //! Build one with
 //! [`PlanetaryConstants::build_frame_named`](crate::planetarylib::PlanetaryConstants::build_frame_named),
-//! which is the port of Skyfield's `planetarylib.PlanetaryConstants`.
+//! which is the port of Skyfield's `planetarylib.PlanetaryConstants`, or let
+//! [`PlanetaryConstants::frame_for`](crate::planetarylib::PlanetaryConstants::frame_for)
+//! reach for one on its own: given the Moon and a loaded `moon_pa_*.bpc` it
+//! returns the principal-axes frame rather than the IAU elements.
 //!
 //! This is the most accurate body-fixed frame available for the Moon: the
 //! lunar principal-axes frames `MOON_PA_DE421` (frame class id 31006) and
@@ -510,6 +513,107 @@ mod tests {
         .unwrap();
         assert!(pc.build_frame_named("MOON_PA_DE421").is_err());
         assert!(pc.build_frame_named("NO_SUCH_FRAME").is_err());
+    }
+
+    /// A verbatim excerpt of `pck00011.tpc`, the source of the IAU elements
+    /// the Moon falls back on when no binary kernel has been read.
+    const EXCERPT: &str = include_str!("pck00011_excerpt.tpc");
+
+    /// A synthetic principal-axes kernel covering one day about J2000, whose
+    /// three Euler angles are constant and of the test's choosing.
+    fn synthetic_moon_pa(frame_id: i32, angles: [f64; 3]) -> crate::jplephem::pck::PCK {
+        let coefficients = std::array::from_fn(|i| vec![angles[i], 0.0, 0.0]);
+        let bytes = test_support::synthetic_pck(
+            frame_id,
+            2,
+            &[(0.0, crate::jplephem::S_PER_DAY / 2.0, coefficients)],
+        )
+        .unwrap();
+        crate::jplephem::pck::PCK::from_bytes(&bytes).unwrap()
+    }
+
+    /// `frame_for(301)` prefers a loaded principal-axes segment to the IAU
+    /// elements, and needs no frame kernel to do it.
+    #[test]
+    fn test_frame_for_the_moon_prefers_a_principal_axes_kernel() {
+        use crate::planetarylib::IauFrame;
+        use crate::planetlib::Body;
+
+        let angles = [0.375, 1.0, 0.5];
+        let mut pc = PlanetaryConstants::new();
+        pc.read_text(EXCERPT).unwrap();
+        pc.read_binary(synthetic_moon_pa(test_support::MOON_PA_DE421, angles));
+
+        let t = crate::time::Timescale::default().tdb_jd(2451545.0);
+        let expected = rot_z(-angles[2]) * rot_x(-angles[1]) * rot_z(-angles[0]);
+        let frame = pc.frame_for(301).unwrap();
+        assert!((frame.rotation_at(&t) - expected).abs().max() < 1e-14);
+
+        // Without the binary kernel the same call gives the IAU elements.
+        let mut iau_only = PlanetaryConstants::new();
+        iau_only.read_text(EXCERPT).unwrap();
+        assert_eq!(
+            iau_only.frame_for(301).unwrap().rotation_at(&t),
+            IauFrame::from_body(Body::Moon).rotation_at(&t)
+        );
+        // And the two frames really are different frames.
+        assert!(
+            (frame.rotation_at(&t) - IauFrame::from_body(Body::Moon).rotation_at(&t))
+                .abs()
+                .max()
+                > 1e-3
+        );
+    }
+
+    /// `MOON_PA_DE440` wins when both principal-axes kernels are loaded.
+    #[test]
+    fn test_frame_for_the_moon_prefers_de440_to_de421() {
+        let de421 = [0.375, 1.0, 0.5];
+        let de440 = [0.25, 0.75, 0.125];
+
+        let mut pc = PlanetaryConstants::new();
+        pc.read_binary(synthetic_moon_pa(test_support::MOON_PA_DE421, de421));
+        pc.read_binary(synthetic_moon_pa(31008, de440));
+
+        let t = crate::time::Timescale::default().tdb_jd(2451545.0);
+        let expected = rot_z(-de440[2]) * rot_x(-de440[1]) * rot_z(-de440[0]);
+        let rotation = pc.frame_for(301).unwrap().rotation_at(&t);
+        assert!((rotation - expected).abs().max() < 1e-14);
+    }
+
+    /// The real kernel, against the same golden matrices Skyfield produced —
+    /// and without a frame kernel, which `frame_for` does not need.
+    #[test]
+    #[ignore = "downloads moon_pa_de421_1900-2050.bpc"]
+    fn test_frame_for_the_moon_matches_the_published_kernel() {
+        let loader = crate::Loader::new();
+        let mut pc = PlanetaryConstants::new();
+        pc.read_binary(
+            loader
+                .open_binary_pck("moon_pa_de421_1900-2050.bpc")
+                .unwrap(),
+        );
+        assert!(pc.build_frame_named("MOON_PA_DE421").is_err());
+
+        let frame = pc.frame_for(301).unwrap();
+        let ts = crate::time::Timescale::default();
+        for (jd, expected) in MOON_PA_DE421_GOLDEN {
+            let t = ts.tdb_jd(jd);
+            assert_matches(&frame.rotation_at(&t), &expected, 1e-9, &format!("JD {jd}"));
+        }
+    }
+
+    /// A body other than the Moon ignores the lunar segments entirely, and
+    /// with no elements read there is nothing to build it from.
+    #[test]
+    fn test_frame_for_another_body_ignores_the_lunar_segments() {
+        let mut pc = PlanetaryConstants::new();
+        pc.read_binary(synthetic_moon_pa(
+            test_support::MOON_PA_DE421,
+            [0.375, 1.0, 0.5],
+        ));
+        assert!(pc.frame_for(499).is_err());
+        assert!(pc.frame_for(301).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The last third of the plan's §2.2 rule, left as a doc note in #177: `PlanetaryConstants::frame_for` now serves the Moon from a binary PCK when one has been read.

```
399  →  ItrsFrame                                    (unchanged)
301  →  PckFrame on MOON_PA_DE440 (31008), else on MOON_PA_DE421 (31006),
        else IauFrame                                (new)
*    →  IauFrame                                     (unchanged)
```

The frame is taken straight from the segment with centre 301, so **no frame kernel is needed** — `moon_080317.tf` is required only to reach the frames *by name* through `build_frame_named`, or to fold in the `MOON_ME` offset. A lunar segment relative to anything other than J2000 is a `DataError`, the same guard `build_frame` already applies, since that is the only reference frame the rotation assumes.

The `frame_for` doc comment now states all three rules and the error cases; `pck_frame`'s module doc points at it.

## Closes #169 as well

#169 asked for `NAIF_PCK_URL`, `resolve_url` mapping `*.tpc`/`*.bpc` to it, and typed `Loader` open helpers. All of it is on `main` already, landed piecemeal with #173, #175 and #176:

- `data::downloader::NAIF_PCK_URL` (`src/data/downloader.rs:31`), with `resolve_url` mapping `.tpc` and `.bpc` there and `.tf` to the NAIF satellite FK directory. Unit tests `test_resolve_url_text_pck`, `test_resolve_url_binary_pck`, `test_resolve_url_frame_kernel` run without a network.
- `Loader::open_text_pck(filename) -> Result<PlanetaryConstants>` and `Loader::open_binary_pck(filename) -> Result<PCK>` (`src/lib.rs:211`, `src/lib.rs:236`), both downloading into `~/.cache/starfield/` on demand. The issue proposed a `TextPck` return type; `PlanetaryConstants` is that parser's result and a superset of it, so no separate type was introduced.
- Download coverage: `test_known_endpoints_reachable` HEADs `pck00011.tpc` and `moon_pa_de440_200625.bpc` among the rest, and the `#[ignore]`d `pck_frame` tests fetch and parse the real `moon_pa_de421_1900-2050.bpc` through `Loader`.

Nothing was missing, so nothing was implemented for it here beyond the new ignored test below, which exercises `Loader::open_binary_pck` on the published kernel.

## Test plan

- `cargo fmt`, `cargo clippy --all-targets` (only the three pre-existing `approx_constant` errors in `catalogs`/`coordinates`/`sbdb` test code), `cargo test`: **680 passed, 0 failed, 23 ignored**, plus 79 doc tests. `cargo test --features python-tests`: 792 passed, 1 failed — the pre-existing astropy Sérsic comparison.
- New tests in `pck_frame.rs`, using the in-memory `jplephem::pck::test_support` builder, so no kernel is downloaded:
  - `test_frame_for_the_moon_prefers_a_principal_axes_kernel` — a synthetic 31006 segment with chosen Euler angles: `frame_for(301)` reproduces `rot_z(−W)·rot_x(−δ)·rot_z(−α)` on them, while the same constants without the binary kernel give exactly `IauFrame::from_body(Body::Moon)`, and the two frames differ by far more than the tolerance.
  - `test_frame_for_the_moon_prefers_de440_to_de421` — both frames loaded, DE440 wins.
  - `test_frame_for_another_body_ignores_the_lunar_segments` — a loaded lunar segment does not rescue `frame_for(499)`.
  - `test_frame_for_the_moon_matches_the_published_kernel` (`#[ignore]`, downloads `moon_pa_de421_1900-2050.bpc`) — reproduces the three checked-in Skyfield golden matrices to 1e-9, with no frame kernel read. Run and passing locally.
- The existing `test_frame_for_picks_itrs_for_the_earth` (399 → `ItrsFrame`, 499 → `IauFrame`, unknown → error) is untouched and passing.

Closes #169
