### PR TITLE
Add sub-observer and sub-solar points

### DIFF
--- a/examples/sub_points.rs
+++ b/examples/sub_points.rs
@@ -1,0 +1,74 @@
+//! Sub-observer and sub-solar points: which hemisphere of a body faces the
+//! observer, and which faces the Sun.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo run --example sub_points
+//! ```
+
+use starfield::framelib::{Frame, ItrsFrame};
+use starfield::jplephem::kernel::SpiceKernel;
+use starfield::jplephem_ext::SpiceKernelExt;
+use starfield::planetarylib::subpoint::{LongitudeSense, SubPoint};
+use starfield::planetarylib::{body_constants, IauFrame};
+use starfield::time::Timescale;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut kernel = SpiceKernel::open("test_data/de421.bsp")?;
+    let ts = Timescale::default();
+
+    // The epoch of the HiRISE image PSP_005558_9040, in which Mars
+    // Reconnaissance Orbiter photographed a gibbous Earth.
+    const EPOCH: &str = "2007-10-03 00:00 UTC";
+    let t = ts.utc((2007, 10, 3, 0, 0, 0.0));
+
+    // Mars as an Earth-bound observer sees it, then the Earth seen from Mars.
+    for (target, center) in [(499, 399), (399, 499)] {
+        let constants = body_constants(target).unwrap();
+        let radii = constants.radii;
+
+        // The Earth is the one body with a frame better than its IAU
+        // elements; everything else uses the WGCCRE polynomials.
+        let frame: Box<dyn Frame> = if target == 399 {
+            Box::new(ItrsFrame)
+        } else {
+            Box::new(IauFrame::from_naif_id(target).unwrap())
+        };
+
+        let observer = kernel.at(&center.to_string(), &t)?;
+        let position = observer.observe(&target.to_string(), &mut kernel, &t)?;
+
+        let sub_observer = position.sub_observer_point(frame.as_ref(), radii, &t);
+        let sub_solar = position.sub_solar_point(frame.as_ref(), radii, &mut kernel, &t)?;
+
+        println!(
+            "{} seen from {} at {EPOCH}",
+            constants.name,
+            body_constants(center).unwrap().name,
+        );
+        report("sub-observer", &sub_observer, target, radii);
+        report("sub-solar", &sub_solar, target, radii);
+        println!();
+    }
+
+    Ok(())
+}
+
+/// Print one sub-point in every form: the reported planetographic longitude,
+/// the east longitude of the underlying frame, and both latitudes.
+fn report(label: &str, point: &SubPoint, target: i32, radii: [f64; 3]) {
+    let sense = LongitudeSense::for_body(target);
+    let direction = match sense {
+        LongitudeSense::East => "E",
+        LongitudeSense::West => "W",
+    };
+    println!(
+        "  {label:<13} {:9.4}° {direction}  {:8.4}° planetographic   \
+         ({:9.4}° E, {:8.4}° planetocentric)",
+        point.longitude_in(sense).to_degrees(),
+        point.lat_rad.to_degrees(),
+        point.lon_rad.to_degrees(),
+        point.to_planetocentric(radii).lat_rad.to_degrees(),
+    );
+}

--- a/src/data/horizons.rs
+++ b/src/data/horizons.rs
@@ -566,6 +566,12 @@ pub struct EphemerisRequest {
     pub quantities: Option<String>,
     /// RA/Dec angle format: "HMS" or "DEG"
     pub ang_format: Option<String>,
+    /// Date column format of an observer table: "CAL", "JD" or "BOTH".
+    ///
+    /// HORIZONS defaults to "CAL", whose date strings
+    /// [`parser::parse_observer_rows`](crate::horizons::parser::parse_observer_rows)
+    /// cannot key rows by; set "JD" to get a Julian date in the first column.
+    pub cal_format: Option<String>,
     /// Enable CSV-format output
     pub csv_format: bool,
     /// Extra precision in RA/Dec
@@ -596,6 +602,7 @@ impl EphemerisRequest {
             ref_plane: Some(ReferencePlane::Ecliptic),
             quantities: None,
             ang_format: None,
+            cal_format: None,
             csv_format: true,
             extra_prec: false,
             ca_table_type: None,
@@ -619,6 +626,7 @@ impl EphemerisRequest {
             ref_plane: None,
             quantities: Some("1,9,20,23".to_string()),
             ang_format: Some("DEG".to_string()),
+            cal_format: None,
             csv_format: true,
             extra_prec: true,
             ca_table_type: None,
@@ -642,6 +650,7 @@ impl EphemerisRequest {
             ref_plane: Some(ReferencePlane::Ecliptic),
             quantities: None,
             ang_format: None,
+            cal_format: None,
             csv_format: true,
             extra_prec: false,
             ca_table_type: None,
@@ -668,6 +677,7 @@ impl EphemerisRequest {
             ref_plane: None,
             quantities: None,
             ang_format: None,
+            cal_format: None,
             csv_format: false,
             extra_prec: false,
             ca_table_type: Some(CaTableType::Standard),
@@ -698,6 +708,7 @@ impl EphemerisRequest {
             ref_plane: None,
             quantities: None,
             ang_format: None,
+            cal_format: None,
             csv_format: false,
             extra_prec: false,
             ca_table_type: None,
@@ -805,6 +816,10 @@ impl EphemerisRequest {
 
         if let Some(fmt) = &self.ang_format {
             params.push(("ANG_FORMAT".into(), format!("'{}'", fmt)));
+        }
+
+        if let Some(fmt) = &self.cal_format {
+            params.push(("CAL_FORMAT".into(), format!("'{}'", fmt)));
         }
 
         if self.csv_format {

--- a/src/planetarylib/horizons_disk_orientation.csv
+++ b/src/planetarylib/horizons_disk_orientation.csv
@@ -1,0 +1,39 @@
+# Disc orientation of Mars seen from the Earth and of the Earth seen from Mars,
+# as published by the JPL Horizons observer table.
+#
+# Source : https://ssd.jpl.nasa.gov/api/horizons.api
+#          EPHEM_TYPE='OBSERVER' QUANTITIES='14,15,16,17' CSV_FORMAT='YES'
+#          ANG_FORMAT='DEG' EXTRA_PREC='YES' CAL_FORMAT='JD' OBJ_DATA='NO'
+#          COMMAND='499' CENTER='500@399' and COMMAND='399' CENTER='500@499'
+#          TLIST=2451545.0,2454376.5,2459136.5
+# Fetched : 2026-09-08, Horizons API version 1.2
+# Reprodu.: src/planetarylib/subpoint.rs, test_horizons_fixture_is_current
+#
+# Horizons quantity 14 is the sub-observer point, 15 the sub-solar point, 16
+# the position angle and disc-centre distance of the sub-solar point and 17
+# the same pair for the north pole. Both longitudes are planetodetic and are
+# given in the sense of the target's cartographic system, which the header of
+# the response states: west-positive for Mars (IAU_MARS), east-positive for
+# the Earth (ITRF93). Both latitudes are planetodetic, so they carry the
+# oblateness of the reference ellipsoid. Both position angles are measured
+# counter-clockwise on the sky from the north of the reference frame of the
+# observer's own body: the equator of date of the Earth for a geocentric
+# observer, and the IAU pole of Mars for a Mars-centred one.
+#
+# Columns
+#   target           NAIF code of the body whose disc is described
+#   center           NAIF code of the body the observer sits at the centre of
+#   jd_ut            Julian date of the row, on the UT scale Horizons prints
+#   obs_sub_lon_deg  ObsSub-LON, degrees
+#   obs_sub_lat_deg  ObsSub-LAT, degrees
+#   sun_sub_lon_deg  SunSub-LON, degrees
+#   sun_sub_lat_deg  SunSub-LAT, degrees
+#   sn_ang_deg       SN.ang, degrees
+#   np_ang_deg       NP.ang, degrees
+target,center,jd_ut,obs_sub_lon_deg,obs_sub_lat_deg,sun_sub_lon_deg,sun_sub_lat_deg,sn_ang_deg,np_ang_deg
+499,399,2451545.0,69.543497,-23.259282,35.074453,-25.374217,250.71,351.6251
+499,399,2454376.5,256.913283,3.994735,295.492284,-14.577633,90.77,334.3250
+499,399,2459136.5,171.769746,-20.714866,171.230584,-22.780267,158.63,325.1196
+399,499,2451545.0,53.918289,-13.266617,4.663870,-23.172174,100.91,351.6251
+399,499,2454376.5,82.612091,23.556937,179.302262,-3.750493,243.55,334.3250
+399,499,2459136.5,358.476685,5.482393,177.371431,-8.286490,166.46,325.1196

--- a/src/planetarylib/mod.rs
+++ b/src/planetarylib/mod.rs
@@ -53,6 +53,7 @@ pub mod occult;
 pub mod pck_frame;
 #[cfg(all(test, feature = "python-tests"))]
 mod python_tests;
+pub mod subpoint;
 pub mod text_pck;
 
 use std::collections::HashMap;

--- a/src/planetarylib/subpoint.rs
+++ b/src/planetarylib/subpoint.rs
@@ -1,0 +1,708 @@
+//! Sub-observer and sub-solar points: which face of a body is turned toward
+//! the observer, and which toward the Sun.
+//!
+//! The sub-observer point is where the line from the body's centre to the
+//! observer pierces the body's surface — the centre of the apparent disc. The
+//! sub-solar point is the same construction toward the Sun, and the great
+//! circle 90° from it is the terminator. Together they say which hemisphere of
+//! a texture to draw and where the day-night line falls across it.
+//!
+//! Both are methods on [`Position`] and both need a body-fixed
+//! [`Frame`]: [`IauFrame`](crate::planetarylib::IauFrame) for most bodies,
+//! [`ItrsFrame`](crate::framelib::ItrsFrame) for the Earth, or whichever frame
+//! [`PlanetaryConstants::frame_for`](crate::planetarylib::PlanetaryConstants::frame_for)
+//! picks. The frame is evaluated at the light-time corrected epoch
+//! `t − light_time`, the moment the light now reaching the observer left the
+//! body, which is what SPICE's `subpnt` does with aberration correction
+//! `LT+S` and what JPL Horizons reports.
+//!
+//! # Planetocentric, planetographic, east and west
+//!
+//! Two latitudes and two longitude senses are in circulation, and Horizons
+//! and SPICE report the ones that are least convenient to compute:
+//!
+//! * **Planetocentric** latitude is the angle at the centre of the body
+//!   between its equator and the point. It is what the body-fixed vector
+//!   gives directly.
+//! * **Planetographic** (the SPICE term is *planetodetic*) latitude is the
+//!   angle between the equator and the surface normal at the point, so it
+//!   carries the body's oblateness. For the disc-centre construction used
+//!   here the two are related by `tan φ_graphic = (a/c)² tan φ_centric`. The
+//!   difference reaches 0.19° on Mars and 0.19° on the Earth, and 4° on
+//!   Saturn.
+//! * **Longitude** runs east in every body-fixed frame — the IAU prime
+//!   meridian angle W increases eastward — but planetographic longitude is
+//!   reported *west*-positive for bodies that rotate prograde, and
+//!   east-positive for the retrograde rotators and for the three bodies the
+//!   IAU exempts. [`LongitudeSense::for_body`] holds the table.
+//!
+//! The two methods here return planetographic points, since that is what the
+//! references publish; [`SubPoint::to_planetocentric`] converts back, and
+//! [`SubPoint::longitude_in`] applies a longitude sense.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use starfield::jplephem::kernel::SpiceKernel;
+//! use starfield::jplephem_ext::SpiceKernelExt;
+//! use starfield::planetarylib::subpoint::LongitudeSense;
+//! use starfield::planetarylib::IauFrame;
+//! use starfield::planetlib::Body;
+//! use starfield::time::Timescale;
+//!
+//! let mut kernel = SpiceKernel::open("test_data/de421.bsp").unwrap();
+//! let t = Timescale::default().utc((2007, 10, 3, 0, 0, 0.0));
+//!
+//! let frame = IauFrame::from_body(Body::Mars);
+//! let radii = Body::Mars.radii_km();
+//!
+//! let earth = kernel.at("earth", &t).unwrap();
+//! let mars = earth.observe("mars", &mut kernel, &t).unwrap();
+//!
+//! let sub_observer = mars.sub_observer_point(&frame, radii, &t);
+//! println!(
+//!     "sub-observer: {:.3}° W, {:.3}° N",
+//!     sub_observer.longitude_in(LongitudeSense::West).to_degrees(),
+//!     sub_observer.lat_rad.to_degrees(),
+//! );
+//! ```
+
+use nalgebra::Vector3;
+
+use crate::constants::{C_AUDAY, TAU};
+use crate::framelib::Frame;
+use crate::jplephem::kernel::SpiceKernel;
+use crate::jplephem_ext::SpiceKernelExt;
+use crate::positions::Position;
+use crate::time::Time;
+use crate::Result;
+
+/// How many times the Sun's position is re-evaluated to remove the light time
+/// of the Sun → target leg. The leg is under 20 minutes for every body in
+/// DE421 and the Sun moves by metres in that time, so one pass converges.
+const SUN_LIGHT_TIME_ITERATIONS: usize = 2;
+
+/// A point on a body's surface, given as a longitude and a latitude.
+///
+/// Produced by [`Position::sub_observer_point`] and
+/// [`Position::sub_solar_point`]. The longitude is always **east**-positive
+/// and in `[0, 2π)`; use [`longitude_in`](Self::longitude_in) to get the
+/// west-positive value that the IAU and Horizons report for most bodies.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SubPoint {
+    /// East-positive longitude in the body-fixed frame, radians in `[0, 2π)`.
+    pub lon_rad: f64,
+    /// Latitude in radians, positive north.
+    pub lat_rad: f64,
+    /// Whether `lat_rad` is planetocentric. When false it is planetographic,
+    /// the oblate latitude of the surface normal, which is what
+    /// [`Position::sub_observer_point`] returns.
+    pub planetocentric: bool,
+}
+
+/// The direction in which a body's planetographic longitude is measured.
+///
+/// The IAU rule (Archinal et al. 2018 §2) is that planetographic longitude
+/// increases in the direction *opposite* to the body's rotation, which makes
+/// it west-positive for the prograde rotators and east-positive for the
+/// retrograde ones — with the Earth, the Moon and the Sun exempted by long
+/// convention and measured east-positive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LongitudeSense {
+    /// Longitude increases eastward, the sense of every body-fixed frame and
+    /// of the reported longitudes of the Sun, Earth, Moon, Venus, Uranus and
+    /// Pluto.
+    East,
+    /// Longitude increases westward, the sense in which the IAU and JPL
+    /// Horizons report Mercury, Mars, Jupiter, Saturn and Neptune.
+    West,
+}
+
+impl LongitudeSense {
+    /// The sense in which planetographic longitude is reported for a body.
+    ///
+    /// | NAIF code | Body | Sense |
+    /// |---|---|---|
+    /// | 10 | Sun | east |
+    /// | 199 | Mercury | west |
+    /// | 299 | Venus | east (retrograde) |
+    /// | 301 | Moon | east |
+    /// | 399 | Earth | east |
+    /// | 499 | Mars | west |
+    /// | 599 | Jupiter | west |
+    /// | 699 | Saturn | west |
+    /// | 799 | Uranus | east (retrograde) |
+    /// | 899 | Neptune | west |
+    /// | 999 | Pluto | east (retrograde) |
+    ///
+    /// Every entry agrees with the `{West-longitude positive}` or
+    /// `{East-longitude positive}` note that JPL Horizons prints in the
+    /// `Target pole/equ` line of an observer table. A barycentre code (`4`
+    /// for Mars, and so on) is read as the body of the same system, and an
+    /// unknown code falls back to east, the sense of the underlying frame.
+    pub fn for_body(naif_id: i32) -> Self {
+        let body = if (1..=9).contains(&naif_id) {
+            naif_id * 100 + 99
+        } else {
+            naif_id
+        };
+        match body {
+            199 | 499 | 599 | 699 | 899 => LongitudeSense::West,
+            _ => LongitudeSense::East,
+        }
+    }
+}
+
+impl SubPoint {
+    /// The longitude of the point measured in the given sense, radians in
+    /// `[0, 2π)`.
+    ///
+    /// East is the frame's own sense and returns [`lon_rad`](Self::lon_rad)
+    /// unchanged; west returns `2π − lon_rad`, the value Horizons prints for
+    /// a body whose [`LongitudeSense::for_body`] is
+    /// [`West`](LongitudeSense::West).
+    pub fn longitude_in(&self, sense: LongitudeSense) -> f64 {
+        match sense {
+            LongitudeSense::East => self.lon_rad,
+            LongitudeSense::West => wrap(-self.lon_rad),
+        }
+    }
+
+    /// The same point with a planetographic (planetodetic) latitude.
+    ///
+    /// `tan φ_graphic = (a/c)² tan φ_centric`, where `a` is the equatorial
+    /// radius `radii_km[0]` and `c` the polar radius `radii_km[2]`. As
+    /// Horizons and SPICE do, the body is treated as an oblate spheroid and
+    /// the second equatorial radius `radii_km[1]` is ignored.
+    ///
+    /// Returns the point unchanged if it is planetographic already.
+    pub fn to_planetographic(&self, radii_km: [f64; 3]) -> SubPoint {
+        if !self.planetocentric {
+            return *self;
+        }
+        SubPoint {
+            lon_rad: self.lon_rad,
+            lat_rad: scale_latitude(self.lat_rad, flattening_factor(radii_km)),
+            planetocentric: false,
+        }
+    }
+
+    /// The same point with a planetocentric latitude, the inverse of
+    /// [`to_planetographic`](Self::to_planetographic).
+    ///
+    /// Returns the point unchanged if it is planetocentric already.
+    pub fn to_planetocentric(&self, radii_km: [f64; 3]) -> SubPoint {
+        if self.planetocentric {
+            return *self;
+        }
+        SubPoint {
+            lon_rad: self.lon_rad,
+            lat_rad: scale_latitude(self.lat_rad, 1.0 / flattening_factor(radii_km)),
+            planetocentric: true,
+        }
+    }
+
+    /// The planetographic point that a body-fixed direction points at.
+    ///
+    /// The direction need not be a unit vector; only its direction is used,
+    /// so this is the disc-centre ("intercept") construction rather than the
+    /// nearest point of the ellipsoid. Horizons reports the disc centre, and
+    /// says so: "This is NOT exactly the same as the *nearest* sub-point for
+    /// a non-spherical target shape".
+    fn from_body_fixed(direction: Vector3<f64>, radii_km: [f64; 3]) -> SubPoint {
+        let r = direction.norm();
+        let lat = if r > 0.0 {
+            (direction.z / r).asin()
+        } else {
+            0.0
+        };
+        SubPoint {
+            lon_rad: wrap(direction.y.atan2(direction.x)),
+            lat_rad: lat,
+            planetocentric: true,
+        }
+        .to_planetographic(radii_km)
+    }
+}
+
+impl Position {
+    /// The sub-observer point: where the centre of the apparent disc falls on
+    /// the body's surface.
+    ///
+    /// `self` is the position of the body as seen by the observer, from
+    /// [`observe`](Position::observe); `frame` is the body's body-fixed
+    /// frame and `radii_km` its triaxial radii, both of which
+    /// [`planetlib::Body`](crate::planetlib::Body) and
+    /// [`PlanetaryConstants`](crate::planetarylib::PlanetaryConstants) can
+    /// supply. The frame is evaluated at `t − light_time`.
+    ///
+    /// The returned latitude is planetographic and the longitude
+    /// east-positive; see the [module documentation](self) for the
+    /// conversions.
+    ///
+    /// Give this an *astrometric* position. An apparent one differs by the
+    /// deflection and aberration of the incoming light, which turn the whole
+    /// sky rather than the body and displace the sub-point by up to about
+    /// 0.006°.
+    pub fn sub_observer_point(&self, frame: &dyn Frame, radii_km: [f64; 3], t: &Time) -> SubPoint {
+        let epoch = t.shift_days(-self.light_time);
+        SubPoint::from_body_fixed(frame.rotation_at(&epoch) * -self.position, radii_km)
+    }
+
+    /// The sub-solar point: where the Sun stands overhead on the body, the
+    /// centre of the lit hemisphere.
+    ///
+    /// Takes the same arguments as
+    /// [`sub_observer_point`](Position::sub_observer_point) plus the kernel,
+    /// which supplies the Sun. Both legs of the light path are corrected: the
+    /// body is taken at `t − light_time` and the Sun at the further light
+    /// time of the Sun → body leg before that, as Horizons does.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StarfieldError::MissingObserver`](crate::StarfieldError::MissingObserver)
+    /// if `self` does not carry the observer's barycentric position, and
+    /// [`StarfieldError::EphemerisError`](crate::StarfieldError::EphemerisError)
+    /// if the kernel cannot place the Sun.
+    pub fn sub_solar_point(
+        &self,
+        frame: &dyn Frame,
+        radii_km: [f64; 3],
+        kernel: &mut SpiceKernel,
+        t: &Time,
+    ) -> Result<SubPoint> {
+        let observer = self.require_observer()?;
+        let epoch = t.shift_days(-self.light_time);
+
+        // The body's own barycentric position at the moment the light left it.
+        let body = observer.position + self.position;
+
+        let mut sun = kernel.at("sun", &epoch)?.position;
+        for _ in 0..SUN_LIGHT_TIME_ITERATIONS {
+            let light_time = (body - sun).norm() / C_AUDAY;
+            sun = kernel.at("sun", &epoch.shift_days(-light_time))?.position;
+        }
+
+        Ok(SubPoint::from_body_fixed(
+            frame.rotation_at(&epoch) * (sun - body),
+            radii_km,
+        ))
+    }
+}
+
+/// `(a / c)²`, the factor that turns a planetocentric latitude's tangent into
+/// a planetographic one.
+fn flattening_factor(radii_km: [f64; 3]) -> f64 {
+    (radii_km[0] / radii_km[2]).powi(2)
+}
+
+/// Scale the tangent of a latitude, the operation both latitude conversions
+/// perform.
+fn scale_latitude(lat_rad: f64, factor: f64) -> f64 {
+    (factor * lat_rad.tan()).atan()
+}
+
+/// Wrap an angle into `[0, 2π)`.
+fn wrap(angle: f64) -> f64 {
+    let wrapped = angle % TAU;
+    if wrapped < 0.0 {
+        wrapped + TAU
+    } else {
+        wrapped
+    }
+}
+
+/// The JPL Horizons rows that the sub-point and position-angle tests compare
+/// against, checked in so that neither test needs the network.
+#[cfg(test)]
+pub(crate) mod horizons_fixture {
+    use crate::time::{Time, Timescale};
+
+    /// The checked-in observer table.
+    const ROWS: &str = include_str!("horizons_disk_orientation.csv");
+
+    /// The quantity codes the fixture was fetched with: sub-observer point,
+    /// sub-solar point, sub-solar position angle, north pole position angle.
+    pub(crate) const QUANTITIES: &str = "14,15,16,17";
+
+    /// One row of the fixture: the disc orientation of `target` seen from the
+    /// centre of `center` at a UT Julian date.
+    #[derive(Debug, Clone, Copy)]
+    pub(crate) struct DiskRow {
+        pub target: i32,
+        pub center: i32,
+        pub jd_ut: f64,
+        /// `ObsSub-LON`, degrees, in the sense Horizons reports for `target`.
+        pub obs_sub_lon_deg: f64,
+        /// `ObsSub-LAT`, planetodetic degrees.
+        pub obs_sub_lat_deg: f64,
+        /// `SunSub-LON`, degrees, in the sense Horizons reports for `target`.
+        pub sun_sub_lon_deg: f64,
+        /// `SunSub-LAT`, planetodetic degrees.
+        pub sun_sub_lat_deg: f64,
+        /// `SN.ang`, the sub-solar point's position angle in degrees.
+        pub sn_ang_deg: f64,
+        /// `NP.ang`, the north pole's position angle in degrees.
+        pub np_ang_deg: f64,
+    }
+
+    impl DiskRow {
+        /// The row's epoch, whose Julian date Horizons gives in UT.
+        pub(crate) fn time(&self, ts: &Timescale) -> Time {
+            ts.utc(ts.jd_to_calendar(self.jd_ut))
+        }
+    }
+
+    /// Every row of the fixture, in file order.
+    pub(crate) fn rows() -> Vec<DiskRow> {
+        ROWS.lines()
+            .filter(|line| {
+                !line.starts_with('#') && !line.is_empty() && !line.starts_with("target")
+            })
+            .map(|line| {
+                let f: Vec<f64> = line
+                    .split(',')
+                    .map(|v| v.trim().parse().expect("fixture holds numbers"))
+                    .collect();
+                assert_eq!(f.len(), 9, "fixture row {line:?} has the wrong width");
+                DiskRow {
+                    target: f[0] as i32,
+                    center: f[1] as i32,
+                    jd_ut: f[2],
+                    obs_sub_lon_deg: f[3],
+                    obs_sub_lat_deg: f[4],
+                    sun_sub_lon_deg: f[5],
+                    sun_sub_lat_deg: f[6],
+                    sn_ang_deg: f[7],
+                    np_ang_deg: f[8],
+                }
+            })
+            .collect()
+    }
+
+    /// The rows for one geometry.
+    pub(crate) fn rows_for(target: i32, center: i32) -> Vec<DiskRow> {
+        rows()
+            .into_iter()
+            .filter(|row| row.target == target && row.center == center)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::horizons_fixture::{rows_for, DiskRow, QUANTITIES};
+    use super::*;
+    use crate::framelib::ItrsFrame;
+    use crate::horizons::parser;
+    use crate::horizons::{Center, Command, EphemerisRequest, HorizonsClient, TimeSpec};
+    use crate::planetarylib::IauFrame;
+    use crate::planetlib::Body;
+    use crate::time::Timescale;
+    use approx::assert_relative_eq;
+
+    fn de421_kernel() -> SpiceKernel {
+        SpiceKernel::open("test_data/de421.bsp").expect("Failed to open DE421")
+    }
+
+    /// The body-fixed frame and radii Horizons used for a target: ITRF93 for
+    /// the Earth, the IAU elements otherwise.
+    fn frame_and_radii(naif_id: i32) -> (Box<dyn Frame>, [f64; 3]) {
+        let radii = crate::planetarylib::body_constants(naif_id).unwrap().radii;
+        if naif_id == 399 {
+            (Box::new(ItrsFrame), radii)
+        } else {
+            (Box::new(IauFrame::from_naif_id(naif_id).unwrap()), radii)
+        }
+    }
+
+    /// The signed difference of two angles in degrees, wrapped to ±180°.
+    fn angle_error_deg(a: f64, b: f64) -> f64 {
+        let mut diff = (a - b) % 360.0;
+        if diff > 180.0 {
+            diff -= 360.0;
+        }
+        if diff < -180.0 {
+            diff += 360.0;
+        }
+        diff
+    }
+
+    /// Our sub-observer and sub-solar points for one fixture row.
+    fn sub_points(row: &DiskRow) -> (SubPoint, SubPoint) {
+        let mut kernel = de421_kernel();
+        let ts = Timescale::default();
+        let t = row.time(&ts);
+
+        let (frame, radii) = frame_and_radii(row.target);
+        let observer = kernel.at(&row.center.to_string(), &t).unwrap();
+        let target = observer
+            .observe(&row.target.to_string(), &mut kernel, &t)
+            .unwrap();
+
+        let sub_observer = target.sub_observer_point(frame.as_ref(), radii, &t);
+        let sub_solar = target
+            .sub_solar_point(frame.as_ref(), radii, &mut kernel, &t)
+            .unwrap();
+        (sub_observer, sub_solar)
+    }
+
+    #[test]
+    fn test_longitude_sense_of_every_body() {
+        for id in [199, 499, 599, 699, 899] {
+            assert_eq!(LongitudeSense::for_body(id), LongitudeSense::West, "{id}");
+        }
+        for id in [10, 299, 301, 399, 799, 999] {
+            assert_eq!(LongitudeSense::for_body(id), LongitudeSense::East, "{id}");
+        }
+        // Barycentre codes stand for the body of the same system.
+        assert_eq!(LongitudeSense::for_body(4), LongitudeSense::West);
+        assert_eq!(LongitudeSense::for_body(7), LongitudeSense::East);
+    }
+
+    #[test]
+    fn test_longitude_in_west_is_the_complement() {
+        let point = SubPoint {
+            lon_rad: 1.0,
+            lat_rad: 0.0,
+            planetocentric: true,
+        };
+        assert_relative_eq!(
+            point.longitude_in(LongitudeSense::West),
+            TAU - 1.0,
+            epsilon = 1e-15
+        );
+        assert_relative_eq!(point.longitude_in(LongitudeSense::East), 1.0);
+
+        // Zero must not wrap to a full turn.
+        let prime = SubPoint {
+            lon_rad: 0.0,
+            ..point
+        };
+        assert_relative_eq!(prime.longitude_in(LongitudeSense::West), 0.0);
+    }
+
+    #[test]
+    fn test_latitude_conversions_round_trip() {
+        let radii = Body::Mars.radii_km();
+        for lat_deg in [-89.0_f64, -45.0, -1.0, 0.0, 23.5, 60.0, 89.9] {
+            let centric = SubPoint {
+                lon_rad: 0.5,
+                lat_rad: lat_deg.to_radians(),
+                planetocentric: true,
+            };
+            let graphic = centric.to_planetographic(radii);
+            assert!(!graphic.planetocentric);
+            assert_eq!(graphic.lon_rad, centric.lon_rad);
+            assert!(
+                graphic.lat_rad.abs() >= centric.lat_rad.abs(),
+                "the oblate latitude is the larger one"
+            );
+            assert_relative_eq!(
+                graphic.to_planetocentric(radii).lat_rad,
+                centric.lat_rad,
+                epsilon = 1e-14
+            );
+            // Converting a point that is already in the target form is a
+            // no-op, not a second application of the scaling.
+            assert_eq!(graphic.to_planetographic(radii), graphic);
+        }
+    }
+
+    #[test]
+    fn test_a_spherical_body_has_equal_latitudes() {
+        let radii = [1000.0, 1000.0, 1000.0];
+        let point = SubPoint {
+            lon_rad: 0.0,
+            lat_rad: 0.7,
+            planetocentric: true,
+        };
+        assert_relative_eq!(point.to_planetographic(radii).lat_rad, 0.7, epsilon = 1e-15);
+    }
+
+    #[test]
+    fn test_sub_observer_point_of_a_hand_built_geometry() {
+        // An observer one AU along +x sees the point of the body-fixed frame
+        // that faces +x, and the Sun in the same place if it is behind them.
+        let radii = [1.0, 1.0, 1.0];
+        let ts = Timescale::default();
+        let t = ts.tdb_jd(2451545.0);
+
+        let observer = Position::barycentric(Vector3::new(1.0, 0.0, 0.0), Vector3::zeros(), 0);
+        let target = Position::astrometric(
+            Vector3::new(-1.0, 0.0, 0.0),
+            Vector3::zeros(),
+            &observer,
+            0,
+            0.0,
+        );
+
+        let point = target.sub_observer_point(&crate::framelib::ICRS, radii, &t);
+        assert_relative_eq!(point.lon_rad, 0.0, epsilon = 1e-12);
+        assert_relative_eq!(point.lat_rad, 0.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn test_sub_solar_point_faces_the_sun() {
+        // Seen from the Sun, a body's sub-solar and sub-observer points are
+        // the same point.
+        let mut kernel = de421_kernel();
+        let ts = Timescale::default();
+        let t = ts.utc((2007, 10, 3, 0, 0, 0.0));
+
+        let radii = Body::Mars.radii_km();
+        let frame = IauFrame::from_body(Body::Mars);
+
+        let sun = kernel.at("sun", &t).unwrap();
+        let mars = sun.observe("mars", &mut kernel, &t).unwrap();
+
+        let sub_observer = mars.sub_observer_point(&frame, radii, &t);
+        let sub_solar = mars
+            .sub_solar_point(&frame, radii, &mut kernel, &t)
+            .unwrap();
+
+        // The light time of the Sun → Mars leg leaves a few arcseconds.
+        assert!(
+            angle_error_deg(
+                sub_observer.lon_rad.to_degrees(),
+                sub_solar.lon_rad.to_degrees()
+            )
+            .abs()
+                < 0.01,
+            "sub-observer {:?} and sub-solar {:?} should coincide",
+            sub_observer,
+            sub_solar
+        );
+        assert!((sub_observer.lat_rad - sub_solar.lat_rad).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_a_position_without_an_observer_cannot_have_a_sub_solar_point() {
+        let mut kernel = de421_kernel();
+        let ts = Timescale::default();
+        let t = ts.tdb_jd(2451545.0);
+
+        let mars = kernel.at("mars", &t).unwrap();
+        let frame = IauFrame::from_body(Body::Mars);
+        assert!(mars
+            .sub_solar_point(&frame, Body::Mars.radii_km(), &mut kernel, &t)
+            .is_err());
+    }
+
+    #[test]
+    fn test_sub_points_match_horizons() {
+        let mut worst_lon = 0.0_f64;
+        let mut worst_lat = 0.0_f64;
+
+        for row in rows_for(499, 399).into_iter().chain(rows_for(399, 499)) {
+            let (sub_observer, sub_solar) = sub_points(&row);
+            let sense = LongitudeSense::for_body(row.target);
+
+            for (label, point, lon_deg, lat_deg) in [
+                (
+                    "sub-observer",
+                    sub_observer,
+                    row.obs_sub_lon_deg,
+                    row.obs_sub_lat_deg,
+                ),
+                (
+                    "sub-solar",
+                    sub_solar,
+                    row.sun_sub_lon_deg,
+                    row.sun_sub_lat_deg,
+                ),
+            ] {
+                let lon_error =
+                    angle_error_deg(point.longitude_in(sense).to_degrees(), lon_deg).abs();
+                let lat_error = (point.lat_rad.to_degrees() - lat_deg).abs();
+                assert!(
+                    lon_error < 0.05,
+                    "{label} longitude of {} from {} at JD {}: {} vs Horizons {} ({} deg)",
+                    row.target,
+                    row.center,
+                    row.jd_ut,
+                    point.longitude_in(sense).to_degrees(),
+                    lon_deg,
+                    lon_error
+                );
+                assert!(
+                    lat_error < 0.05,
+                    "{label} latitude of {} from {} at JD {}: {} vs Horizons {} ({} deg)",
+                    row.target,
+                    row.center,
+                    row.jd_ut,
+                    point.lat_rad.to_degrees(),
+                    lat_deg,
+                    lat_error
+                );
+                worst_lon = worst_lon.max(lon_error);
+                worst_lat = worst_lat.max(lat_error);
+            }
+        }
+
+        println!("worst longitude error {worst_lon:.4}°, worst latitude error {worst_lat:.4}°");
+    }
+
+    #[test]
+    fn test_planetocentric_latitude_is_not_what_horizons_reports() {
+        // A guard against reporting the planetocentric latitude by mistake:
+        // for Mars at these epochs the two differ by more than the tolerance
+        // of the comparison above.
+        let radii = Body::Mars.radii_km();
+        let row = rows_for(499, 399)[0];
+        let (sub_observer, _) = sub_points(&row);
+        let centric = sub_observer.to_planetocentric(radii);
+        assert!(
+            (centric.lat_rad.to_degrees() - row.obs_sub_lat_deg).abs() > 0.1,
+            "the planetocentric and planetodetic latitudes should be distinguishable"
+        );
+    }
+
+    /// Re-fetch the checked-in Horizons rows and confirm they still hold.
+    ///
+    /// This is the request the fixture came from; run it with
+    /// `cargo test -- --ignored test_horizons_fixture_is_current`.
+    #[test]
+    #[ignore = "queries the JPL Horizons API over the network"]
+    fn test_horizons_fixture_is_current() {
+        let client = HorizonsClient::new().unwrap();
+
+        for (target, center) in [(499, 399), (399, 499)] {
+            let rows = rows_for(target, center);
+            let mut request = EphemerisRequest::observer(
+                Command::MajorBody(target),
+                Center::BodyCenter(center),
+                TimeSpec::JulianDayList(rows.iter().map(|row| row.jd_ut).collect()),
+            );
+            request.quantities = Some(QUANTITIES.to_string());
+            request.cal_format = Some("JD".to_string());
+
+            let response = client.query(&request).unwrap();
+            let result = response.result.unwrap();
+            let names = parser::extract_column_names(&result);
+            let block = parser::extract_ephemeris_block(&result).unwrap();
+            let fetched = parser::parse_observer_rows(block, &names).unwrap();
+
+            assert_eq!(fetched.len(), rows.len());
+            for (row, fetched) in rows.iter().zip(fetched) {
+                let field = |name: &str| -> f64 {
+                    fetched
+                        .fields
+                        .iter()
+                        .find(|(key, _)| key == name)
+                        .unwrap_or_else(|| panic!("Horizons returned no column {name}"))
+                        .1
+                        .parse()
+                        .unwrap()
+                };
+                assert_relative_eq!(fetched.jd, row.jd_ut, epsilon = 1e-6);
+                assert_relative_eq!(field("ObsSub-LON"), row.obs_sub_lon_deg, epsilon = 1e-4);
+                assert_relative_eq!(field("ObsSub-LAT"), row.obs_sub_lat_deg, epsilon = 1e-4);
+                assert_relative_eq!(field("SunSub-LON"), row.sun_sub_lon_deg, epsilon = 1e-4);
+                assert_relative_eq!(field("SunSub-LAT"), row.sun_sub_lat_deg, epsilon = 1e-4);
+                assert_relative_eq!(field("SN.ang"), row.sn_ang_deg, epsilon = 1e-2);
+                assert_relative_eq!(field("NP.ang"), row.np_ang_deg, epsilon = 1e-2);
+            }
+        }
+    }
+}

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -1222,6 +1222,25 @@ impl Time {
         self.whole + tdb_frac
     }
 
+    /// The same instant shifted by `days` days of TDB, on the same timescale.
+    ///
+    /// Light-time corrections need the epoch at the far end of the light path,
+    /// `t.shift_days(-light_time)`, and this keeps whatever ΔT, leap-second
+    /// and polar-motion tables the timescale carries, which
+    /// `Timescale::default().tdb_jd(..)` would silently drop.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use starfield::time::Timescale;
+    ///
+    /// let t = Timescale::default().tdb_jd(2451545.0);
+    /// assert_eq!(t.shift_days(-0.5).tdb(), 2451544.5);
+    /// ```
+    pub fn shift_days(&self, days: f64) -> Time {
+        self.ts.tdb_jd(self.tdb() + days)
+    }
+
     /// Calculate TDB - TT difference in seconds
     fn tdb_minus_tt(&self, jd_tdb: f64) -> f64 {
         // Implementation of USNO Circular 179, eq. 2.6


### PR DESCRIPTION
Supersedes #184, which GitHub closed when its stacked base branch was deleted on merge of #180; the branch is rebased onto main with no content change.

## Summary

PR 11 of `docs/solar-system-bodies-plan.md`. **Stacked on #180** (`meawoppl/illumination-geometry`, PR 6) — the base is set to that branch, so review only the second commit; retarget to `main` once #180 merges.

New `src/planetarylib/subpoint.rs`:

- `SubPoint { lon_rad, lat_rad, planetocentric }`, `Position::sub_observer_point(frame, radii_km, t)` and `Position::sub_solar_point(frame, radii_km, kernel, t)`. Both rotate into the body-fixed frame evaluated at the light-time corrected epoch `t − light_time`, as SPICE `subpnt` does with `LT+S`; the sub-solar point additionally removes the light time of the Sun → body leg, which is what Horizons reports.
- `SubPoint::to_planetographic(radii_km)` / `to_planetocentric(radii_km)` — the oblate latitude, `tan φ_graphic = (a/c)² tan φ_centric`, treating the body as an oblate spheroid and ignoring `radii_km[1]` exactly as Horizons and SPICE do. Both conversions are no-ops on a point that is already in the target form.
- `LongitudeSense::{East, West}` and `LongitudeSense::for_body(naif_id)` — the per-body rule, with `SubPoint::longitude_in(sense)`. Longitude in a body-fixed frame is always east-positive (W increases eastward); planetographic longitude is reported **west**-positive for the prograde rotators Mercury, Mars, Jupiter, Saturn and Neptune, and **east**-positive for the retrograde Venus, Uranus and Pluto and for the Sun, Earth and Moon, which the IAU exempts. Every entry was checked against the `{West-longitude positive}` / `{East-longitude positive}` note in the `Target pole/equ` line of a Horizons observer table for that body.

Two deviations from the issue text, both deliberate:

1. The two methods return a **planetographic** point (`planetocentric: false`). That is the only form in which `radii_km` — which the requested signature carries — does any work, and it is the form Horizons and SPICE publish; `to_planetocentric` gives the other one.
2. `to_planetographic` takes the radii only; the longitude sense is a separate, per-body concern and lives in `LongitudeSense::for_body` rather than being guessed from a radii triple.

Support changes: `Time::shift_days(days)` (the light-time epoch on the same timescale, keeping whatever ΔT and polar-motion tables it carries, which `Timescale::default()` would drop), and `EphemerisRequest::cal_format` so an observer table can be requested with `CAL_FORMAT='JD'` — without it the first column is a calendar string and `parser::parse_observer_rows` yields nothing.

`examples/sub_points.rs` prints both points for Mars-from-Earth and Earth-from-Mars in all four forms.

## Test plan

- `cargo fmt`, `cargo clippy --all-targets` — clean for the new and changed files.
- `cargo test` — 694 passed, 0 failed, 24 ignored (lib); 82 doctests passed.
- `cargo test --features python-tests` — 807 passed, 1 failed: the pre-existing `catalogs::…astropy_sersic2d` failure, unrelated.
- **Horizons comparison** (`test_sub_points_match_horizons`), quantities 14 and 15 for Mars-from-Earth (`@399` → `499`) and Earth-from-Mars (`@499` → `399`) at JD UT 2451545.0, 2454376.5 and 2459136.5, twelve longitude/latitude pairs in all: **worst longitude error 0.0071°, worst latitude error 0.0023°**, against the 0.05° budget. Mars uses `IauFrame`, the Earth uses `ItrsFrame` — which is the frame Horizons itself uses for the Earth (`Target pole/equ : ITRF93`).
- The rows are checked in as `src/planetarylib/horizons_disk_orientation.csv` with a provenance header, so CI needs no network. The live fetch is `test_horizons_fixture_is_current`, `#[ignore]`d; it was run once and reproduces every column of the fixture.
- A guard test asserts that the planetocentric latitude is *not* what Horizons reports, so the oblate conversion cannot be silently dropped.

Closes #163