### PR TITLE
frame_for falls back to the embedded IAU table; 0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.16.1
+
+- `PlanetaryConstants::frame_for` now falls back to the embedded IAU 2015 table when no text kernel read so far defines the body, as the plan promised: `PlanetaryConstants::new().frame_for(499)` works offline, and kernel values still win when loaded. Earth (`ItrsFrame`) and the Moon with a principal-axes kernel (`PckFrame`) are unchanged
+- `planetarylib::TEXT_MAGIC_NUMBERS` is public so content validators can reuse starfield's own list of text-kernel magic numbers; `text_pck::{parse, load}` are documented as the unchecked tokenizer beneath the validated `read_text`
+- `data::downloader::tests::test_known_endpoints_reachable` is `#[ignore]`d: it made live HEAD requests to JPL and NAIF from the default suite and failed CI three times in one day on upstream hiccups
+
 ## 0.16.0
 
 Completes the resolved-solar-system-bodies milestone from `docs/solar-system-bodies-plan.md`: disk geometry, illumination and non-Earth observers for the focalplane renderer.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starfield"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 authors = ["Matthew Goodman"]
 description = "Astronomical data reduction toolkit with star catalogs, coordinate systems, and star finding algorithms (inspired by skyfield)"

--- a/src/data/downloader.rs
+++ b/src/data/downloader.rs
@@ -461,6 +461,7 @@ mod tests {
     ///
     /// This catches broken URLs in CI without streaming large files.
     #[test]
+    #[ignore = "makes live HEAD requests to JPL and NAIF"]
     fn test_known_endpoints_reachable() {
         let filenames = [
             "de421.bsp",

--- a/src/planetarylib/iau_frame.rs
+++ b/src/planetarylib/iau_frame.rs
@@ -848,4 +848,35 @@ mod tests {
         assert_eq!(mars, IauFrame::from_body(Body::Mars).rotation_at(&t));
         assert!(pc.frame_for(-1).is_err());
     }
+
+    /// With no kernel read, `frame_for` falls back to the embedded table for
+    /// the bodies it covers, and kernel values win once one is read.
+    #[test]
+    fn test_frame_for_falls_back_to_the_embedded_table() {
+        let ts = Timescale::default();
+        let t = ts.tdb_jd(2455362.5);
+
+        let empty = PlanetaryConstants::new();
+        let mars = empty.frame_for(499).unwrap().rotation_at(&t);
+        assert_eq!(mars, IauFrame::from_body(Body::Mars).rotation_at(&t));
+        let moon = empty.frame_for(301).unwrap().rotation_at(&t);
+        assert_eq!(moon, IauFrame::from_body(Body::Moon).rotation_at(&t));
+        // Phobos is in pck00011.tpc but not in the embedded table.
+        assert!(empty.frame_for(401).is_err());
+
+        let mut pc = PlanetaryConstants::new();
+        pc.read_text(concat!(
+            "KPL/PCK\n\\begindata\n",
+            "BODY499_POLE_RA = ( 300.0 0.0 0.0 )\n",
+            "BODY499_POLE_DEC = ( 50.0 0.0 0.0 )\n",
+            "BODY499_PM = ( 0.0 0.0 0.0 )\n",
+            "\\begintext\n",
+        ))
+        .unwrap();
+        let from_kernel = pc.frame_for(499).unwrap().rotation_at(&t);
+        assert_ne!(from_kernel, mars, "kernel values must override the table");
+        let (ra, dec, _) = IauFrame::new(499, &pc).unwrap().pole_and_meridian(&t);
+        assert!((ra.to_degrees() - 300.0).abs() < 1e-12);
+        assert!((dec.to_degrees() - 50.0).abs() < 1e-12);
+    }
 }

--- a/src/planetarylib/mod.rs
+++ b/src/planetarylib/mod.rs
@@ -272,8 +272,13 @@ const MOON: i32 = 301;
 /// `MOON_PA_DE440` then `MOON_PA_DE421`.
 const MOON_PA_FRAMES: [i32; 2] = [31008, 31006];
 
-/// The magic numbers that open a NAIF text kernel.
-const TEXT_MAGIC_NUMBERS: [&str; 2] = ["KPL/FK", "KPL/PCK"];
+/// The magic numbers that open a NAIF text kernel: the first non-blank
+/// characters of a valid `.tpc` or `.tf` file.
+///
+/// [`read_text`](PlanetaryConstants::read_text) rejects input that does not
+/// start with one of these, so a download that returned an HTML error or login
+/// page is refused rather than parsed as an empty kernel.
+pub const TEXT_MAGIC_NUMBERS: [&str; 2] = ["KPL/FK", "KPL/PCK"];
 
 /// The error for a kernel variable that a frame needs and no kernel defines.
 fn missing(name: &str) -> StarfieldError {
@@ -593,7 +598,9 @@ impl PlanetaryConstants {
     ///   from the same fits as the ephemerides where the IAU elements are a
     ///   truncated series;
     /// * every other body, and the Moon without such a kernel, gets an
-    ///   [`IauFrame`] built from the kernels read so far.
+    ///   [`IauFrame`] built from the kernels read so far, or from the embedded
+    ///   IAU 2015 table when no kernel read so far defines the body. Kernel
+    ///   values win when present; the table makes the call work offline.
     ///
     /// The lunar frame is taken straight from the segment, so no frame kernel
     /// need be read for it; `moon_080317.tf` is needed only to reach the
@@ -602,26 +609,20 @@ impl PlanetaryConstants {
     ///
     /// # Errors
     ///
-    /// Returns [`StarfieldError::DataError`] if the kernels read so far define
-    /// no rotational elements for `body`, or if a lunar principal-axes segment
-    /// has been read that is relative to something other than J2000, which is
-    /// the only reference frame the rotation assumes.
+    /// Returns [`StarfieldError::DataError`] if neither the kernels read so far
+    /// nor the embedded table define rotational elements for `body`, or if a
+    /// lunar principal-axes segment has been read that is relative to
+    /// something other than J2000, which is the only reference frame the
+    /// rotation assumes.
     ///
     /// # Example
     ///
     /// ```
     /// use starfield::planetarylib::PlanetaryConstants;
     ///
-    /// let mut pc = PlanetaryConstants::new();
-    /// pc.read_text(concat!(
-    ///     "KPL/PCK\n\\begindata\n",
-    ///     "BODY499_POLE_RA = ( 317.269202 -0.10927547 0.0 )\n",
-    ///     "BODY499_POLE_DEC = ( 54.432516 -0.05827105 0.0 )\n",
-    ///     "BODY499_PM = ( 176.049863 350.891982443297 0.0 )\n",
-    ///     "\\begintext\n",
-    /// )).unwrap();
-    /// assert!(pc.frame_for(499).is_ok());
-    /// assert!(pc.frame_for(599).is_err());
+    /// let pc = PlanetaryConstants::new();
+    /// assert!(pc.frame_for(499).is_ok());   // Mars, from the embedded table
+    /// assert!(pc.frame_for(401).is_err());  // Phobos needs a text kernel
     /// ```
     pub fn frame_for(&self, body: i32) -> Result<Box<dyn Frame>> {
         if body == EARTH {
@@ -632,7 +633,18 @@ impl PlanetaryConstants {
                 return Ok(Box::new(frame));
             }
         }
-        Ok(Box::new(IauFrame::new(body, self)?))
+        if let Ok(frame) = IauFrame::new(body, self) {
+            return Ok(Box::new(frame));
+        }
+        IauFrame::from_naif_id(body)
+            .map(|frame| Box::new(frame) as Box<dyn Frame>)
+            .ok_or_else(|| {
+                StarfieldError::DataError(format!(
+                    "neither the text kernels read so far nor the embedded IAU table \
+                     define rotational elements for body {}",
+                    body
+                ))
+            })
     }
 
     /// The lunar principal-axes frame of the best binary PCK read so far, or

--- a/src/planetarylib/pck_frame.rs
+++ b/src/planetarylib/pck_frame.rs
@@ -603,8 +603,8 @@ mod tests {
         }
     }
 
-    /// A body other than the Moon ignores the lunar segments entirely, and
-    /// with no elements read there is nothing to build it from.
+    /// A body other than the Moon ignores the lunar segments entirely: Mars
+    /// comes from the embedded table, and a body the table lacks has nothing.
     #[test]
     fn test_frame_for_another_body_ignores_the_lunar_segments() {
         let mut pc = PlanetaryConstants::new();
@@ -612,7 +612,12 @@ mod tests {
             test_support::MOON_PA_DE421,
             [0.375, 1.0, 0.5],
         ));
-        assert!(pc.frame_for(499).is_err());
+        let t = crate::time::Timescale::default().tdb_jd(2455362.5);
+        assert_eq!(
+            pc.frame_for(499).unwrap().rotation_at(&t),
+            crate::planetarylib::IauFrame::from_body(crate::planetlib::Body::Mars).rotation_at(&t)
+        );
+        assert!(pc.frame_for(401).is_err());
         assert!(pc.frame_for(301).is_ok());
     }
 

--- a/src/planetarylib/text_pck.rs
+++ b/src/planetarylib/text_pck.rs
@@ -135,6 +135,13 @@ static TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// Later assignments to the same name replace earlier ones, and `+=`
 /// assignments append, exactly as the SPICE readers do.
 ///
+/// This is the unchecked tokenizer, a port of Skyfield's `text_pck.load`: it
+/// does not look for the `KPL/…` magic number, and input with no
+/// `\begindata` block — an HTML error page, say — parses as an empty map.
+/// [`PlanetaryConstants::read_text`](crate::planetarylib::PlanetaryConstants::read_text)
+/// is the validated entry point; it checks
+/// [`TEXT_MAGIC_NUMBERS`](crate::planetarylib::TEXT_MAGIC_NUMBERS) first.
+///
 /// # Errors
 ///
 /// Returns [`StarfieldError::DataError`] if an assignment is malformed, if a


### PR DESCRIPTION
## Summary

Patch release correcting three things from 0.16.0 that both downstream consumers (focalplane, starfield-datasources) are working around:

- `PlanetaryConstants::frame_for(body)` now falls back to the embedded IAU 2015 table when no text kernel read so far defines the body, as `docs/solar-system-bodies-plan.md` §2.2 and OrbitalCommons/starfield#160 promised. `PlanetaryConstants::new().frame_for(499)` works offline; kernel values still win once read; Earth → `ItrsFrame` and Moon-with-PA-kernel → `PckFrame` unchanged. Bodies in neither source (e.g. Phobos without `pck00011.tpc`) still error.
- `planetarylib::TEXT_MAGIC_NUMBERS` is public so the OrbitalCommons/starfield-datastore#1 datastore's content check reuses starfield's own list; `text_pck::{parse, load}` are documented as the unchecked tokenizer beneath the validated `read_text`.
- `test_known_endpoints_reachable` is `#[ignore]`d — live HEAD requests to JPL/NAIF failed CI three times yesterday on upstream hiccups.

Version 0.16.1 with a `CHANGELOG.md` entry; additive/corrective, so a patch bump.

## Test plan

- [x] `cargo test --lib` green locally (new `test_frame_for_falls_back_to_the_embedded_table`; `test_frame_for_another_body_ignores_the_lunar_segments` updated for the new rule; `frame_for` doctest exercises the kernel-free path)
- [x] `cargo fmt`, `cargo clippy` clean for touched files
- [ ] CI